### PR TITLE
Fix Tijdslot display in POS

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -905,8 +905,8 @@ if (remark) orderText += `, Opmerking: ${remark}`;
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     const total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
     const remark = order.opmerking || order.remark || '';
-    const pickup = order.pickupTime;
-    const delivery = order.deliveryTime;
+    const pickup = order.pickupTime || order.pickup_time;
+    const delivery = order.deliveryTime || order.delivery_time;
 
     tr.innerHTML = `
       <td>${order.created_date || ''}</td>

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -91,8 +91,8 @@
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
       const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
       const remark = order.opmerking || order.remark || '';
-      const pickup = order.pickup_time;
-      const delivery = order.delivery_time;
+      const pickup = order.pickup_time || order.pickupTime;
+      const delivery = order.delivery_time || order.deliveryTime;
       tr.innerHTML = `
         <td>${order.created_date || ''}</td>
         <td>${order.created_at || ''}</td>


### PR DESCRIPTION
## Summary
- fix new order row rendering to support both `pickup_time` & `pickupTime`
- same fix for delivery fields

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684dd24fe94c83339ddd726dda09c402