### PR TITLE
Add opmerking field support

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1824,6 +1824,7 @@ function checkout() {
         ? document.getElementById('deliveryArea').value.trim()
         : '',
       items: itemsToSend,
+      opmerking: remark,
       message, email // ✅ 仍然推送到 Telegram
     })
   })

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -33,7 +33,7 @@
           {% endfor %}
           </ul>
         </td>
-        <td>{{ order.remark or '-' }}</td>
+        <td>{{ order.opmerking or '-' }}</td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
           {% if is_delivery %}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -625,7 +625,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     city: delivery ? document.getElementById('city').value.trim() : '',
     items: itemsToSend,
     message: orderText,
-    remark: remark
+    opmerking: remark
   };
 
 
@@ -688,7 +688,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     const total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
-    const remark = order.remark || order.opmerking || '';
+    const remark = order.opmerking || order.remark || '';
     const pickup = order.pickupTime;
     const delivery = order.deliveryTime;
 

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -53,7 +53,7 @@
           {% endfor %}
           </ul>
         </td>
-        <td>{{ order.remark or '-' }}</td>
+        <td>{{ order.opmerking or '-' }}</td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
           {% if is_delivery %}
@@ -90,7 +90,7 @@
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
       const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
-      const remark = order.remark || order.opmerking || '';
+      const remark = order.opmerking || order.remark || '';
       const pickup = order.pickup_time;
       const delivery = order.delivery_time;
       tr.innerHTML = `


### PR DESCRIPTION
## Summary
- add `opmerking` column to `Order`
- include remark in JSON payloads and SocketIO events
- allow DB migration for new column
- send `opmerking` from checkout forms
- display customer remarks in order tables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c205df7cc8333ae617a226b97e395