### PR TITLE
Add maps link and remark column

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,6 +103,8 @@ class Order(db.Model):
     house_number = db.Column(db.String(10))
     street = db.Column(db.String(100))
     city = db.Column(db.String(100))
+    remark = db.Column(db.Text)
+    maps_link = db.Column(db.String(255))
     items = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -138,6 +140,8 @@ def pos():
             house_number=data.get("house_number"),
             street=data.get("street"),
             city=data.get("city"),
+            remark=data.get("remark") or data.get("opmerking"),
+            maps_link=data.get("maps_link"),
             items=json.dumps(data.get("items", {})),
         )
         db.session.add(order)
@@ -160,6 +164,8 @@ def pos():
                 "house_number": order.house_number,
                 "street": order.street,
                 "city": order.city,
+                "remark": order.remark,
+                "maps_link": order.maps_link,
                 "created_date": to_nl(order.created_at).strftime("%Y-%m-%d"),
                 "created_at": to_nl(order.created_at).strftime("%H:%M"),
                 "items": json.loads(order.items or "{}"),
@@ -213,6 +219,8 @@ def api_orders():
             house_number=data.get("house_number"),
             street=data.get("street"),
             city=data.get("city"),
+            remark=data.get("remark") or data.get("opmerking"),
+            maps_link=data.get("maps_link"),
             items=json.dumps(data.get("items", {})),
         )
 
@@ -236,6 +244,8 @@ def api_orders():
                 "house_number": order.house_number,
                 "street": order.street,
                 "city": order.city,
+                "remark": order.remark,
+                "maps_link": order.maps_link,
                 "created_date": to_nl(order.created_at).strftime("%Y-%m-%d"),
                 "created_at": to_nl(order.created_at).strftime("%H:%M"),
                 "items": json.loads(order.items or "{}"),
@@ -386,6 +396,8 @@ def pos_orders_today():
             "house_number": o.house_number,
             "street": o.street,
             "city": o.city,
+            "remark": o.remark,
+            "maps_link": o.maps_link,
             "created_date": to_nl(o.created_at).strftime("%Y-%m-%d"),
             "created_at": to_nl(o.created_at).strftime("%H:%M"),
             "items": o.items_dict,

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -9,6 +9,7 @@
         <th>Telefoon</th>
         <th>Email</th>
         <th>Items</th>
+        <th>Opmerking</th>
         <th>Totaal (&euro;)</th>
         <th>Adres</th>
         <th>Tijdslot</th>
@@ -32,10 +33,14 @@
           {% endfor %}
           </ul>
         </td>
+        <td>{{ order.remark or '-' }}</td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
           {% if is_delivery %}
             {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}
+            {% if order.maps_link %}
+              <a href="{{ order.maps_link }}" target="_blank">📍Maps</a>
+            {% endif %}
           {% else %}-{% endif %}
         </td>
         <td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -688,6 +688,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     const total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+    const remark = order.remark || order.opmerking || '';
     const pickup = order.pickupTime;
     const delivery = order.deliveryTime;
 
@@ -699,8 +700,9 @@ if (remark) orderText += `, Opmerking: ${remark}`;
       <td>${order.phone || ''}</td>
       <td>${order.email || '-'}</td>
       <td><ul>${items}</ul></td>
+      <td>${remark || '-'}</td>
       <td>${total.toFixed(2)}</td>
-      <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}` : '-'}</td>
+      <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
       <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
       <td>${order.payment_method || ''}</td>`;
       

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -29,6 +29,7 @@
         <th>Telefoon</th>
         <th>Email</th>
         <th>Items</th>
+        <th>Opmerking</th>
         <th>Totaal (&euro;)</th>
         <th>Adres</th>
         <th>Tijdslot</th>
@@ -52,10 +53,14 @@
           {% endfor %}
           </ul>
         </td>
+        <td>{{ order.remark or '-' }}</td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
           {% if is_delivery %}
             {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}
+            {% if order.maps_link %}
+              <a href="{{ order.maps_link }}" target="_blank">📍Maps</a>
+            {% endif %}
           {% else %}-{% endif %}
         </td>
         <td>
@@ -85,6 +90,7 @@
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
       const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+      const remark = order.remark || order.opmerking || '';
       const pickup = order.pickup_time;
       const delivery = order.delivery_time;
       tr.innerHTML = `
@@ -95,8 +101,9 @@
         <td>${order.phone || ''}</td>
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
+        <td>${remark || '-'}</td>
         <td>${total.toFixed(2)}</td>
-        <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}` : '-'}</td>
+        <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>`;
       tbody.prepend(tr);


### PR DESCRIPTION
## Summary
- support new remark and maps_link fields in the Order model
- display remarks and Google Maps link in POS order tables

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb7964c988333a8b05d31f3026b04