### PR TITLE
Fix POS submission payload and reset form

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -482,6 +482,8 @@ function toggleToday(){
   panel.classList.toggle('visible');
   if(panel.classList.contains('visible')){
     fetchOrders();
+    newOrderCount = 0;
+    updateTabTitle();
   }
 }
 
@@ -537,6 +539,21 @@ function updateQRCode(){
     container.classList.add('hidden');
   }
 }
+
+function clearForm(){
+  ['custName','custPhone','pickupTime','deliveryTime','postcode','houseNumber','street','city'].forEach(id=>{
+    const el=document.getElementById(id);
+    if(el) el.value='';
+  });
+  ['pickupPayment','deliveryPayment','chopstickCount','soyCount','gemberCount','wasabiCount'].forEach(id=>{
+    const el=document.getElementById(id);
+    if(el) el.value=el.options[0].value;
+  });
+  document.getElementById('remark').value='';
+  document.querySelectorAll('.product-list select').forEach(sel=>{sel.value=0;});
+  for(const k in cart) delete cart[k];
+  updateCart();
+}
 function submitOrder() {
   const name = document.getElementById('custName').value.trim();
   const phone = document.getElementById('custPhone').value.trim();
@@ -590,17 +607,25 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
+  const orderType = delivery ? 'bezorgen' : 'afhalen';
   const payload = {
-    message: orderText,
-    remark: remark,
+    orderType: orderType,
+    name: name,
+    phone: phone,
+    email: '',
+    customerEmail: '',
+    pickup_time: !delivery ? document.getElementById('pickupTime').value : '',
+    delivery_time: delivery ? document.getElementById('deliveryTime').value : '',
     paymentMethod: delivery
       ? document.getElementById('deliveryPayment').value
       : document.getElementById('pickupPayment').value,
-    orderType: delivery ? 'delivery' : 'pickup',
-    name: name,
+    postcode: delivery ? document.getElementById('postcode').value.trim() : '',
+    house_number: delivery ? document.getElementById('houseNumber').value.trim() : '',
+    street: delivery ? document.getElementById('street').value.trim() : '',
+    city: delivery ? document.getElementById('city').value.trim() : '',
     items: itemsToSend,
-    pickupTime: !delivery ? document.getElementById('pickupTime').value : '',
-    deliveryTime: delivery ? document.getElementById('deliveryTime').value : ''
+    message: orderText,
+    remark: remark
   };
 
 
@@ -617,8 +642,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
         window.location.href = res.paymentLink;
       } else if (res.success || res.status === 'ok') {
         alert('Bestelling succesvol verzonden!');
-        for(const k in cart) delete cart[k];
-        updateCart();
+        clearForm();
         fetchOrders();
       } else {
         alert('Er is een fout opgetreden bij het verzenden van uw bestelling. Probeer het opnieuw.');
@@ -634,6 +658,11 @@ if (remark) orderText += `, Opmerking: ${remark}`;
   const socket = io('https://flask-order-api.onrender.com', { transports: ['websocket'] });
 
   let pollTimer;
+  const baseTitle = document.title;
+  let newOrderCount = 0;
+  function updateTabTitle(){
+    document.title = newOrderCount ? `${baseTitle} (${newOrderCount})` : baseTitle;
+  }
 
   // 音效播放
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -684,6 +713,8 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     beep();
     alert('Nieuwe bestelling ontvangen!');
     addRow(order);
+    newOrderCount++;
+    updateTabTitle();
   });
 
   // 断线后启用轮询
@@ -728,6 +759,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
   }
 
   window.addEventListener('beforeunload', () => socket.disconnect());
+  window.addEventListener('focus', () => { newOrderCount = 0; updateTabTitle(); });
 </script>
 
 


### PR DESCRIPTION
## Summary
- use the same payload structure for POS orders as index.html
- clear POS form and cart after sending an order
- show count of new orders in the browser tab title

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb1ee557c8333b6ba48de2d73bf2d