### PR TITLE
Fix create_db imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import inspect, text
 from flask_login import (
     LoginManager,
     UserMixin,
@@ -304,7 +305,20 @@ def api_send():
 @app.route('/create_db')
 def create_db():
     try:
+        # Ensure tables exist before checking columns
         db.create_all()
+
+        inspector = inspect(db.engine)
+        cols = set()
+        if inspector.has_table("orders"):
+            cols = {c["name"] for c in inspector.get_columns("orders")}
+
+        with db.engine.begin() as conn:
+            if "remark" not in cols:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN remark TEXT"))
+            if "maps_link" not in cols:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN maps_link VARCHAR(255)"))
+
         return "✅ Database tables created!"
     except Exception as e:
         return f"❌ Error: {e}"


### PR DESCRIPTION
## Summary
- import `inspect` and `text` from SQLAlchemy
- use these helpers in the `create_db` route

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684bd186c5b88333a551113ea25b5660