### PR TITLE
Improve POS and center desktop nav

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -59,6 +59,17 @@
     scroll-behavior: auto;
   }
 
+  .nav-categories {
+    display: flex;
+    white-space: nowrap;
+  }
+
+  @media (min-width: 768px) {
+    .nav-categories {
+      margin: 0 auto;
+    }
+  }
+
   .navbar a {
     flex: 0 0 auto;
     padding: 14px 20px;
@@ -500,14 +511,16 @@ input#bezorgen:checked ~ .slider {
 <body>
 <div class="navbar-container" id="navbar-container">
     <nav class="navbar" id="navbar">
-      <a href="#delivery-options">delivery-options</a>
-      <a href="#checkbox-group">checkbox-group</a>
-      <a href="#bento">Bento Box</a>
-      <a href="#sushi">Sushi Rolls</a>
-      <a href="#bubble">Bubble Tea</a>
-      <a href="#dessert">Dessert</a>
-      <a href="#snack">Snack</a>
-      <a href="#vegan">Vegan</a>
+      <div class="nav-categories">
+        <a href="#delivery-options">delivery-options</a>
+        <a href="#checkbox-group">checkbox-group</a>
+        <a href="#bento">Bento Box</a>
+        <a href="#sushi">Sushi Rolls</a>
+        <a href="#bubble">Bubble Tea</a>
+        <a href="#dessert">Dessert</a>
+        <a href="#snack">Snack</a>
+        <a href="#vegan">Vegan</a>
+      </div>
       <div class="indicator" id="indicator"></div>
     </nav>
   </div>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1,4 +1,376 @@
-<!doctype html>
-<title>POS</title>
-<h1>POS Interface</h1>
-<p>This is a placeholder for staff to create orders.</p>
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>POS Interface</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    padding: 20px;
+    max-width: 1200px;
+    margin: auto;
+    background: var(--primary-color);
+    color: var(--secondary-color);
+    padding-top: 60px;
+    text-align: center;
+  }
+
+  :root {
+    --primary-color: #f2e9d8;
+    --secondary-color: #333333;
+    --accent-color: #3f5c4b;
+    --off-white: #faf8f3;
+    --section-alt-bg: #f0e6d7;
+    --sakura: #f6d4dc;
+    --gold: #c5a253;
+  }
+  .navbar-container::-webkit-scrollbar { display: none; }
+  .navbar-container {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    padding: 0;
+    margin: 0;
+    background-color: var(--off-white);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    border-bottom: 1px solid #ccc;
+    z-index: 999;
+  }
+  .navbar {
+    display: flex;
+    flex-direction: row;
+    white-space: nowrap;
+    position: relative;
+    width: 100vw;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    scroll-behavior: auto;
+  }
+  .nav-categories { display: flex; white-space: nowrap; }
+  @media (min-width: 768px) { .nav-categories { margin: 0 auto; } }
+  .navbar a {
+    flex: 0 0 auto;
+    padding: 14px 20px;
+    color: var(--accent-color);
+    text-decoration: none;
+    font-weight: bold;
+    border-radius: 24px;
+    transition: all 0.3s ease;
+    position: relative;
+    z-index: 2;
+  }
+  .navbar a.active { color: white; }
+  .indicator {
+    position: absolute;
+    height: 32px;
+    background-color: var(--accent-color);
+    border-radius: 24px;
+    bottom: 8px;
+    z-index: 1;
+    transition: all 0.3s ease;
+    will-change: transform;
+  }
+  .navbar::after { content: ""; flex: 0 0 50vw; }
+  section {
+    padding: 40px 20px;
+    box-sizing: border-box;
+    border-bottom: 1px solid #ccc;
+    border-radius: 16px;
+    background: var(--off-white);
+    margin-bottom: 20px;
+  }
+  section:nth-child(even) { background: var(--section-alt-bg); }
+  h1,h2,h3,h4,h5,h6,p { text-align: center; }
+  .menu-item {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    padding: 16px;
+    margin-bottom: 12px;
+    border-radius: 16px;
+    background: var(--off-white);
+    border: 1px solid #e0e0e0;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  }
+  img { max-width: 100%; height: auto; }
+  .menu-item img { width: 100%; max-width: 120px; height: auto; object-fit: cover; border-radius: 12px; flex-shrink: 0; }
+  .menu-item select, .menu-item button {
+    margin-top: 8px;
+    padding: 6px 8px;
+    font-size: 0.85rem;
+    height: 36px;
+    border-radius: 10px;
+    border: 1px solid #ccc;
+  }
+  .menu-item button {
+    width: 2.2rem;
+    height: 2.2rem;
+    font-size: 1rem;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: none;
+    transition: background 0.2s ease;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  }
+  .add-button { background: var(--accent-color); color: white; }
+  .remove-button { background: var(--sakura); color: white; }
+  @media (max-width: 600px) {
+    .menu-item button { width:1.8rem; height:1.8rem; font-size:0.9rem; }
+    .menu-item img { max-width:80px; }
+  }
+  @media (max-width: 600px) { .menu-item { flex-direction: column; align-items: flex-start; } }
+  .pos-container { display: flex; flex-direction: column; }
+  .order-summary {
+    background: var(--off-white);
+    border: 1px solid #e0e0e0;
+    border-radius: 16px;
+    padding: 20px;
+    margin-top: 20px;
+  }
+  @media (min-width: 768px) {
+    .pos-container { flex-direction: row; align-items: flex-start; }
+    .product-list { flex: 2; margin-right:20px; }
+    .order-summary { width:300px; margin-top:0; }
+  }
+  .order-summary button {
+    width:100%;
+    margin-top:10px;
+    padding:12px;
+    font-size:1.1rem;
+    background: var(--accent-color);
+    color:white;
+    border:none;
+    border-radius:12px;
+  }
+  .hidden { display:none; }
+</style>
+</head>
+<body>
+<div class="navbar-container" id="navbar-container">
+  <nav class="navbar" id="navbar">
+    <div class="nav-categories">
+      <a href="#customer-info">Klant</a>
+      <a href="#bento">Bento Box</a>
+      <a href="#sushi">Sushi Rolls</a>
+      <a href="#bubble">Bubble Tea</a>
+      <a href="#dessert">Dessert</a>
+      <a href="#snack">Snack</a>
+      <a href="#vegan">Vegan</a>
+    </div>
+    <div class="indicator" id="indicator"></div>
+  </nav>
+</div>
+<h1>Bestelling</h1>
+<div class="pos-container">
+  <div class="product-list">
+    <section id="customer-info">
+      <div class="delivery-options">
+        <h2>Klantgegevens</h2>
+        <label for="custName">Naam*</label>
+        <input id="custName" type="text" required />
+        <label for="custPhone">Telefoonnummer*</label>
+        <input id="custPhone" type="tel" required />
+        <div style="margin-top:10px;">
+          <input type="radio" id="typePickup" name="orderType" value="pickup" checked required />
+          <label for="typePickup">Pickup</label>
+          <input type="radio" id="typeDelivery" name="orderType" value="delivery" style="margin-left:20px;" />
+          <label for="typeDelivery">Delivery</label>
+        </div>
+        <div id="addressField" class="hidden" style="margin-top:10px;">
+          <label for="custAddress">Adres*</label>
+          <input id="custAddress" type="text" />
+        </div>
+      </div>
+    </section>
+    <section id="bento">
+      <div class="bento-group">
+        <h2>Bento Box 🍱</h2>
+        <div class="bento-row menu-item" data-name="Chicken Bento" data-price="12">
+          <img class="bento-img" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}" alt="Chicken Bento" loading="lazy"/>
+          <div class="bento-content">
+            <h3>Chicken Bento</h3>
+            <p>€ 12.00</p>
+            <label for="chickenBentoCount">Aantal</label>
+            <select id="chickenBentoCount" name="chickenBentoCount"></select>
+            <button type="button" class="qty-plus add-button" data-target="chickenBentoCount">+</button>
+            <button type="button" class="qty-minus remove-button" data-target="chickenBentoCount">-</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="sushi">
+      <div class="menu-group">
+        <h2>Sushi Rolls 🍣</h2>
+        <div class="menu-row menu-item" data-name="Sake Maki" data-price="8.5">
+          <img class="menu-img" src="{{ url_for('static', filename='images/sake-maki.jpg') }}" alt="Sake Maki" loading="lazy" />
+          <div class="menu-content">
+            <h3>Sake Maki</h3>
+            <p>€ 8.50</p>
+            <label for="sakeCount">Aantal</label>
+            <select id="sakeCount" name="sakeCount"></select>
+            <button type="button" class="qty-plus add-button" data-target="sakeCount">+</button>
+            <button type="button" class="qty-minus remove-button" data-target="sakeCount">-</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="bubble">
+      <div class="menu-group">
+        <h2>Bubble Tea 🧋</h2>
+        <div class="menu-row menu-item" data-name="Bubble Tea" data-price="5">
+          <div class="menu-img">
+            <img src="{{ url_for('static', filename='images/bubble-tea.jpg') }}" alt="Bubble Tea" class="menu-img" loading="lazy" />
+          </div>
+          <div class="menu-content">
+            <h3>Bubble Tea</h3>
+            <p>€ 5.00</p>
+            <label for="bubbleTeaCount">Aantal</label>
+            <select id="bubbleTeaCount" name="bubbleTeaCount"></select>
+            <button type="button" class="qty-plus add-button" data-target="bubbleTeaCount">+</button>
+            <button type="button" class="qty-minus remove-button" data-target="bubbleTeaCount">-</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="dessert">
+      <div class="menu-group">
+        <h2>Dessert 🍡</h2>
+        <div class="menu-row menu-item" data-name="Mochi" data-price="4">
+          <img src="{{ url_for('static', filename='images/mochi.jpg') }}" alt="Mochi" class="menu-img" loading="lazy" />
+          <div class="menu-content">
+            <h3>Mochi (rijstcake)</h3>
+            <p>€ 4.00</p>
+            <label for="dessertCount">Aantal</label>
+            <select id="dessertCount" name="dessertCount"></select>
+            <button type="button" class="qty-plus add-button" data-target="dessertCount">+</button>
+            <button type="button" class="qty-minus remove-button" data-target="dessertCount">-</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="snack">
+      <div class="menu-group">
+        <h2>Snack 🍤</h2>
+        <div class="menu-row menu-item" data-name="Karaage" data-price="6.5">
+          <img src="{{ url_for('static', filename='images/karaage.jpg') }}" alt="Karaage" class="menu-img" loading="lazy" />
+          <div class="menu-content">
+            <h3>Karaage (Japanse gefrituurde kip)</h3>
+            <p>€ 6.50</p>
+            <label for="snackCount">Aantal</label>
+            <select id="snackCount" name="snackCount"></select>
+            <button type="button" class="qty-plus add-button" data-target="snackCount">+</button>
+            <button type="button" class="qty-minus remove-button" data-target="snackCount">-</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="vegan">
+      <div class="menu-group">
+        <h2>Vegan 🥬</h2>
+        <div class="menu-row menu-item" data-name="Avocado Roll" data-price="7">
+          <img src="{{ url_for('static', filename='images/avocado-roll.jpg') }}" alt="Avocado Roll" class="menu-img" loading="lazy" />
+          <div class="menu-content">
+            <h3>Avocado Roll</h3>
+            <p>€ 7.00</p>
+            <label for="veganCount">Aantal</label>
+            <select id="veganCount" name="veganCount"></select>
+            <button type="button" class="qty-plus add-button" data-target="veganCount">+</button>
+            <button type="button" class="qty-minus remove-button" data-target="veganCount">-</button>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="order-summary">
+    <h2>Overzicht</h2>
+    <ul id="cart"></ul>
+    <div class="total">Totaal: €<span id="total">0.00</span></div>
+    <button id="submitOrder">Submit Order</button>
+  </div>
+</div>
+
+<script>
+const cart = {};
+function populateSelect(sel){
+  for(let i=0;i<=20;i++){ const opt=document.createElement('option'); opt.value=i; opt.textContent=i; sel.appendChild(opt); }
+}
+function createSelect(current,onChange){
+  const sel=document.createElement('select');
+  for(let i=0;i<=20;i++){ const opt=document.createElement('option'); opt.value=i; opt.textContent=i; if(i===current) opt.selected=true; sel.appendChild(opt); }
+  sel.addEventListener('change',()=>onChange(parseInt(sel.value))); return sel;
+}
+function setQty(name,price,qty){ if(qty===0){ delete cart[name]; } else { cart[name]={price,qty}; } updateCart(); }
+function updateCart(){
+  const list=document.getElementById('cart');
+  list.innerHTML='';
+  let total=0;
+  Object.entries(cart).forEach(([name,item])=>{
+    const li=document.createElement('li');
+    const sel=createSelect(item.qty,val=>{ document.querySelector(`[data-name="${name}"] select`).value=val; setQty(name,item.price,val); });
+    const subtotal=item.qty*item.price;
+    li.textContent=`${name} = €${subtotal.toFixed(2)} `;
+    li.appendChild(sel);
+    list.appendChild(li);
+    if(item.qty>0) total+=subtotal;
+  });
+  document.getElementById('total').textContent=total.toFixed(2);
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+  document.querySelectorAll('.menu-item select').forEach(sel=>{
+    populateSelect(sel);
+    const parent=sel.closest('.menu-item');
+    const name=parent.dataset.name;
+    const price=parseFloat(parent.dataset.price);
+    sel.addEventListener('change',()=>{ setQty(name,price,parseInt(sel.value)); });
+  });
+  document.querySelectorAll('.qty-plus').forEach(btn=>{
+    btn.addEventListener('click',()=>{ const sel=document.getElementById(btn.dataset.target); let val=parseInt(sel.value); if(val<20) val++; sel.value=val; const parent=sel.closest('.menu-item'); setQty(parent.dataset.name,parseFloat(parent.dataset.price),val); });
+  });
+  document.querySelectorAll('.qty-minus').forEach(btn=>{
+    btn.addEventListener('click',()=>{ const sel=document.getElementById(btn.dataset.target); let val=parseInt(sel.value); if(val>0) val--; sel.value=val; const parent=sel.closest('.menu-item'); setQty(parent.dataset.name,parseFloat(parent.dataset.price),val); });
+  });
+  document.getElementById('typePickup').addEventListener('change',toggleAddress);
+  document.getElementById('typeDelivery').addEventListener('change',toggleAddress);
+  document.getElementById('submitOrder').addEventListener('click',submitOrder);
+  updateCart();
+  toggleAddress();
+});
+function toggleAddress(){
+  const delivery=document.getElementById('typeDelivery').checked;
+  const field=document.getElementById('addressField');
+  const input=document.getElementById('custAddress');
+  if(delivery){ field.classList.remove('hidden'); input.required=true; }
+  else{ field.classList.add('hidden'); input.required=false; input.value=''; }
+}
+function submitOrder(){
+  const name=document.getElementById('custName').value.trim();
+  const phone=document.getElementById('custPhone').value.trim();
+  if(!name||!phone){ alert('Vul naam en telefoon in.'); return; }
+  const delivery=document.getElementById('typeDelivery').checked;
+  const address=document.getElementById('custAddress').value.trim();
+  if(delivery && !address){ alert('Adres is verplicht bij bezorgen.'); return; }
+  if(Object.keys(cart).length===0){ alert('Geen producten geselecteerd.'); return; }
+  let summary=Object.entries(cart).map(([n,i])=>`${n} x ${i.qty}`).join('\n');
+  summary+=`\nNaam: ${name}\nTelefoon: ${phone}`;
+  if(delivery) summary+=`\nAdres: ${address}`; else summary+='\nPickup';
+  alert('Bestelling verzonden!\n\n'+summary);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add wrapper around nav items and center nav links on desktop
- rebuild staff POS page with customer info, order summary and product menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ffe7721c8333bd556c8b2fed3204