### PR TITLE
Add dynamic delivery fee and discount options

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -806,7 +806,14 @@ input:focus, select:focus, textarea:focus {
   <ul id="cart"></ul>
   <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
   <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
-  <div class="total">Totaal: €<span id="total">0.00</span></div>
+  <div class="totals">
+    <div>Subtotaal: €<span id="subtotal">0.00</span></div>
+    <div>Verpakkingskosten: €<span id="packaging">0.00</span></div>
+    <div id="deliveryRow" style="display:none;">Bezorgkosten: €<span id="deliveryFee">2.50</span></div>
+    <div>BTW (9%): €<span id="vat">0.00</span></div>
+    <div class="total">Totaal: €<span id="total">0.00</span></div>
+    <p style="font-size:0.9rem;">Alle prijzen zijn inclusief BTW</p>
+  </div>
   <button class="checkout-btn" onclick="checkout()">Afrekenen &amp; Betalen</button>
 
 </div>
@@ -1432,6 +1439,10 @@ const extras = {
   gemberCount: { label: 'Gember', price: 0 }
 };
 
+const PACKAGING_RATE = 0.25; // verpakkingskosten per item
+const DELIVERY_FEE = 2.5;
+const VAT_RATE = 0.09;
+
 
 function changeBubbleQty(delta) {
   const qtySel = document.getElementById('bubbleTeaQty');
@@ -1597,7 +1608,8 @@ function setQty(name, price, qty) {
 function updateCart() {
   const list = document.getElementById('cart');
   list.innerHTML = '';
-  let total = 0;
+  let subtotal = 0;
+  let itemQty = 0;
 
   Object.entries(cart).forEach(([name, item]) => {
     const li = document.createElement('li');
@@ -1620,11 +1632,14 @@ function updateCart() {
       }
       setQty(name, item.price, val);
     });
-    const subtotal = item.qty * item.price;
-    li.textContent = `${name} = €${subtotal.toFixed(2)} `;
+    const lineTotal = item.qty * item.price;
+    li.textContent = `${name} = €${lineTotal.toFixed(2)} `;
     li.appendChild(sel);
     list.appendChild(li);
-    if (item.qty > 0) total += subtotal;
+    if (item.qty > 0) {
+      subtotal += lineTotal;
+      itemQty += item.qty;
+    }
   });
 
   const title = document.createElement('li');
@@ -1644,9 +1659,21 @@ function updateCart() {
     list.appendChild(li);
   });
 
+  const packaging = itemQty * PACKAGING_RATE;
+  const deliverySelected = document.getElementById('bezorgen').checked;
+  const delivery = deliverySelected ? DELIVERY_FEE : 0;
+  document.getElementById('deliveryRow').style.display = deliverySelected ? 'block' : 'none';
+  const preVatBase = subtotal + packaging;
+  const vat = preVatBase * VAT_RATE;
+  const total = preVatBase + vat + delivery;
+
+  document.getElementById('subtotal').textContent = subtotal.toFixed(2);
+  document.getElementById('packaging').textContent = packaging.toFixed(2);
+  document.getElementById('deliveryFee').textContent = delivery.toFixed(2);
+  document.getElementById('vat').textContent = vat.toFixed(2);
   document.getElementById('total').textContent = total.toFixed(2);
 
-  const totalQty = Object.values(cart).reduce((s, it) => s + it.qty, 0) +
+  const totalQty = itemQty +
     Object.keys(extras).reduce((s, id) => s + parseInt(document.getElementById(id).value || 0), 0);
 
   const badge = document.getElementById('cart-count');
@@ -1916,10 +1943,11 @@ function checkout() {
       bezorgenFields.classList.add('hidden');
     } else {
       infoBox.textContent = 'Wij bezorgen in de volgende postcodegebieden:\n2341, 2342, 2343, 2333, 2334, 2231, 2232, 2361, 2235';
-      
+
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
     }
+    updateCart();
   }
 
   // 初始化执行一次

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -367,7 +367,23 @@
       </div>
       <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
       <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
-      <div class="total">Totaal: €<span id="total">0.00</span></div>
+      <div class="totals">
+        <div>Subtotaal: €<span id="subtotal">0.00</span></div>
+        <div>Verpakkingskosten: €<span id="packaging">0.00</span></div>
+        <div id="deliveryRow" style="display:none;">Bezorgkosten: €<span id="deliveryFee">2.50</span></div>
+        <div>
+          Korting: <input id="discount" type="text" value="0" list="discountOptions" style="max-width:80px;" />
+          <datalist id="discountOptions">
+            <option value="5%"></option>
+            <option value="10%"></option>
+            <option value="15%"></option>
+            <option value="20%"></option>
+          </datalist>
+        </div>
+        <div>BTW (9%): €<span id="vat">0.00</span></div>
+        <div class="total">Totaal: €<span id="total">0.00</span></div>
+        <p style="font-size:0.9rem;">Alle prijzen zijn inclusief BTW</p>
+      </div>
     </div>
     <div class="product-list">
       {% include 'menu.html' %}
@@ -436,6 +452,22 @@ const extras = {
   wasabiCount: { label: 'Wasabi', price: 0 }
 };
 
+const PACKAGING_RATE = 0.25; // verpakkingskosten per item
+const DELIVERY_FEE = 2.5;
+const VAT_RATE = 0.09;
+
+function parseDiscount(val, base){
+  if(!val) return 0;
+  val = val.toString().trim();
+  if(val.endsWith('%')){
+    const p = parseFloat(val.slice(0,-1));
+    if(isNaN(p)) return 0;
+    return base * p / 100;
+  }
+  const num = parseFloat(val);
+  return isNaN(num) ? 0 : num;
+}
+
 function changeBubbleQty(delta){
   const sel=document.getElementById('bubbleTeaQty');
   let val=parseInt(sel.value||0);
@@ -475,16 +507,30 @@ function setQty(name,price,qty){ if(qty===0){ delete cart[name]; } else { cart[n
 function updateCart(){
   const list=document.getElementById('cart');
   list.innerHTML='';
-  let total=0;
+  let subtotal=0;
+  let itemQty=0;
   Object.entries(cart).forEach(([name,item])=>{
     const li=document.createElement('li');
     const sel=createSelect(item.qty,val=>{ document.querySelector(`[data-name="${name}"] select`).value=val; setQty(name,item.price,val); });
-    const subtotal=item.qty*item.price;
-    li.textContent=`${name} = €${subtotal.toFixed(2)} `;
+    const lineTotal=item.qty*item.price;
+    li.textContent=`${name} = €${lineTotal.toFixed(2)} `;
     li.appendChild(sel);
     list.appendChild(li);
-    if(item.qty>0) total+=subtotal;
+    if(item.qty>0){ subtotal+=lineTotal; itemQty+=item.qty; }
   });
+  const packaging=itemQty*PACKAGING_RATE;
+  const deliverySelected=document.getElementById('typeDelivery').checked;
+  const delivery=deliverySelected?DELIVERY_FEE:0;
+  document.getElementById('deliveryRow').style.display=deliverySelected?'block':'none';
+  const discountVal=parseDiscount(document.getElementById('discount').value, subtotal);
+  const base=Math.max(0, subtotal-discountVal)+packaging;
+  const vat=base*VAT_RATE;
+  const total=base+vat+delivery;
+
+  document.getElementById('subtotal').textContent=subtotal.toFixed(2);
+  document.getElementById('packaging').textContent=packaging.toFixed(2);
+  document.getElementById('deliveryFee').textContent=delivery.toFixed(2);
+  document.getElementById('vat').textContent=vat.toFixed(2);
   document.getElementById('total').textContent=total.toFixed(2);
 }
 
@@ -540,6 +586,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('street').addEventListener('blur',updateQRCode);
   document.getElementById('city').addEventListener('blur',updateQRCode);
   document.getElementById('submitOrder').addEventListener('click',submitOrder);
+  document.getElementById('discount').addEventListener('input',updateCart);
   updateCart();
   toggleAddress();
   // 🔊 解锁 AudioContext
@@ -575,6 +622,7 @@ function toggleAddress(){
   } else {
     updateQRCode();
   }
+  updateCart();
 }
 async function fetchAddress(){
   const pc=document.getElementById('postcode').value.trim();
@@ -624,6 +672,7 @@ function clearForm(){
     if(el) el.value=el.options[0].value;
   });
   document.getElementById('remark').value='';
+  document.getElementById('discount').value='0';
   document.querySelectorAll('.product-list select').forEach(sel=>{sel.value=0;});
   for(const k in cart) delete cart[k];
   updateCart();


### PR DESCRIPTION
## Summary
- hide delivery fee unless delivery selected
- exclude delivery fee from VAT calculation
- add % discount suggestions in POS screen

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684d312d4e748333a9ffa32a58279ea0