### PR TITLE
Adjust cart/checkout layout

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -168,8 +168,6 @@
   position: sticky;
   top: 80px; /* 与导航栏保持一定距离 */
   align-self: flex-start;
-  flex: 1.2;
-  max-width: 380px;
   width: 100%;
   backdrop-filter: blur(8px);
   border-radius: 16px;
@@ -324,11 +322,7 @@
 
 /* Floating cart and checkout panel */
   .cart-panel {
-    align-self: flex-start;
-    flex: 1.2;
-    max-width: 380px;
     width: 100%;
-
   }
   .close-btn { display:none; }
   .cart-toggle {


### PR DESCRIPTION
## Summary
- keep cart and checkout side panels sticky on desktop
- simplify base styles for cart panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e5c3a63dc83338e7e31d5a78a6044