### PR TITLE
Add live order notifications on POS page

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -430,5 +430,25 @@ function submitOrder(){
     .catch(()=>alert('Fout bij verzenden'));
 }
 </script>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+<script>
+  const socket = io();
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  function beep(){
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(660, audioCtx.currentTime);
+    gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.2);
+  }
+  socket.on('new_order', order => {
+    beep();
+    alert('Nieuwe bestelling ontvangen!');
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- connect POS page to backend Socket.IO server
- alert and play short beep when a `new_order` event arrives

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_68457f925b2c8333bd3ec34ed5f7539b