### PR TITLE
Prepare for Render deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,22 +9,19 @@ from flask_login import (
 )
 from datetime import datetime
 import os
-import tempfile
 import json
 
 # 初始化 Flask
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 app = Flask(
     __name__,
-    template_folder=os.path.join(BASE_DIR, "../templates"),
-    static_folder=os.path.join(BASE_DIR, "../static"),
+    template_folder="templates",
+    static_folder="static",
 )
 app.config["SECRET_KEY"] = "replace-this"
 
-db_file = os.path.join(BASE_DIR, "db.sqlite3")
-if os.environ.get("VERCEL"):
-    db_file = os.path.join(tempfile.gettempdir(), "db.sqlite3")
-app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_file}"
+DATABASE = os.path.join(BASE_DIR, "db.sqlite3")
+app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{DATABASE}"
 
 db = SQLAlchemy(app)
 with app.app_context():

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: flask-app
+    runtime: python
+    buildCommand: ""
+    startCommand: gunicorn app:app
+    envVars:
+      - key: FLASK_ENV
+        value: production

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 flask
-flask-login
-flask-sqlalchemy
-werkzeug
 gunicorn

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "builds": [
-    { "src": "api/index.py", "use": "@vercel/python" }
-  ],
-  "routes": [
-    { "src": "/(.*)", "dest": "api/index.py" }
-  ]
-}


### PR DESCRIPTION
## Summary
- move Flask entry point `index.py` to `app.py` at repo root
- configure Flask to load templates and static files directly from root directories
- simplify SQLite path handling
- drop vercel configuration and add Render deployment config
- reduce `requirements.txt` to only flask and gunicorn

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684344c51460833396a092beb968a3ba