### PR TITLE
Fix time fields to camelCase

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1774,10 +1774,10 @@ function checkout() {
         ? document.getElementById('pickupPhone').value.trim()
         : document.getElementById('deliveryPhone').value.trim(),
       email: email,
-      pickup_time: orderType === 'afhalen'
+      pickupTime: orderType === 'afhalen'
         ? document.getElementById('pickupTime').value
         : '',
-      delivery_time: orderType === 'bezorgen'
+      deliveryTime: orderType === 'bezorgen'
         ? document.getElementById('deliveryTime').value
         : '',
       paymentMethod: paymentMethod,

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -38,9 +38,9 @@
         </td>
         <td>
           {% if is_delivery %}
-            {{ order.delivery_time or '-' }}
+            {{ order.deliveryTime or '-' }}
           {% else %}
-            {{ order.pickup_time or '-' }}
+            {{ order.pickupTime or '-' }}
           {% endif %}
         </td>
         <td>{{ order.payment_method }}</td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -467,8 +467,8 @@ function submitOrder() {
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     const total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
-    const pickup = order.pickupTime ?? order.pickup_time;
-    const delivery = order.deliveryTime ?? order.delivery_time;
+    const pickup = order.pickupTime;
+    const delivery = order.deliveryTime;
 
     tr.innerHTML = `
       <td>${order.created_at || ''}</td>

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -83,8 +83,8 @@
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
       const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
-      const pickup = order.pickupTime ?? order.pickup_time;
-      const delivery = order.deliveryTime ?? order.delivery_time;
+      const pickup = order.pickupTime;
+      const delivery = order.deliveryTime;
       tr.innerHTML = `
         <td>${order.created_at || ''}</td>
         <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>


### PR DESCRIPTION
## Summary
- use `pickupTime` and `deliveryTime` everywhere
- update POS table to read camelCase data
- update orders table template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684acd0b5edc8333b9679e6366bb6805