### PR TITLE
Fix checkout script and implement send API

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask_login import (
 from datetime import datetime
 import os
 import json
+import requests
 
 # 初始化 Flask
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -85,6 +86,28 @@ def pos():
         db.session.commit()
         return jsonify({"success": True})
     return render_template("pos.html")
+
+# 简易消息发送接口，用于通知 Telegram 或邮件
+@app.route('/api/send', methods=["POST"])
+def api_send():
+    data = request.get_json() or {}
+    message = data.get("message", "")
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if token and chat_id and message:
+        try:
+            resp = requests.post(
+                f"https://api.telegram.org/bot{token}/sendMessage",
+                json={"chat_id": chat_id, "text": message},
+                timeout=5,
+            )
+            resp.raise_for_status()
+        except Exception as e:
+            return jsonify({"status": "error", "error": str(e)}), 500
+
+    # 实际环境中这里可能还会发送邮件
+    return jsonify({"status": "ok"})
 
 # 管理员首页（占位）
 @app.route('/admin')

--- a/templates/index.html
+++ b/templates/index.html
@@ -910,7 +910,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 <script>
 function checkout() {
-  const paidItems = cart.filter(item => item.price > 0 && item.qty > 0);
+  const paidItems = Object.values(cart).filter(item => item.price > 0 && item.qty > 0);
   if (paidItems.length === 0) {
     alert('U moet ten minste één gerecht selecteren om te bestellen.');
     return;
@@ -921,7 +921,9 @@ function checkout() {
   const wasabiCount = document.getElementById('wasabiCount').value;
   const gemberCount = document.getElementById('gemberCount').value;
 
-  let orderSummary = cart.map(item => `${item.name} x ${item.qty}`).join('\n');
+  let orderSummary = Object.entries(cart)
+    .map(([name, item]) => `${name} x ${item.qty}`)
+    .join('\n');
   orderSummary += `\nStokjes nodig: ${chopstickCount}`;
   orderSummary += `\nSojasaus: ${soyCount}`;
   orderSummary += `\nWasabi: ${wasabiCount}`;


### PR DESCRIPTION
## Summary
- fix cart handling in checkout script
- add `/api/send` endpoint in Flask to forward messages to Telegram

## Testing
- `python -m py_compile app.py wsgi.py`
- `pytest -q` *(no tests found)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f5c7fca88333a7e907cb2cfd8f5b