### PR TITLE
Fix broken buttons and sticky cart

### DIFF
--- a/templates/menu.html
+++ b/templates/menu.html
@@ -209,7 +209,7 @@
 
 
     <!-- Veggie Bento -->
-   <div class="menu-row menu-item" data-name="Veggie Bento" data-price="10" data-packaging="0.2">
+   <div id="vegan" class="menu-row menu-item" data-name="Veggie Bento" data-price="10" data-packaging="0.2">
   <div class="menu-img">
     <img src="{{ url_for('static', filename='images/veggie-bento.png') }}" alt="Veggie Bento">
   </div>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -166,7 +166,7 @@
   .center-area { flex:1; }
   .checkout-panel {
   position: sticky;
-  top: 80px; /* 与导航栏保持一定距离 */
+  top: 60px; /* 与导航栏保持一定距离 */
   align-self: flex-start;
   flex: 1.2;
   max-width: 380px;
@@ -324,6 +324,8 @@
 
 /* Floating cart and checkout panel */
   .cart-panel {
+    position: sticky;
+    top: 60px;
     align-self: flex-start;
     flex: 1.2;
     max-width: 380px;
@@ -699,6 +701,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.target === cartPanel) cartPanel.classList.remove('open');
     });
   }
+
+  const todayBtn = document.getElementById('toggleToday');
+  if (todayBtn) todayBtn.addEventListener('click', toggleToday);
+  const submitBtn = document.getElementById('submitOrder');
+  if (submitBtn) submitBtn.addEventListener('click', submitOrder);
 
   updateCart();      // 初始化购物车
   toggleAddress();   // 设置显示配送或自取表单


### PR DESCRIPTION
## Summary
- make checkout and cart panel sticky below navbar
- hook up Bestellingen Vandaag and Submit Order buttons
- add `id="vegan"` anchor in menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e61d4cf888333b969a9919156713a