### PR TITLE
Add date column to order tables

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,6 +158,7 @@ def pos():
                 "house_number": order.house_number,
                 "street": order.street,
                 "city": order.city,
+                "created_date": to_nl(order.created_at).strftime("%Y-%m-%d"),
                 "created_at": to_nl(order.created_at).strftime("%H:%M"),
                 "items": json.loads(order.items or "{}"),
             }
@@ -231,6 +232,7 @@ def api_orders():
                 "house_number": order.house_number,
                 "street": order.street,
                 "city": order.city,
+                "created_date": to_nl(order.created_at).strftime("%Y-%m-%d"),
                 "created_at": to_nl(order.created_at).strftime("%H:%M"),
                 "items": json.loads(order.items or "{}"),
             }
@@ -378,6 +380,7 @@ def pos_orders_today():
             "house_number": o.house_number,
             "street": o.street,
             "city": o.city,
+            "created_date": to_nl(o.created_at).strftime("%Y-%m-%d"),
             "created_at": to_nl(o.created_at).strftime("%H:%M"),
             "items": o.items_dict,
             "total": total,

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -2,6 +2,7 @@
   <table>
     <thead>
       <tr>
+        <th>Datum</th>
         <th>Tijd</th>
         <th>Type</th>
         <th>Klant</th>
@@ -17,6 +18,7 @@
     <tbody>
     {% for order in orders %}
       <tr>
+        <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
         <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -471,6 +471,7 @@ function submitOrder() {
     const delivery = order.delivery_time;
 
     tr.innerHTML = `
+      <td>${order.created_date || ''}</td>
       <td>${order.created_at || ''}</td>
       <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
       <td>${order.customer_name || ''}</td>

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -22,6 +22,7 @@
   <table>
     <thead>
       <tr>
+        <th>Datum</th>
         <th>Tijd</th>
         <th>Type</th>
         <th>Klant</th>
@@ -37,6 +38,7 @@
     <tbody>
     {% for order in orders %}
       <tr>
+        <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
         <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
@@ -86,6 +88,7 @@
       const pickup = order.pickup_time;
       const delivery = order.delivery_time;
       tr.innerHTML = `
+        <td>${order.created_date || ''}</td>
         <td>${order.created_at || ''}</td>
         <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
         <td>${order.customer_name || ''}</td>


### PR DESCRIPTION
## Summary
- display order date in `orders_table.html`
- show date in POS orders table and realtime updates
- include `created_date` in order payloads

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_684ae8c844908333b4d360ac6f7e5baf