### PR TITLE
Fix order flow by running SocketIO with eventlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository demonstrates a minimal Flask deployment on Render. The goal is t
 - `requirements.txt` – Dependencies. Now includes `Flask-SocketIO` for real-time
   updates.
 - `runtime.txt` – Python version lock.
-- `render.yaml` – Render configuration.
+- `render.yaml` – Render configuration with an `eventlet` worker.
 
 ## Render configuration
 
@@ -23,8 +23,8 @@ services:
     buildCommand: |
       pip install --upgrade pip
       pip install -r requirements.txt
-      pip install gunicorn
-    startCommand: gunicorn wsgi:app
+      pip install gunicorn eventlet
+    startCommand: gunicorn --worker-class eventlet -w 1 wsgi:app
 ```
 
 Create a new Web Service on Render, link this repository, and it will deploy using the configuration above.

--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ from flask_login import (
     login_required,
 )
 from flask_socketio import SocketIO
+import eventlet
+eventlet.monkey_patch()
 from datetime import datetime
 import os
 import json
@@ -28,7 +30,7 @@ with app.app_context():
 
 
 # Socket.IO for real-time updates
-socketio = SocketIO(app, cors_allowed_origins="*")
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
 
 
 def send_telegram(message: str):

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: nova-asia
+    runtime: python
+    buildCommand: |
+      pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install gunicorn eventlet
+    startCommand: gunicorn --worker-class eventlet -w 1 wsgi:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.31.0
 gunicorn==21.2.0
 psycopg2-binary==2.9.9
 Flask-SocketIO==5.3.6
+eventlet==0.33.3


### PR DESCRIPTION
## Summary
- use eventlet for Flask-SocketIO to avoid blocking the API
- document Render configuration using an eventlet worker
- add render.yaml for Render deploy

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_684877d5d1888333855b0b95082b356e