### PR TITLE
Fix SQLite path for Vercel

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -8,13 +8,27 @@ from flask_login import (
     login_required,
 )
 from datetime import datetime
+import os
+import tempfile
 import json
 
 # 初始化 Flask
-app = Flask(__name__, template_folder="../templates", static_folder="../static")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+app = Flask(
+    __name__,
+    template_folder=os.path.join(BASE_DIR, "../templates"),
+    static_folder=os.path.join(BASE_DIR, "../static"),
+)
 app.config["SECRET_KEY"] = "replace-this"
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///db.sqlite3"
+
+db_file = os.path.join(BASE_DIR, "db.sqlite3")
+if os.environ.get("VERCEL"):
+    db_file = os.path.join(tempfile.gettempdir(), "db.sqlite3")
+app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_file}"
+
 db = SQLAlchemy(app)
+with app.app_context():
+    db.create_all()
 
 # 设置登录管理
 login_manager = LoginManager(app)


### PR DESCRIPTION
## Summary
- create database in `/tmp` when running on Vercel
- ensure templates/static folders use absolute paths
- automatically initialize database tables at startup

## Testing
- `python -m py_compile api/index.py`


------
https://chatgpt.com/codex/tasks/task_e_68428beca43c83339b40232c164691fd