### PR TITLE
Add admin orders page

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -78,6 +78,24 @@ def pos():
 def admin():
     return render_template('admin.html')
 
+@app.route('/admin/orders')
+@login_required
+def admin_orders():
+    orders = Order.query.order_by(Order.created_at.desc()).all()
+    order_data = []
+    for o in orders:
+        try:
+            items = json.loads(o.items or "{}")
+        except Exception:
+            items = {}
+        total = 0
+        for item in items.values():
+            price = float(item.get("price", 0))
+            qty = int(item.get("qty", 0))
+            total += price * qty
+        order_data.append({"order": o, "total": total})
+    return render_template("admin_orders.html", order_data=order_data)
+
 @app.route('/login', methods=["GET", "POST"])
 def login():
     if request.method == "POST":

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Orders</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            padding: 20px;
+            max-width: 1200px;
+            margin: auto;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        @media (max-width: 600px) {
+            table, thead, tbody, th, td, tr {
+                display: block;
+            }
+            thead tr {
+                display: none;
+            }
+            tr {
+                margin-bottom: 15px;
+                border: 1px solid #ddd;
+                padding: 10px;
+            }
+            td {
+                border: none;
+                position: relative;
+                padding-left: 50%;
+            }
+            td:before {
+                position: absolute;
+                left: 10px;
+                top: 0;
+                width: 45%;
+                white-space: nowrap;
+                font-weight: bold;
+            }
+            td:nth-of-type(1):before { content: "ID"; }
+            td:nth-of-type(2):before { content: "Type"; }
+            td:nth-of-type(3):before { content: "Customer"; }
+            td:nth-of-type(4):before { content: "Phone"; }
+            td:nth-of-type(5):before { content: "Address"; }
+            td:nth-of-type(6):before { content: "Payment"; }
+            td:nth-of-type(7):before { content: "Created"; }
+            td:nth-of-type(8):before { content: "Total"; }
+        }
+    </style>
+</head>
+<body>
+    <h1>Alle Bestellingen</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Type</th>
+                <th>Klant</th>
+                <th>Telefoon</th>
+                <th>Adres</th>
+                <th>Betaalmethode</th>
+                <th>Aangemaakt</th>
+                <th>Totaal (€)</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for info in order_data %}
+            <tr>
+                <td>{{ info.order.id }}</td>
+                <td>{{ 'Delivery' if info.order.order_type == 'delivery' else 'Pickup' }}</td>
+                <td>{{ info.order.customer_name }}</td>
+                <td>{{ info.order.phone }}</td>
+                <td>
+                    {% if info.order.order_type == 'delivery' %}
+                        {{ info.order.street }} {{ info.order.house_number }} {{ info.order.postcode }} {{ info.order.city }}
+                    {% else %}-{% endif %}
+                </td>
+                <td>{{ info.order.payment_method }}</td>
+                <td>{{ info.order.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                <td>{{ '%.2f' % info.total }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `/admin/orders` route that lists orders
- compute total price for each order
- add responsive `templates/admin_orders.html`

## Testing
- `python -m py_compile api/index.py`

------
https://chatgpt.com/codex/tasks/task_e_684286d77f4c833395adc5c46081a236