### PR TITLE
Add opmerking field support

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask_login import (
     login_required,
 )
 from flask_socketio import SocketIO
+from sqlalchemy import text
 import eventlet
 eventlet.monkey_patch()
 from datetime import datetime, timezone
@@ -28,6 +29,14 @@ print(repr(os.getenv("DATABASE_URL")))
 db = SQLAlchemy(app)
 with app.app_context():
     db.create_all()
+    try:
+        inspector = db.inspect(db.engine)
+        cols = {c["name"] for c in inspector.get_columns("orders")}
+        if "opmerking" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN opmerking TEXT"))
+    except Exception as e:
+        print(f"DB init error: {e}")
 
 UTC = timezone.utc
 NL_TZ = ZoneInfo("Europe/Amsterdam")
@@ -103,6 +112,7 @@ class Order(db.Model):
     house_number = db.Column(db.String(10))
     street = db.Column(db.String(100))
     city = db.Column(db.String(100))
+    opmerking = db.Column(db.Text)
     items = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -138,6 +148,7 @@ def pos():
             house_number=data.get("house_number"),
             street=data.get("street"),
             city=data.get("city"),
+            opmerking=data.get("opmerking") or data.get("remark"),
             items=json.dumps(data.get("items", {})),
         )
         db.session.add(order)
@@ -160,6 +171,7 @@ def pos():
                 "house_number": order.house_number,
                 "street": order.street,
                 "city": order.city,
+                "opmerking": order.opmerking,
                 "created_date": to_nl(order.created_at).strftime("%Y-%m-%d"),
                 "created_at": to_nl(order.created_at).strftime("%H:%M"),
                 "items": json.loads(order.items or "{}"),
@@ -213,6 +225,7 @@ def api_orders():
             house_number=data.get("house_number"),
             street=data.get("street"),
             city=data.get("city"),
+            opmerking=data.get("opmerking") or data.get("remark"),
             items=json.dumps(data.get("items", {})),
         )
 
@@ -236,6 +249,7 @@ def api_orders():
                 "house_number": order.house_number,
                 "street": order.street,
                 "city": order.city,
+                "opmerking": order.opmerking,
                 "created_date": to_nl(order.created_at).strftime("%Y-%m-%d"),
                 "created_at": to_nl(order.created_at).strftime("%H:%M"),
                 "items": json.loads(order.items or "{}"),
@@ -294,6 +308,11 @@ def api_send():
 @app.route('/create_db')
 def create_db():
     try:
+        inspector = db.inspect(db.engine)
+        cols = {c["name"] for c in inspector.get_columns("orders")}
+        if "opmerking" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(db.text("ALTER TABLE orders ADD COLUMN opmerking TEXT"))
         db.create_all()
         return "✅ Database tables created!"
     except Exception as e:
@@ -386,6 +405,7 @@ def pos_orders_today():
             "house_number": o.house_number,
             "street": o.street,
             "city": o.city,
+            "opmerking": o.opmerking,
             "created_date": to_nl(o.created_at).strftime("%Y-%m-%d"),
             "created_at": to_nl(o.created_at).strftime("%H:%M"),
             "items": o.items_dict,

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -53,9 +53,10 @@
             td:nth-of-type(3):before { content: "Customer"; }
             td:nth-of-type(4):before { content: "Phone"; }
             td:nth-of-type(5):before { content: "Address"; }
-            td:nth-of-type(6):before { content: "Payment"; }
-            td:nth-of-type(7):before { content: "Created"; }
-            td:nth-of-type(8):before { content: "Total"; }
+            td:nth-of-type(6):before { content: "Remark"; }
+            td:nth-of-type(7):before { content: "Payment"; }
+            td:nth-of-type(8):before { content: "Created"; }
+            td:nth-of-type(9):before { content: "Total"; }
         }
     </style>
 </head>
@@ -69,6 +70,7 @@
                 <th>Klant</th>
                 <th>Telefoon</th>
                 <th>Adres</th>
+                <th>Opmerking</th>
                 <th>Betaalmethode</th>
                 <th>Aangemaakt</th>
                 <th>Totaal (€)</th>
@@ -87,6 +89,7 @@
                         {{ info.order.street }} {{ info.order.house_number }} {{ info.order.postcode }} {{ info.order.city }}
                     {% else %}-{% endif %}
                 </td>
+                <td>{{ info.order.opmerking or '-' }}</td>
                 <td>{{ info.order.payment_method }}</td>
                 <td>{{ info.order.created_at_local.strftime('%Y-%m-%d %H:%M') }}</td>
                 <td>{{ '%.2f' % info.total }}</td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1824,6 +1824,7 @@ function checkout() {
         ? document.getElementById('deliveryArea').value.trim()
         : '',
       items: itemsToSend,
+      opmerking: remark,
       message, email // ✅ 仍然推送到 Telegram
     })
   })

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -33,7 +33,7 @@
           {% endfor %}
           </ul>
         </td>
-        <td>{{ order.remark or '-' }}</td>
+        <td>{{ order.opmerking or '-' }}</td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
           {% if is_delivery %}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -625,7 +625,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     city: delivery ? document.getElementById('city').value.trim() : '',
     items: itemsToSend,
     message: orderText,
-    remark: remark
+    opmerking: remark
   };
 
 
@@ -688,7 +688,7 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     const total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
-    const remark = order.remark || order.opmerking || '';
+    const remark = order.opmerking || order.remark || '';
     const pickup = order.pickupTime;
     const delivery = order.deliveryTime;
 

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -53,7 +53,7 @@
           {% endfor %}
           </ul>
         </td>
-        <td>{{ order.remark or '-' }}</td>
+        <td>{{ order.opmerking or '-' }}</td>
         <td>{{ '%.2f' % order.total }}</td>
         <td>
           {% if is_delivery %}
@@ -90,7 +90,7 @@
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
       const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
-      const remark = order.remark || order.opmerking || '';
+      const remark = order.opmerking || order.remark || '';
       const pickup = order.pickup_time;
       const delivery = order.delivery_time;
       tr.innerHTML = `


### PR DESCRIPTION
## Summary
- add `opmerking` column to `Order`
- include remark in JSON payloads and SocketIO events
- allow DB migration for new column
- send `opmerking` from checkout forms
- display customer remarks in order tables
- show opmerking column on admin orders page
- ensure the opmerking column exists at startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c205df7cc8333ae617a226b97e395