### PR TITLE
Dual panel POS layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -721,44 +721,7 @@ input#bezorgen:checked ~ .slider {
     </div>
   </div>
 </section>
-<section id="checkbox-group">
-<div class="checkbox-group">
-<h2>Draag bij aan duurzaamheid en voorkom verspilling 🌱</h2>
-<p style="margin-top: -12px; font-size: 0.95rem; color: #555; text-align: center;">
-    Geef aan hoeveel u nodig heeft:
-  </p>
-<div class="supply-row">
-  <img alt="Stokjes" class="supply-img photo" src="{{ url_for('static', filename='images/chopsticks.png') }}"/>
-  <div class="supply-content">
-    <label for="chopstickCount">Aantal stokjes</label>
-    <select id="chopstickCount" class="supply-select"></select>
-  </div>
-</div>
-<!-- Sojasaus -->
-<div class="supply-row">
-<img alt="Sojasaus" class="supply-img photo" src="{{ url_for('static', filename='images/soja saus.webp') }}"/>
-<div class="supply-content">
-<label for="soyCount">Aantal sojasaus flesjes</label>
-<select id="soyCount" class="supply-select"></select>
-</div>
-</div>
-<!-- Wasabi -->
-<div class="supply-row">
-<img alt="Wasabi" class="supply-img photo" src="{{ url_for('static', filename='images/wasabi.webp') }}"/>
-<div class="supply-content">
-<label for="wasabiCount">Aantal wasabi</label>
-<select id="wasabiCount" class="supply-select"></select>
-</div>
-</div>
-<!-- Gember -->
-<div class="supply-row">
-<img alt="Gember" class="supply-img photo" src="{{ url_for('static', filename='images/gember.webp') }}"/>
-<div class="supply-content">
-<label for="gemberCount">Aantal gember</label>
-<select id="gemberCount" class="supply-select"></select>
-</div>
-</div>
-</div></section>
+{% include "menu.html" %}
 
 
 <div class="cart-section" id="mobileCart">

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -1,0 +1,659 @@
+<section id="checkbox-group">
+<div class="checkbox-group">
+<h2>Draag bij aan duurzaamheid en voorkom verspilling 🌱</h2>
+<p style="margin-top: -12px; font-size: 0.95rem; color: #555; text-align: center;">
+    Geef aan hoeveel u nodig heeft:
+  </p>
+<div class="supply-row">
+  <img alt="Stokjes" class="supply-img photo" src="{{ url_for('static', filename='images/chopsticks.png') }}"/>
+  <div class="supply-content">
+    <label for="chopstickCount">Aantal stokjes</label>
+    <select id="chopstickCount" class="supply-select"></select>
+  </div>
+</div>
+<!-- Sojasaus -->
+<div class="supply-row">
+<img alt="Sojasaus" class="supply-img photo" src="{{ url_for('static', filename='images/soja saus.webp') }}"/>
+<div class="supply-content">
+<label for="soyCount">Aantal sojasaus flesjes</label>
+<select id="soyCount" class="supply-select"></select>
+</div>
+</div>
+<!-- Wasabi -->
+<div class="supply-row">
+<img alt="Wasabi" class="supply-img photo" src="{{ url_for('static', filename='images/wasabi.webp') }}"/>
+<div class="supply-content">
+<label for="wasabiCount">Aantal wasabi</label>
+<select id="wasabiCount" class="supply-select"></select>
+</div>
+</div>
+<!-- Gember -->
+<div class="supply-row">
+<img alt="Gember" class="supply-img photo" src="{{ url_for('static', filename='images/gember.webp') }}"/>
+<div class="supply-content">
+<label for="gemberCount">Aantal gember</label>
+<select id="gemberCount" class="supply-select"></select>
+</div>
+</div>
+</div></section>
+
+
+<div class="cart-section" id="mobileCart">
+  <button id="closeCartBtn" onclick="toggleMobileCart()">×</button>
+  <h2 style="padding-top: 60px;">Winkelwagen</h2>
+  <ul id="cart"></ul>
+  <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
+  <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
+  <div class="total">Totaal: €<span id="total">0.00</span></div>
+  <button class="checkout-btn" onclick="checkout()">Afrekenen &amp; Betalen</button>
+
+</div>
+
+<button id="cart-toggle" onclick="toggleMobileCart()">🛒<span id="cart-count" style="
+      position: absolute;
+      top: -6px;
+      right: -6px;
+      background: red;
+      color: white;
+      border-radius: 50%;
+      padding: 2px 6px;
+      font-size: 0.75rem;
+      font-weight: bold;
+      line-height: 1;">0</span>
+</button>
+
+ 
+<section id="bubble">
+  <div class="menu-group">
+   <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Bubble Tea
+</h2>
+
+
+    <div class="menu-row menu-item" data-name="Bubble Tea" data-price="5">
+      <div class="menu-img">
+       <img src="{{ url_for('static', filename='images/bubble-tea-main.jpg') }}" alt="Bubble Tea">
+
+      </div>
+      <div class="menu-content">
+        <h3>Bubble Tea</h3>
+        <p>€ 5.00</p>
+    
+        <div class="bubble-option">
+       
+          <select id="bubbleType">
+            <option value="">Base</option>
+            <option value="Green Tea">Green Tea</option>
+            <option value="Milk Tea">Milk Tea</option>
+            <option value="Milkshake">Milkshake</option>
+          </select>
+        </div>
+
+        <div class="bubble-option">
+         
+          <select id="bubbleFlavor">
+            <option value="">Smaak</option>
+            <option value="Mango">Mango</option>
+            <option value="Appel">Appel</option>
+            <option value="Matcha">Matcha</option>
+            <option value="Brown Sugar">Brown Sugar</option>
+          </select>
+        </div>
+
+        <div class="bubble-option">
+    
+          <select id="bubbleTopping">
+            <option value="">Topping</option>
+            <option value="Appel Popping">Appel Popping</option>
+            <option value="Perzik Popping">Perzik Popping</option>
+            <option value="Tapioca">Tapioca</option>
+          </select>
+        </div>
+
+        <div class="qty-box">
+          <label for="bubbleTeaQty">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="bubbleTeaQty">-</button>
+          <select id="bubbleTeaQty"></select>
+          <button type="button" class="qty-plus add-button" data-target="bubbleTeaQty">+</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+
+
+
+<section id="bento">
+  <div class="menu-group">
+   <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Bento box
+</h2>
+
+
+    <!-- Chicken Bento -->
+    <div class="menu-row menu-item" data-name="Chicken Bento" data-price="12">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/chicken-bento.jpg') }}" alt="Chicken Bento">
+      </div>
+
+      <div class="menu-content">
+        <h3>Chicken Bento</h3>
+        <p>€ 12.00</p>
+
+        <div class="qty-box">
+          <label for="chickenBentoCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="chickenBentoCount">-</button>
+          <select id="chickenBentoCount" name="chickenBentoCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="chickenBentoCount">+</button>
+        </div>
+      </div>
+    </div>
+ 
+
+    <!-- Meatlover Bento -->
+<!-- Meatlover Bento -->
+<div class="menu-row menu-item" data-name="Meatlover Bento" data-price="14">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/Meatlove bento.png') }}" alt="Meatlover Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Meatlover Bento</h3>
+    <p>€ 14.00</p>
+
+    <div class="qty-box">
+      <label for="meatloverBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="meatloverBentoCount">-</button>
+      <select id="meatloverBentoCount" name="meatloverBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="meatloverBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+    <!-- Zalm Lover Bento -->
+    <div class="menu-row menu-item" data-name="Zalm Lover Bento" data-price="13">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}" alt="Zalm Lover Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Zalm Lover Bento</h3>
+    <p>€ 13.00</p>
+
+    <div class="qty-box">
+      <label for="zalmLoverBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="zalmLoverBentoCount">-</button>
+      <select id="zalmLoverBentoCount" name="zalmLoverBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="zalmLoverBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+    <!-- Ebi Lover Bento -->
+    <div class="menu-row menu-item" data-name="Ebi Lover Bento" data-price="13">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}" alt="Ebi Lover Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Ebi Lover Bento</h3>
+    <p>€ 13.00</p>
+
+    <div class="qty-box">
+      <label for="ebiLoverBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="ebiLoverBentoCount">-</button>
+      <select id="ebiLoverBentoCount" name="ebiLoverBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="ebiLoverBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+    <!-- Surf & Turf Bento -->
+   <div class="menu-row menu-item" data-name="Surf & Turf Bento" data-price="15">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}" alt="Surf & Turf Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Surf & Turf Bento</h3>
+    <p>€ 15.00</p>
+
+    <div class="qty-box">
+      <label for="surfTurfBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="surfTurfBentoCount">-</button>
+      <select id="surfTurfBentoCount" name="surfTurfBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="surfTurfBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+    <!-- Dimsum Bento -->
+   <div class="menu-row menu-item" data-name="Dimsum Bento" data-price="11">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/dimsum-bento.png') }}" alt="Dimsum Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Dimsum Bento</h3>
+    <p>€ 11.00</p>
+
+    <div class="qty-box">
+      <label for="dimsumBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="dimsumBentoCount">-</button>
+      <select id="dimsumBentoCount" name="dimsumBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="dimsumBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+    <!-- Lamskotelet Bento -->
+    <div class="menu-row menu-item" data-name="Lamskotelet Bento" data-price="14">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}" alt="Lamskotelet Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Lamskotelet Bento</h3>
+    <p>€ 14.00</p>
+
+    <div class="qty-box">
+      <label for="lamsBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="lamsBentoCount">-</button>
+      <select id="lamsBentoCount" name="lamsBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="lamsBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+    <!-- Veggie Bento -->
+   <div class="menu-row menu-item" data-name="Veggie Bento" data-price="10">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/veggie-bento.png') }}" alt="Veggie Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Veggie Bento</h3>
+    <p>€ 10.00</p>
+
+    <div class="qty-box">
+      <label for="veggieBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="veggieBentoCount">-</button>
+      <select id="veggieBentoCount" name="veggieBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="veggieBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+  <div class="menu-row menu-item" data-name="Sushi Bento" data-price="14">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/sushi-bento.jpg') }}" alt="Sushi Bento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Sushi Bento</h3>
+    <p>€ 14.00</p>
+
+    <div class="qty-box">
+      <label for="sushiBentoCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="sushiBentoCount">-</button>
+      <select id="sushiBentoCount" name="sushiBentoCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="sushiBentoCount">+</button>
+    </div>
+  </div>
+</div>
+
+    <!-- Xbento - Stel je eigen bento samen -->
+<!-- Xbento - Stel je eigen bento samen -->
+<div class="menu-row menu-item" data-name="Xbento" data-price="14">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/xbento.png') }}" alt="Xbento">
+  </div>
+
+  <div class="menu-content">
+    <h3>Xbento (stel zelf samen)</h3>
+    <p>Vanaf € 14.00</p>
+
+    <div class="bubble-option">
+      <select id="xBentoMain">
+        <option value="">Hoofdgerecht</option>
+        <option value="Teriyaki beef">Teriyaki beef</option>
+        <option value="Karaage chicken">Karaage chicken</option>
+        <option value="Ebi fry">Ebi fry</option>
+        <option value="Zalm">Zalm</option>
+        <option value="Teriyaki chicken">Teriyaki chicken</option>
+      </select>
+    </div>
+
+    <div class="bubble-option">
+      <select id="xBentoSide">
+        <option value="">Bijgerecht</option>
+        <option value="Gyoza">Gyoza</option>
+        <option value="Edamame">Edamame</option>
+        <option value="Spring Roll">Spring Roll</option>
+      </select>
+    </div>
+
+    <div class="bubble-option">
+      <select id="xBentoRice">
+        <option value="">Rijstsoort</option>
+        <option value="White rice">White rice</option>
+        <option value="Fried rice (+€5)">Fried rice (+€5)</option>
+        <option value="Sushi rice">Sushi rice</option>
+      </select>
+    </div>
+
+    <div class="qty-box">
+      <label for="xBentoQty">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="xBentoQty">-</button>
+      <select id="xBentoQty" class="qty-select" name="xBentoQty"></select>
+      <button type="button" class="qty-plus add-button" data-target="xBentoQty">+</button>
+
+    </div>
+  </div>
+</div>
+
+
+  </div>
+</section>
+
+<!-- Ramen Section -->
+<section id="Ramen">
+  <h2>Ramen</h2>
+  <div class="menu-section">
+    <!-- 示例商品，可替换或添加更多 -->
+    <div class="menu-row menu-item" data-name="Tonkotsu Ramen" data-price="13">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}" alt="Tonkotsu Ramen">
+      </div>
+      <div class="menu-content">
+        <h3>Tonkotsu Ramen</h3>
+        <p>€ 13.00</p>
+        <p class="menu-description">Romige varkensbouillon met chashu, ramennoedels, ei en nori.</p>
+        <div class="qty-box">
+          <label for="tonkotsuRamenCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="tonkotsuRamenCount">-</button>
+          <select id="tonkotsuRamenCount" name="tonkotsuRamenCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="tonkotsuRamenCount">+</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- Pokebowl Section -->
+<section id="Pokebowl">
+  <h2>Pokebowl</h2>
+  <div class="menu-section">
+    <!-- 示例商品，可替换或添加更多 -->
+    <div class="menu-row menu-item" data-name="Zalm Pokebowl" data-price="12">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/zalm-pokebowl.png') }}" alt="Zalm Pokebowl">
+      </div>
+      <div class="menu-content">
+        <h3>Zalm Pokebowl</h3>
+        <p>€ 12.00</p>
+        <p class="menu-description">Verse zalm met sushirijst, avocado, komkommer, wakame en sesam.</p>
+        <div class="qty-box">
+          <label for="zalmPokebowlCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="zalmPokebowlCount">-</button>
+          <select id="zalmPokebowlCount" name="zalmPokebowlCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="zalmPokebowlCount">+</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section id="sushi">
+  <div class="menu-group">
+    <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Sushi
+</h2>
+
+
+<div class="menu-row menu-item" data-name="Green Dragon Roll" data-price="13.5">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/green-dragon-roll.png') }}" alt="Green Dragon Roll">
+  </div>
+
+  <div class="menu-content">
+    <h3>Green Dragon Roll</h3>
+    <p>Ebi fry roll met avocado & viskuit topping<br>€ 13.50</p>
+
+    <div class="qty-box">
+      <label for="greenDragonCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="greenDragonCount">-</button>
+      <select id="greenDragonCount" name="greenDragonCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="greenDragonCount">+</button>
+    </div>
+  </div>
+</div>
+
+<div class="menu-row menu-item" data-name="Angry Dragon Roll" data-price="13.5">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/angry-dragon.png') }}" alt="Angry Dragon Roll">
+  </div>
+
+  <div class="menu-content">
+    <h3>Angry Dragon Roll</h3>
+    <p>Ebi fry roll met aburi zalm & unagi saus topping<br>€ 13.50</p>
+
+    <div class="qty-box">
+      <label for="angryDragonCount">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="angryDragonCount">-</button>
+      <select id="angryDragonCount" name="angryDragonCount"></select>
+      <button type="button" class="qty-plus add-button" data-target="angryDragonCount">+</button>
+    </div>
+  </div>
+</div>
+
+
+</section>
+
+
+<section id="Crispy-rice-sandwich">
+  <div class="menu-group">
+    <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+      Crispy rice sandwich
+    </h2>
+
+    <!-- Zalm -->
+    <div class="menu-row menu-item" data-name="Zalm crispy rice sandwich" data-price="7">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/zalm.png') }}" alt="Zalm crispy rice sandwich">
+      </div>
+
+      <div class="menu-content">
+        <h3>Zalm crispy rice sandwich</h3>
+        <p>€ 7.00</p>
+
+        <div class="qty-box">
+          <label for="zalm-crispy-rice-sandwich">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="zalm-crispy-rice-sandwich">-</button>
+          <select id="zalm-crispy-rice-sandwich" name="Zalm crispy rice sandwich"></select>
+          <button type="button" class="qty-plus add-button" data-target="zalm-crispy-rice-sandwich">+</button>
+        </div>
+      </div>
+    </div>
+
+
+
+    <!-- Ebi -->
+    <!-- Ebi Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Ebi crispy rice sandwich" data-price="7">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/Ebi.png') }}" alt="Ebi Crispy Rice Sandwich">
+  </div>
+
+  <div class="menu-content">
+    <h3>Ebi crispy rice sandwich</h3>
+    <p>€ 7.00</p>
+
+    <div class="qty-box">
+      <label for="ebiCrispyRiceSandwich">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="ebiCrispyRiceSandwich">-</button>
+      <select id="ebiCrispyRiceSandwich" name="ebiCrispyRiceSandwich"></select>
+      <button type="button" class="qty-plus add-button" data-target="ebiCrispyRiceSandwich">+</button>
+    </div>
+  </div>
+</div>
+
+
+  <!-- Beef Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Beef crispy rice sandwich" data-price="7.5">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/beef-crispy.png') }}" alt="Beef Crispy Rice Sandwich">
+  </div>
+
+  <div class="menu-content">
+    <h3>Beef crispy rice sandwich</h3>
+    <p>€ 7.50</p>
+    <div class="qty-box">
+      <label for="beefCrispyRiceSandwich">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="beefCrispyRiceSandwich">-</button>
+      <select id="beefCrispyRiceSandwich" name="beefCrispyRiceSandwich"></select>
+      <button type="button" class="qty-plus add-button" data-target="beefCrispyRiceSandwich">+</button>
+    </div>
+  </div>
+</div>
+<!-- California Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="California crispy rice sandwich" data-price="7.5">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/california-crispy.png') }}" alt="California Crispy Rice Sandwich">
+  </div>
+
+  <div class="menu-content">
+    <h3>California crispy rice sandwich</h3>
+    <p>€ 7.50</p>
+    <div class="qty-box">
+      <label for="californiaCrispyRiceSandwich">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="californiaCrispyRiceSandwich">-</button>
+      <select id="californiaCrispyRiceSandwich" name="californiaCrispyRiceSandwich"></select>
+      <button type="button" class="qty-plus add-button" data-target="californiaCrispyRiceSandwich">+</button>
+    </div>
+  </div>
+</div>
+
+<!-- Chicken Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Chicken crispy rice sandwich" data-price="7">
+  <div class="menu-img">
+    <img src="{{ url_for('static', filename='images/chicken-crispy.png') }}" alt="Chicken Crispy Rice Sandwich">
+  </div>
+
+  <div class="menu-content">
+    <h3>Chicken crispy rice sandwich</h3>
+    <p>€ 7.00</p>
+    <div class="qty-box">
+      <label for="chickenCrispyRiceSandwich">Aantal</label>
+      <button type="button" class="qty-minus remove-button" data-target="chickenCrispyRiceSandwich">-</button>
+      <select id="chickenCrispyRiceSandwich" name="chickenCrispyRiceSandwich"></select>
+      <button type="button" class="qty-plus add-button" data-target="chickenCrispyRiceSandwich">+</button>
+    </div>
+  </div>
+</div>
+  </div>
+</section>
+<section id="snack">
+  <div class="menu-group">
+    <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Snack
+</h2>
+
+
+    <div class="menu-row menu-item" data-name="Karaage" data-price="6.5">
+      <img src="{{ url_for('static', filename='images/karaage.png') }}" alt="Karaage" class="menu-img" loading="lazy" />
+      <div class="menu-content">
+        <h3>Karaage (Japanse gefrituurde kip)</h3>
+        <p>€ 6.50</p>
+        <div class="qty-box">
+          <label for="snackCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="snackCount">-</button>
+          <select id="snackCount" name="snackCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="snackCount">+</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<section id="dessert">
+  <div class="menu-group">
+
+    <!-- Mango -->
+    <div class="menu-row menu-item" data-name="Mochi Mango" data-price="4">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/mochi-mango.png') }}" alt="Mochi Mango" loading="lazy" />
+      </div>
+      <div class="menu-content">
+        <h3>Mochi – Mango</h3>
+        <p>€ 4.00</p>
+        <div class="qty-box">
+          <label for="mochiMangoCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="mochiMangoCount">-</button>
+          <select id="mochiMangoCount" name="mochiMangoCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="mochiMangoCount">+</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Aardbei -->
+    <div class="menu-row menu-item" data-name="Mochi Aardbei" data-price="4">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/mochi-aardbei.png') }}" alt="Mochi Aardbei" loading="lazy" />
+      </div>
+      <div class="menu-content">
+        <h3>Mochi – Aardbei</h3>
+        <p>€ 4.00</p>
+        <div class="qty-box">
+          <label for="mochiAardbeiCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="mochiAardbeiCount">-</button>
+          <select id="mochiAardbeiCount" name="mochiAardbeiCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="mochiAardbeiCount">+</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Matcha -->
+    <div class="menu-row menu-item" data-name="Mochi Matcha" data-price="4">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/mochi-matcha.png') }}" alt="Mochi Matcha" loading="lazy" />
+      </div>
+      <div class="menu-content">
+        <h3>Mochi – Matcha</h3>
+        <p>€ 4.00</p>
+        <div class="qty-box">
+          <label for="mochiMatchaCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="mochiMatchaCount">-</button>
+          <select id="mochiMatchaCount" name="mochiMatchaCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="mochiMatchaCount">+</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Pistachio -->
+    <div class="menu-row menu-item" data-name="Mochi Pistachio" data-price="4">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/mochi-pistachio.png') }}" alt="Mochi Pistachio" loading="lazy" />
+      </div>
+      <div class="menu-content">
+        <h3>Mochi – Pistachio</h3>
+        <p>€ 4.00</p>
+        <div class="qty-box">
+          <label for="mochiPistachioCount">Aantal</label>
+          <button type="button" class="qty-minus remove-button" data-target="mochiPistachioCount">-</button>
+          <select id="mochiPistachioCount" name="mochiPistachioCount"></select>
+          <button type="button" class="qty-plus add-button" data-target="mochiPistachioCount">+</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -1,0 +1,50 @@
+  <h1>Bestellingen Vandaag</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Tijd</th>
+        <th>Type</th>
+        <th>Klant</th>
+        <th>Telefoon</th>
+        <th>Email</th>
+        <th>Items</th>
+        <th>Totaal (&euro;)</th>
+        <th>Adres</th>
+        <th>Tijdslot</th>
+        <th>Betaling</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for order in orders %}
+      <tr>
+        <td>{{ order.created_at.strftime('%H:%M') }}</td>
+        {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
+        <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
+        <td>{{ order.customer_name or '' }}</td>
+        <td>{{ order.phone or '' }}</td>
+        <td>{{ order.email or '-' }}</td>
+        <td>
+          <ul>
+          {% for name, item in order.items_dict.items() %}
+            <li>{{ name }} x {{ item['qty'] }}</li>
+          {% endfor %}
+          </ul>
+        </td>
+        <td>{{ '%.2f' % order.total }}</td>
+        <td>
+          {% if is_delivery %}
+            {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}
+          {% else %}-{% endif %}
+        </td>
+        <td>
+          {% if is_delivery %}
+            {{ order.delivery_time or '-' }}
+          {% else %}
+            {{ order.pickup_time or '-' }}
+          {% endif %}
+        </td>
+        <td>{{ order.payment_method }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -130,6 +130,12 @@
   }
   @media (max-width: 600px) { .menu-item { flex-direction: column; align-items: flex-start; } }
   .pos-container { display: flex; flex-direction: column; }
+  .left-panel { display:flex; flex-direction: column; flex:2; }
+  .orders-panel { margin-top:20px; }
+  .orders-panel table { width:100%; border-collapse: collapse; }
+  .orders-panel th, .orders-panel td { border:1px solid #ddd; padding:8px; text-align:left; }
+  .orders-panel th { background:#f2f2f2; }
+  .orders-panel ul { margin:0; padding-left:20px; }
   .order-summary {
     background: var(--off-white);
     border: 1px solid #e0e0e0;
@@ -139,8 +145,10 @@
   }
   @media (min-width: 768px) {
     .pos-container { flex-direction: row; align-items: flex-start; }
-    .product-list { flex: 2; margin-right:20px; }
-    .order-summary { width:300px; margin-top:0; }
+    .left-panel { flex-direction: row; flex:2; }
+    .product-list { flex:2; margin-right:20px; }
+    .order-summary { width:300px; margin-right:20px; margin-top:0; }
+    .orders-panel { flex:1; max-width:400px; }
   }
   .order-summary button {
     width:100%;
@@ -171,9 +179,9 @@
   </nav>
 </div>
 <h1>Bestelling</h1>
-<p><a href="{{ url_for('pos_orders_today') }}">Bekijk bestellingen vandaag</a></p>
 <div class="pos-container">
-  <div class="product-list">
+  <div class="left-panel">
+    <div class="product-list">
     <section id="customer-info">
       <div class="delivery-options">
         <h2>Klantgegevens</h2>
@@ -217,115 +225,17 @@
         </div>
       </div>
     </section>
-    <section id="bento">
-      <div class="bento-group">
-        <h2>Bento Box 🍱</h2>
-        <div class="bento-row menu-item" data-name="Chicken Bento" data-price="12">
-          <img class="bento-img" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}" alt="Chicken Bento" loading="lazy"/>
-          <div class="bento-content">
-            <h3>Chicken Bento</h3>
-            <p>€ 12.00</p>
-            <label for="chickenBentoCount">Aantal</label>
-            <select id="chickenBentoCount" name="chickenBentoCount"></select>
-            <button type="button" class="qty-plus add-button" data-target="chickenBentoCount">+</button>
-            <button type="button" class="qty-minus remove-button" data-target="chickenBentoCount">-</button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="sushi">
-      <div class="menu-group">
-        <h2>Sushi Rolls 🍣</h2>
-        <div class="menu-row menu-item" data-name="Sake Maki" data-price="8.5">
-          <img class="menu-img" src="{{ url_for('static', filename='images/sake-maki.jpg') }}" alt="Sake Maki" loading="lazy" />
-          <div class="menu-content">
-            <h3>Sake Maki</h3>
-            <p>€ 8.50</p>
-            <label for="sakeCount">Aantal</label>
-            <select id="sakeCount" name="sakeCount"></select>
-            <button type="button" class="qty-plus add-button" data-target="sakeCount">+</button>
-            <button type="button" class="qty-minus remove-button" data-target="sakeCount">-</button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="bubble">
-      <div class="menu-group">
-        <h2>Bubble Tea 🧋</h2>
-        <div class="menu-row menu-item" data-name="Bubble Tea" data-price="5">
-          <div class="menu-img">
-            <img src="{{ url_for('static', filename='images/bubble-tea.jpg') }}" alt="Bubble Tea" class="menu-img" loading="lazy" />
-          </div>
-          <div class="menu-content">
-            <h3>Bubble Tea</h3>
-            <p>€ 5.00</p>
-            <label for="bubbleTeaCount">Aantal</label>
-            <select id="bubbleTeaCount" name="bubbleTeaCount"></select>
-            <button type="button" class="qty-plus add-button" data-target="bubbleTeaCount">+</button>
-            <button type="button" class="qty-minus remove-button" data-target="bubbleTeaCount">-</button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="dessert">
-      <div class="menu-group">
-        <h2>Dessert 🍡</h2>
-        <div class="menu-row menu-item" data-name="Mochi" data-price="4">
-          <img src="{{ url_for('static', filename='images/mochi.jpg') }}" alt="Mochi" class="menu-img" loading="lazy" />
-          <div class="menu-content">
-            <h3>Mochi (rijstcake)</h3>
-            <p>€ 4.00</p>
-            <label for="dessertCount">Aantal</label>
-            <select id="dessertCount" name="dessertCount"></select>
-            <button type="button" class="qty-plus add-button" data-target="dessertCount">+</button>
-            <button type="button" class="qty-minus remove-button" data-target="dessertCount">-</button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="snack">
-      <div class="menu-group">
-        <h2>Snack 🍤</h2>
-        <div class="menu-row menu-item" data-name="Karaage" data-price="6.5">
-          <img src="{{ url_for('static', filename='images/karaage.jpg') }}" alt="Karaage" class="menu-img" loading="lazy" />
-          <div class="menu-content">
-            <h3>Karaage (Japanse gefrituurde kip)</h3>
-            <p>€ 6.50</p>
-            <label for="snackCount">Aantal</label>
-            <select id="snackCount" name="snackCount"></select>
-            <button type="button" class="qty-plus add-button" data-target="snackCount">+</button>
-            <button type="button" class="qty-minus remove-button" data-target="snackCount">-</button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="vegan">
-      <div class="menu-group">
-        <h2>Vegan 🥬</h2>
-        <div class="menu-row menu-item" data-name="Avocado Roll" data-price="7">
-          <img src="{{ url_for('static', filename='images/avocado-roll.jpg') }}" alt="Avocado Roll" class="menu-img" loading="lazy" />
-          <div class="menu-content">
-            <h3>Avocado Roll</h3>
-            <p>€ 7.00</p>
-            <label for="veganCount">Aantal</label>
-            <select id="veganCount" name="veganCount"></select>
-            <button type="button" class="qty-plus add-button" data-target="veganCount">+</button>
-            <button type="button" class="qty-minus remove-button" data-target="veganCount">-</button>
-          </div>
-        </div>
-      </div>
-    </section>
+    {% include 'menu.html' %}
   </div>
   <div class="order-summary">
     <h2>Overzicht</h2>
     <ul id="cart"></ul>
     <div class="total">Totaal: €<span id="total">0.00</span></div>
     <button id="submitOrder">Submit Order</button>
+  </div>
+  </div>
+  <div class="orders-panel">
+    {% include 'orders_table.html' %}
   </div>
 </div>
 
@@ -464,9 +374,29 @@ function submitOrder(){
     const type = ['delivery','bezorgen'].includes(o.order_type) ? 'Bezorgen' : 'Afhalen';
     return `${name}${type}\n${items}`;
   }
+  function addRow(order){
+    const tbody = document.querySelector('.orders-panel tbody');
+    if(!tbody) return;
+    const tr = document.createElement('tr');
+    const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
+    const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
+    const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+    tr.innerHTML = `
+      <td>${order.created_at || ''}</td>
+      <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
+      <td>${order.customer_name || ''}</td>
+      <td>${order.phone || ''}</td>
+      <td>${order.email || '-'}</td>
+      <td><ul>${items}</ul></td>
+      <td>${total.toFixed(2)}</td>
+      <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}` : '-'}</td>
+      <td>${isDelivery ? (order.delivery_time || '-') : (order.pickup_time || '-')}</td>
+      <td>${order.payment_method || ''}</td>`;
+    tbody.prepend(tr);
+  }
   socket.on('new_order', order => {
     beep();
-    alert(`Nieuwe bestelling ontvangen!\n\n${formatOrder(order)}`);
+    addRow(order);
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- share order menu using new `menu.html` include
- show POS order entry and today's orders side-by-side
- update JS to append new orders in real time
- fetch today's orders when rendering `/pos`

## Testing
- `python -m py_compile app.py`
- `flake8 || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684867e55bd4833384d9f9a68abb269c