### PR TITLE
Fix POS order display

### DIFF
--- a/app.py
+++ b/app.py
@@ -164,7 +164,11 @@ def admin_orders():
         try:
             items = json.loads(o.items or "{}")
         except Exception:
-            items = {}
+            try:
+                import ast
+                items = ast.literal_eval(o.items)
+            except Exception:
+                items = {}
         total = sum(float(i.get("price", 0)) * int(i.get("qty", 0)) for i in items.values())
         order_data.append({"order": o, "total": total})
     return render_template("admin_orders.html", order_data=order_data)
@@ -178,9 +182,13 @@ def pos_orders_today():
     for o in orders:
         try:
             o.items_dict = json.loads(o.items or "{}")
-        except Exception as e:
-            print(f"❌ JSON解析失败: {e}")
-            o.items_dict = {}
+        except Exception:
+            try:
+                import ast
+                o.items_dict = ast.literal_eval(o.items)
+            except Exception as e:
+                print(f"❌ JSON解析失败: {e}")
+                o.items_dict = {}
     return render_template("pos_orders.html", orders=orders)
 # 登录
 @app.route('/login', methods=["GET", "POST"])

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -24,7 +24,9 @@
       <tr>
         <th>Tijd</th>
         <th>Klant</th>
+        <th>Telefoon</th>
         <th>Items</th>
+        <th>Adres</th>
         <th>Betaling</th>
         <th>Type</th>
       </tr>
@@ -34,12 +36,18 @@
       <tr>
         <td>{{ order.created_at.strftime('%H:%M') }}</td>
         <td>{{ order.customer_name or '' }}</td>
+        <td>{{ order.phone or '' }}</td>
         <td>
           <ul>
           {% for name, item in order.items_dict.items() %}
             <li>{{ name }} x {{ item['qty'] }}</li>
           {% endfor %}
           </ul>
+        </td>
+        <td>
+          {% if order.order_type == 'delivery' %}
+            {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}
+          {% else %}-{% endif %}
         </td>
         <td>{{ order.payment_method }}</td>
         <td>{{ 'Bezorgen' if order.order_type == 'delivery' else 'Afhalen' }}</td>


### PR DESCRIPTION
## Summary
- handle non-JSON item strings when showing orders
- show phone and address in `pos_orders.html`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847ee32f0788333b2f32ce704df8e94