### PR TITLE
Enhance POS page style for mobile

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -15,6 +15,9 @@
     padding-top: 60px;
     text-align: center;
   }
+  @media (max-width: 480px) {
+    body { padding: 10px; }
+  }
 
   :root {
     --primary-color: #f2e9d8;
@@ -35,10 +38,11 @@
     width: 100vw;
     padding: 0;
     margin: 0;
-    background-color: var(--off-white);
+    background: rgba(255,255,255,0.65);
+    backdrop-filter: blur(12px);
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid rgba(255,255,255,0.3);
     z-index: 999;
   }
   .navbar {
@@ -65,19 +69,25 @@
     position: relative;
     z-index: 2;
   }
+  @media (max-width: 480px) {
+    .navbar a { padding: 10px 14px; font-size: 0.9rem; }
+    .today-btn { padding: 8px 14px; }
+  }
   .navbar a.active { color: white; }
   .today-btn {
     flex: 0 0 auto;
     padding: 10px 16px;
     margin-left: 10px;
-    background: #e5e5ea;
-    border: none;
+    background: rgba(255,255,255,0.6);
+    border: 1px solid rgba(255,255,255,0.4);
     border-radius: 20px;
     color: #333;
     cursor: pointer;
+    backdrop-filter: blur(8px);
     transition: background 0.3s ease;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
   }
-  .today-btn:hover { background:#dcdce0; }
+  .today-btn:hover { background: rgba(255,255,255,0.8); }
   .indicator {
     position: absolute;
     height: 32px;
@@ -150,11 +160,16 @@
   .center-area { flex:1; }
   .checkout-panel {
     width:300px;
-    background: var(--off-white);
+    background: rgba(255,255,255,0.6);
+    backdrop-filter: blur(8px);
     padding:20px;
     border-radius:16px;
     position: sticky;
     top: 70px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  }
+  @media (max-width: 600px) {
+    .checkout-panel { width:100%; }
   }
   .orders-slide {
     position: fixed;
@@ -163,21 +178,28 @@
     height: calc(100vh - 60px);
     width: 90%;
     max-width: 1200px;
-    background: var(--off-white);
+    background: rgba(255,255,255,0.7);
+    backdrop-filter: blur(8px);
     overflow: auto;
     transition: left 0.3s;
     z-index: 1000;
     padding: 10px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
   }
   .orders-slide.visible { left: 5%; }
   .orders-panel table { width:100%; border-collapse: collapse; }
+  @media (max-width: 768px) {
+    .orders-panel table { display:block; overflow-x:auto; white-space:nowrap; }
+  }
   .orders-panel th, .orders-panel td { border:1px solid #ddd; padding:8px; text-align:left; }
   .orders-panel th { background:#f2f2f2; }
   .orders-panel ul { margin:0; padding-left:20px; }
   input, select, textarea {
-    border:1px solid #ccc;
+    border:1px solid rgba(255,255,255,0.4);
     border-radius:8px;
     padding:6px 10px;
+    background: rgba(255,255,255,0.6);
+    backdrop-filter: blur(6px);
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
     transition:border-color 0.2s, box-shadow 0.2s;
   }
@@ -304,9 +326,9 @@
       <div class="delivery-options">
         <h2>Klantgegevens</h2>
         <label for="custName">Naam*</label>
-        <input id="custName" type="text" required />
+        <input id="custName" type="text" placeholder="Naam" required />
         <label for="custPhone">Telefoonnummer*</label>
-        <input id="custPhone" type="tel" required />
+        <input id="custPhone" type="tel" placeholder="Telefoonnummer" required />
         <div style="margin-top:10px;">
           <input type="radio" id="typePickup" name="orderType" value="pickup" checked />
           <label for="typePickup">Pickup</label>
@@ -325,13 +347,13 @@
         </div>
         <div id="deliveryFields" class="hidden" style="margin-top:10px;">
           <label for="postcode">Postcode*</label>
-          <input id="postcode" type="text" />
+          <input id="postcode" type="text" placeholder="1234AB" />
           <label for="houseNumber">Huisnummer*</label>
-          <input id="houseNumber" type="text" />
+          <input id="houseNumber" type="text" placeholder="1" />
           <label for="street">Straat*</label>
-          <input id="street" type="text" />
+          <input id="street" type="text" placeholder="Straat" />
           <label for="city">Plaats*</label>
-          <input id="city" type="text" />
+          <input id="city" type="text" placeholder="Plaats" />
           <label for="deliveryTime">Bezorgtijd (optioneel)</label>
           <input id="deliveryTime" type="time" />
           <label for="deliveryPayment">Betaalmethode*</label>


### PR DESCRIPTION
## Summary
- refine POS page with glassy navbar and buttons
- tweak inputs for softer glassmorphism style
- add placeholders for customer and address fields
- improve responsive layout and table scrolling on small screens

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_684d03696ab88333a014dcf6bba3bb9d