### PR TITLE
Fix order type display

### DIFF
--- a/app.py
+++ b/app.py
@@ -246,7 +246,8 @@ def pos_orders_today():
         o.total = total
         summary = "\n".join(f"{name} x {item['qty']}" for name, item in o.items_dict.items())
 
-        if o.order_type == "afhalen":
+        is_pickup = o.order_type in ["afhalen", "pickup"]
+        if is_pickup:
             details = f"[Afhalen]\nNaam: {o.customer_name}\nTelefoon: {o.phone}"
             if o.email:
                 details += f"\nEmail: {o.email}"

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -78,11 +78,12 @@
         {% for info in order_data %}
             <tr>
                 <td>{{ info.order.id }}</td>
-                <td>{{ 'Delivery' if info.order.order_type == 'delivery' else 'Pickup' }}</td>
+                {% set is_delivery = info.order.order_type in ['delivery', 'bezorgen'] %}
+                <td>{{ 'Delivery' if is_delivery else 'Pickup' }}</td>
                 <td>{{ info.order.customer_name }}</td>
                 <td>{{ info.order.phone }}</td>
                 <td>
-                    {% if info.order.order_type == 'delivery' %}
+                    {% if is_delivery %}
                         {{ info.order.street }} {{ info.order.house_number }} {{ info.order.postcode }} {{ info.order.city }}
                     {% else %}-{% endif %}
                 </td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -461,7 +461,7 @@ function submitOrder(){
   function formatOrder(o){
     const items = Object.entries(o.items || {}).map(([n,i])=>`${n} x ${i.qty}`).join('\n');
     const name = o.customer_name ? `Klant: ${o.customer_name}\n` : '';
-    const type = o.order_type === 'delivery' ? 'Bezorgen' : 'Afhalen';
+    const type = ['delivery','bezorgen'].includes(o.order_type) ? 'Bezorgen' : 'Afhalen';
     return `${name}${type}\n${items}`;
   }
   socket.on('new_order', order => {

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -38,7 +38,8 @@
     {% for order in orders %}
       <tr>
         <td>{{ order.created_at.strftime('%H:%M') }}</td>
-        <td>{{ 'Bezorgen' if order.order_type == 'delivery' else 'Afhalen' }}</td>
+        {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
+        <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
         <td>{{ order.customer_name or '' }}</td>
         <td>{{ order.phone or '' }}</td>
         <td>{{ order.email or '-' }}</td>
@@ -51,12 +52,12 @@
         </td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
-          {% if order.order_type == 'delivery' %}
+          {% if is_delivery %}
             {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}
           {% else %}-{% endif %}
         </td>
         <td>
-          {% if order.order_type == 'delivery' %}
+          {% if is_delivery %}
             {{ order.delivery_time or '-' }}
           {% else %}
             {{ order.pickup_time or '-' }}


### PR DESCRIPTION
## Summary
- handle multiple order type strings when rendering orders

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68482e1a5ebc83339451cb5e85f01ebe