### PR TITLE
Implement POS checkout summary

### DIFF
--- a/templates/menu.html
+++ b/templates/menu.html
@@ -5,7 +5,7 @@
 </h2>
 
 
-    <div class="menu-row menu-item" data-name="Bubble Tea" data-price="5">
+    <div class="menu-row menu-item" data-name="Bubble Tea" data-price="5" data-packaging="0.2">
       <div class="menu-img">
        <img src="{{ url_for('static', filename='images/bubble-tea-main.jpg') }}" alt="Bubble Tea">
 
@@ -68,7 +68,7 @@
 
 
     <!-- Chicken Bento -->
-    <div class="menu-row menu-item" data-name="Chicken Bento" data-price="12">
+    <div class="menu-row menu-item" data-name="Chicken Bento" data-price="12" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/chicken-bento.jpg') }}" alt="Chicken Bento">
       </div>
@@ -89,7 +89,7 @@
 
     <!-- Meatlover Bento -->
 <!-- Meatlover Bento -->
-<div class="menu-row menu-item" data-name="Meatlover Bento" data-price="14">
+<div class="menu-row menu-item" data-name="Meatlover Bento" data-price="14" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/Meatlove bento.png') }}" alt="Meatlover Bento">
   </div>
@@ -109,7 +109,7 @@
 
 
     <!-- Zalm Lover Bento -->
-    <div class="menu-row menu-item" data-name="Zalm Lover Bento" data-price="13">
+    <div class="menu-row menu-item" data-name="Zalm Lover Bento" data-price="13" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}" alt="Zalm Lover Bento">
   </div>
@@ -129,7 +129,7 @@
 
 
     <!-- Ebi Lover Bento -->
-    <div class="menu-row menu-item" data-name="Ebi Lover Bento" data-price="13">
+    <div class="menu-row menu-item" data-name="Ebi Lover Bento" data-price="13" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}" alt="Ebi Lover Bento">
   </div>
@@ -149,7 +149,7 @@
 
 
     <!-- Surf & Turf Bento -->
-   <div class="menu-row menu-item" data-name="Surf & Turf Bento" data-price="15">
+   <div class="menu-row menu-item" data-name="Surf & Turf Bento" data-price="15" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}" alt="Surf & Turf Bento">
   </div>
@@ -169,7 +169,7 @@
 
 
     <!-- Dimsum Bento -->
-   <div class="menu-row menu-item" data-name="Dimsum Bento" data-price="11">
+   <div class="menu-row menu-item" data-name="Dimsum Bento" data-price="11" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/dimsum-bento.png') }}" alt="Dimsum Bento">
   </div>
@@ -189,7 +189,7 @@
 
 
     <!-- Lamskotelet Bento -->
-    <div class="menu-row menu-item" data-name="Lamskotelet Bento" data-price="14">
+    <div class="menu-row menu-item" data-name="Lamskotelet Bento" data-price="14" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}" alt="Lamskotelet Bento">
   </div>
@@ -209,7 +209,7 @@
 
 
     <!-- Veggie Bento -->
-   <div class="menu-row menu-item" data-name="Veggie Bento" data-price="10">
+   <div class="menu-row menu-item" data-name="Veggie Bento" data-price="10" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/veggie-bento.png') }}" alt="Veggie Bento">
   </div>
@@ -228,7 +228,7 @@
 </div>
 
 
-  <div class="menu-row menu-item" data-name="Sushi Bento" data-price="14">
+  <div class="menu-row menu-item" data-name="Sushi Bento" data-price="14" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/sushi-bento.jpg') }}" alt="Sushi Bento">
   </div>
@@ -248,7 +248,7 @@
 
     <!-- Xbento - Stel je eigen bento samen -->
 <!-- Xbento - Stel je eigen bento samen -->
-<div class="menu-row menu-item" data-name="Xbento" data-price="14">
+<div class="menu-row menu-item" data-name="Xbento" data-price="14" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/xbento.png') }}" alt="Xbento">
   </div>
@@ -305,7 +305,7 @@
   <h2>Ramen</h2>
   <div class="menu-section">
     <!-- 示例商品，可替换或添加更多 -->
-    <div class="menu-row menu-item" data-name="Tonkotsu Ramen" data-price="13">
+    <div class="menu-row menu-item" data-name="Tonkotsu Ramen" data-price="13" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}" alt="Tonkotsu Ramen">
       </div>
@@ -328,7 +328,7 @@
   <h2>Pokebowl</h2>
   <div class="menu-section">
     <!-- 示例商品，可替换或添加更多 -->
-    <div class="menu-row menu-item" data-name="Zalm Pokebowl" data-price="12">
+    <div class="menu-row menu-item" data-name="Zalm Pokebowl" data-price="12" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/zalm-pokebowl.png') }}" alt="Zalm Pokebowl">
       </div>
@@ -355,7 +355,7 @@
 </h2>
 
 
-<div class="menu-row menu-item" data-name="Green Dragon Roll" data-price="13.5">
+<div class="menu-row menu-item" data-name="Green Dragon Roll" data-price="13.5" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/green-dragon-roll.png') }}" alt="Green Dragon Roll">
   </div>
@@ -373,7 +373,7 @@
   </div>
 </div>
 
-<div class="menu-row menu-item" data-name="Angry Dragon Roll" data-price="13.5">
+<div class="menu-row menu-item" data-name="Angry Dragon Roll" data-price="13.5" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/angry-dragon.png') }}" alt="Angry Dragon Roll">
   </div>
@@ -402,7 +402,7 @@
     </h2>
 
     <!-- Zalm -->
-    <div class="menu-row menu-item" data-name="Zalm crispy rice sandwich" data-price="7">
+    <div class="menu-row menu-item" data-name="Zalm crispy rice sandwich" data-price="7" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/zalm.png') }}" alt="Zalm crispy rice sandwich">
       </div>
@@ -424,7 +424,7 @@
 
     <!-- Ebi -->
     <!-- Ebi Crispy Rice Sandwich -->
-<div class="menu-row menu-item" data-name="Ebi crispy rice sandwich" data-price="7">
+<div class="menu-row menu-item" data-name="Ebi crispy rice sandwich" data-price="7" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/Ebi.png') }}" alt="Ebi Crispy Rice Sandwich">
   </div>
@@ -444,7 +444,7 @@
 
 
   <!-- Beef Crispy Rice Sandwich -->
-<div class="menu-row menu-item" data-name="Beef crispy rice sandwich" data-price="7.5">
+<div class="menu-row menu-item" data-name="Beef crispy rice sandwich" data-price="7.5" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/beef-crispy.png') }}" alt="Beef Crispy Rice Sandwich">
   </div>
@@ -461,7 +461,7 @@
   </div>
 </div>
 <!-- California Crispy Rice Sandwich -->
-<div class="menu-row menu-item" data-name="California crispy rice sandwich" data-price="7.5">
+<div class="menu-row menu-item" data-name="California crispy rice sandwich" data-price="7.5" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/california-crispy.png') }}" alt="California Crispy Rice Sandwich">
   </div>
@@ -479,7 +479,7 @@
 </div>
 
 <!-- Chicken Crispy Rice Sandwich -->
-<div class="menu-row menu-item" data-name="Chicken crispy rice sandwich" data-price="7">
+<div class="menu-row menu-item" data-name="Chicken crispy rice sandwich" data-price="7" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/chicken-crispy.png') }}" alt="Chicken Crispy Rice Sandwich">
   </div>
@@ -504,7 +504,7 @@
 </h2>
 
 
-    <div class="menu-row menu-item" data-name="Karaage" data-price="6.5">
+    <div class="menu-row menu-item" data-name="Karaage" data-price="6.5" data-packaging="0.2">
       <img src="{{ url_for('static', filename='images/karaage.png') }}" alt="Karaage" class="menu-img" loading="lazy" />
       <div class="menu-content">
         <h3>Karaage (Japanse gefrituurde kip)</h3>
@@ -523,7 +523,7 @@
   <div class="menu-group">
 
     <!-- Mango -->
-    <div class="menu-row menu-item" data-name="Mochi Mango" data-price="4">
+    <div class="menu-row menu-item" data-name="Mochi Mango" data-price="4" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/mochi-mango.png') }}" alt="Mochi Mango" loading="lazy" />
       </div>
@@ -540,7 +540,7 @@
     </div>
 
     <!-- Aardbei -->
-    <div class="menu-row menu-item" data-name="Mochi Aardbei" data-price="4">
+    <div class="menu-row menu-item" data-name="Mochi Aardbei" data-price="4" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/mochi-aardbei.png') }}" alt="Mochi Aardbei" loading="lazy" />
       </div>
@@ -557,7 +557,7 @@
     </div>
 
     <!-- Matcha -->
-    <div class="menu-row menu-item" data-name="Mochi Matcha" data-price="4">
+    <div class="menu-row menu-item" data-name="Mochi Matcha" data-price="4" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/mochi-matcha.png') }}" alt="Mochi Matcha" loading="lazy" />
       </div>
@@ -574,7 +574,7 @@
     </div>
 
     <!-- Pistachio -->
-    <div class="menu-row menu-item" data-name="Mochi Pistachio" data-price="4">
+    <div class="menu-row menu-item" data-name="Mochi Pistachio" data-price="4" data-packaging="0.2">
       <div class="menu-img">
         <img src="{{ url_for('static', filename='images/mochi-pistachio.png') }}" alt="Mochi Pistachio" loading="lazy" />
       </div>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -298,6 +298,13 @@
     transition: background 0.3s ease;
   }
   .cart-area button:hover { background:#a3c8ff; }
+  .checkout-summary div {
+    display:flex;
+    justify-content:space-between;
+    margin-top:4px;
+  }
+  .discount-row { align-items:center; gap:4px; }
+  .total-row { font-weight:bold; margin-top:6px; display:flex; justify-content:space-between; }
   .hidden { display:none; }
 @media (min-width: 768px) {
   .pos-layout {
@@ -436,7 +443,24 @@
       </div>
       <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
       <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
-      <div class="total">Totaal: €<span id="total">0.00</span></div>
+      <div class="checkout-summary">
+        <div><span>Subtotaal:</span> <span id="summarySubtotal">€0,00</span></div>
+        <div><span>Verpakkingskosten:</span> <span id="summaryPackaging">€0,00</span></div>
+        <div id="summaryDeliveryRow" class="hidden"><span>Bezorgkosten:</span> <span id="summaryDelivery">€0,00</span></div>
+        <div class="discount-row">
+          <label for="discountType">Korting:</label>
+          <select id="discountType" style="margin-left:4px;">
+            <option value="none">Geen</option>
+            <option value="amount">Bedrag (€)</option>
+            <option value="percent">Percentage (%)</option>
+          </select>
+          <input id="discountValue" type="number" value="0" min="0" style="width:60px;margin-left:4px;" />
+          <span id="summaryDiscount" style="margin-left:4px;">€0,00</span>
+        </div>
+        <div><span>BTW (9%):</span> <span id="summaryBtw">€0,00</span></div>
+        <div class="total-row"><strong>Totaal:</strong> <span id="total">€0,00</span></div>
+        <p style="font-size:0.9rem;margin-top:4px;">Alle prijzen zijn inclusief BTW</p>
+      </div>
     </div>
     <div class="checkout-panel">
       <section id="customer-info">
@@ -513,7 +537,8 @@ function changeBubbleQty(delta){
   const topping=document.getElementById('bubbleTopping').value;
   if(!type||!flavor||!topping) return;
   const name=`Bubble Tea (${type}, ${flavor}, ${topping})`;
-  setQty(name,5,val);
+  const pack=parseFloat(document.querySelector('[data-name="Bubble Tea"]').dataset.packaging||0);
+  setQty(name,5,val,pack);
 }
 
 function changeXbentoQty(delta){
@@ -528,7 +553,8 @@ function changeXbentoQty(delta){
   let price=14;
   if(rice.includes('Fried rice')) price+=5;
   const name=`Xbento (${main}, ${side}, ${rice})`;
-  setQty(name,price,val);
+  const pack=parseFloat(document.querySelector('[data-name="Xbento"]').dataset.packaging||0);
+  setQty(name,price,val,pack);
 }
 function populateSelect(sel){
   for(let i=0;i<=20;i++){ const opt=document.createElement('option'); opt.value=i; opt.textContent=i; sel.appendChild(opt); }
@@ -538,23 +564,50 @@ function createSelect(current,onChange){
   for(let i=0;i<=20;i++){ const opt=document.createElement('option'); opt.value=i; opt.textContent=i; if(i===current) opt.selected=true; sel.appendChild(opt); }
   sel.addEventListener('change',()=>onChange(parseInt(sel.value))); return sel;
 }
-function setQty(name,price,qty){ if(qty===0){ delete cart[name]; } else { cart[name]={price,qty}; } updateCart(); }
+function setQty(name,price,qty,packaging=0){
+  if(qty===0){
+    delete cart[name];
+  } else {
+    cart[name]={price,qty,packaging};
+  }
+  updateCart();
+}
 function updateCart(){
   const list=document.getElementById('cart');
   list.innerHTML='';
-  let total=0;
+  let subtotal=0;
+  let packagingTotal=0;
   let count=0;
   Object.entries(cart).forEach(([name,item])=>{
     const li=document.createElement('li');
-    const sel=createSelect(item.qty,val=>{ document.querySelector(`[data-name="${name}"] select`).value=val; setQty(name,item.price,val); });
-    const subtotal=item.qty*item.price;
-    li.textContent=`${name} = €${subtotal.toFixed(2)} `;
+    const sel=createSelect(item.qty,val=>{ document.querySelector(`[data-name="${name}"] select`).value=val; setQty(name,item.price,val,item.packaging); });
+    const rowTotal=item.qty*item.price;
+    li.textContent=`${name} = €${rowTotal.toFixed(2)} `;
     li.appendChild(sel);
     list.appendChild(li);
-    if(item.qty>0) total+=subtotal;
+    if(item.qty>0){
+      subtotal+=rowTotal;
+      packagingTotal+= (item.packaging||0)*item.qty;
+    }
     count+=item.qty;
   });
-  document.getElementById('total').textContent=total.toFixed(2);
+  const delivery=document.getElementById('typeDelivery').checked ? 2.5 : 0;
+  const discountType=document.getElementById('discountType').value;
+  let discountVal=parseFloat(document.getElementById('discountValue').value)||0;
+  let discount=0;
+  if(discountType==='amount'){ discount=Math.min(discountVal,subtotal); }
+  else if(discountType==='percent'){ discount=Math.min(discountVal,100)/100*subtotal; }
+  if(discount<0||isNaN(discount)) discount=0;
+  const btw=((subtotal-discount)+packagingTotal)*0.09;
+  const total=subtotal-discount+packagingTotal+delivery+btw;
+  const fmt=n=>`€${n.toFixed(2).replace('.',',')}`;
+  document.getElementById('summarySubtotal').textContent=fmt(subtotal);
+  document.getElementById('summaryPackaging').textContent=fmt(packagingTotal);
+  document.getElementById('summaryDelivery').textContent=fmt(delivery);
+  document.getElementById('summaryDeliveryRow').classList.toggle('hidden',!delivery);
+  document.getElementById('summaryDiscount').textContent=discount?`- ${fmt(discount)}`:'€0,00';
+  document.getElementById('summaryBtw').textContent=fmt(btw);
+  document.getElementById('total').textContent=fmt(total);
   const badge=document.getElementById('cartCount');
   if(badge) badge.textContent=count;
 }
@@ -567,7 +620,8 @@ document.addEventListener('DOMContentLoaded',()=>{
       const parent=sel.closest('.menu-item');
       const name=parent.dataset.name;
       const price=parseFloat(parent.dataset.price);
-      sel.addEventListener('change',()=>{ setQty(name,price,parseInt(sel.value)); });
+      const pack=parseFloat(parent.dataset.packaging||0);
+      sel.addEventListener('change',()=>{ setQty(name,price,parseInt(sel.value),pack); });
     }
   });
 
@@ -590,11 +644,11 @@ document.addEventListener('DOMContentLoaded',()=>{
 
   document.querySelectorAll('.qty-plus').forEach(btn=>{
     if(['bubbleTeaQty','xBentoQty'].includes(btn.dataset.target)) return;
-    btn.addEventListener('click',()=>{ const sel=document.getElementById(btn.dataset.target); let val=parseInt(sel.value); if(val<20) val++; sel.value=val; const parent=sel.closest('.menu-item'); setQty(parent.dataset.name,parseFloat(parent.dataset.price),val); });
+    btn.addEventListener('click',()=>{ const sel=document.getElementById(btn.dataset.target); let val=parseInt(sel.value); if(val<20) val++; sel.value=val; const parent=sel.closest('.menu-item'); setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0)); });
   });
   document.querySelectorAll('.qty-minus').forEach(btn=>{
     if(['bubbleTeaQty','xBentoQty'].includes(btn.dataset.target)) return;
-    btn.addEventListener('click',()=>{ const sel=document.getElementById(btn.dataset.target); let val=parseInt(sel.value); if(val>0) val--; sel.value=val; const parent=sel.closest('.menu-item'); setQty(parent.dataset.name,parseFloat(parent.dataset.price),val); });
+    btn.addEventListener('click',()=>{ const sel=document.getElementById(btn.dataset.target); let val=parseInt(sel.value); if(val>0) val--; sel.value=val; const parent=sel.closest('.menu-item'); setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0)); });
   });
   ['chopstickCount','soyCount','gemberCount','wasabiCount'].forEach(id=>{
     populateSelect(document.getElementById(id));
@@ -610,6 +664,8 @@ document.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('houseNumber').addEventListener('blur',updateQRCode);
   document.getElementById('street').addEventListener('blur',updateQRCode);
   document.getElementById('city').addEventListener('blur',updateQRCode);
+  document.getElementById('discountType').addEventListener('change',updateCart);
+  document.getElementById('discountValue').addEventListener('input',updateCart);
   document.getElementById('submitOrder').addEventListener('click',submitOrder);
   const cartToggle=document.getElementById('cartToggle');
   const cartPanel=document.getElementById('cartPanel');
@@ -662,6 +718,7 @@ function toggleAddress(){
   } else {
     updateQRCode();
   }
+  updateCart();
 }
 async function fetchAddress(){
   const pc=document.getElementById('postcode').value.trim();


### PR DESCRIPTION
## Summary
- include `data-packaging` field on all menu items
- add checkout summary section on POS page with discount logic
- calculate packaging, discount, BTW and total in `updateCart`
- update quantity handlers to pass packaging values
- recalc totals when order type or discount fields change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684dc770b920833397e0d22a84ab0828