### PR TITLE
Implement detailed checkout with tips

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -684,6 +684,30 @@ input:focus, select:focus, textarea:focus {
   border-color: #ff9900;
 }
 
+.price-details {
+  text-align: left;
+  margin-top: 10px;
+  font-size: 0.95rem;
+}
+.price-details .price-row {
+  display: flex;
+  justify-content: space-between;
+  margin: 4px 0;
+}
+.price-details select {
+  width: auto;
+}
+.price-details .total-row {
+  font-weight: bold;
+  border-top: 1px solid #ccc;
+  padding-top: 4px;
+}
+.price-details .btw-note {
+  font-size: 0.85rem;
+  color: #555;
+  text-align: right;
+}
+
 
 </style>
 </head>
@@ -818,7 +842,15 @@ input:focus, select:focus, textarea:focus {
   <ul id="cart"></ul>
   <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
   <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
-  <div class="total">Totaal: €<span id="total">0.00</span></div>
+  <div class="price-details">
+    <div class="price-row"><span>Subtotaal:</span> <span id="subtotalDisplay">€0,00</span></div>
+    <div class="price-row"><span>Verpakkingskosten:</span> <span id="packagingDisplay">€0,20</span></div>
+    <div class="price-row" id="deliveryRow"><span>Bezorgkosten:</span> <span id="deliveryDisplay">€2,50</span></div>
+    <div class="price-row"><label for="tipSelect">Fooi:</label> <select id="tipSelect"></select></div>
+    <div class="price-row"><span>BTW (9%):</span> <span id="btwDisplay">€0,00</span></div>
+    <div class="price-row total-row"><span>Totaal:</span> <span id="totalDisplay">€0,00</span></div>
+    <div class="btw-note">Alle prijzen zijn inclusief BTW</div>
+  </div>
   <button class="checkout-btn" onclick="checkout()">Afrekenen &amp; Betalen</button>
 
 </div>
@@ -1444,6 +1476,29 @@ const extras = {
   gemberCount: { label: 'Gember', price: 0 }
 };
 
+const PACKAGING_FEE = 0.20;
+const DELIVERY_FEE = 2.50;
+let currentSubtotal = 0;
+let finalTotal = 0;
+
+function formatEuro(val) {
+  return `€${val.toFixed(2).replace('.', ',')}`;
+}
+
+function updatePriceBreakdown(subtotal) {
+  currentSubtotal = subtotal;
+  const tip = parseFloat(document.getElementById('tipSelect').value || '0');
+  const orderType = document.querySelector('input[name="orderType"]:checked').value;
+  const deliveryFee = orderType === 'bezorgen' ? DELIVERY_FEE : 0;
+  const btw = (subtotal + PACKAGING_FEE) * 0.09;
+  finalTotal = subtotal + PACKAGING_FEE + deliveryFee + tip + btw;
+  document.getElementById('subtotalDisplay').textContent = formatEuro(subtotal);
+  document.getElementById('packagingDisplay').textContent = formatEuro(PACKAGING_FEE);
+  document.getElementById('deliveryDisplay').textContent = formatEuro(deliveryFee);
+  document.getElementById('btwDisplay').textContent = formatEuro(btw);
+  document.getElementById('totalDisplay').textContent = formatEuro(finalTotal);
+}
+
 
 function changeBubbleQty(delta) {
   const qtySel = document.getElementById('bubbleTeaQty');
@@ -1656,7 +1711,7 @@ function updateCart() {
     list.appendChild(li);
   });
 
-  document.getElementById('total').textContent = total.toFixed(2);
+  updatePriceBreakdown(total);
 
   const totalQty = Object.values(cart).reduce((s, it) => s + it.qty, 0) +
     Object.keys(extras).reduce((s, id) => s + parseInt(document.getElementById(id).value || 0), 0);
@@ -1713,6 +1768,16 @@ document.addEventListener('DOMContentLoaded', () => {
     populateSelect(sel);
     sel.addEventListener('change', updateCart);
   });
+
+  const tipSel = document.getElementById('tipSelect');
+  for (let i = 0; i <= 20; i++) {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = formatEuro(i);
+    tipSel.appendChild(opt);
+  }
+  tipSel.value = 0;
+  tipSel.addEventListener('change', () => updatePriceBreakdown(currentSubtotal));
 
   updateCart();
 });
@@ -1839,7 +1904,13 @@ function checkout() {
     customerDetails += `\nAdres: ${address} ${houseNumber}\nPostcode: ${postcodeRaw}\nGebied: ${area}\nBezorgtijd: ${time}\nBetaalwijze: ${paymentMethod}`;
   }
 
-  const totalPrice = document.getElementById('total').textContent;
+  const tip = parseFloat(document.getElementById('tipSelect').value);
+  const subtotal = currentSubtotal;
+  const packagingFee = 0.20;
+  const deliveryFee = orderType === 'bezorgen' ? 2.50 : 0;
+  const btw = (subtotal + packagingFee) * 0.09;
+  const total = subtotal + packagingFee + deliveryFee + tip + btw;
+  const totalPrice = total.toFixed(2);
   const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}\nTotaal: €${totalPrice}`;
 
   const itemsToSend = { ...cart };
@@ -1882,6 +1953,12 @@ function checkout() {
         : '',
       items: itemsToSend,
       opmerking: remark,
+      tip: tip.toFixed(2),
+      subtotal: subtotal.toFixed(2),
+      packaging_fee: packagingFee.toFixed(2),
+      delivery_fee: deliveryFee.toFixed(2),
+      btw: btw.toFixed(2),
+      totaal: total.toFixed(2),
       message, email // ✅ 仍然推送到 Telegram
     })
   })
@@ -1918,20 +1995,21 @@ function checkout() {
     const bezorgenFields = document.getElementById('bezorgenFields');
 
     if (afhalen.checked) {
-      infoBox.innerHTML = `Adres voor afhalen: 
+      infoBox.innerHTML = `Adres voor afhalen:
   <a href="https://www.google.com/maps?q=Sjoukje+Dijkstralaan+83,+2134+CN+Hoofddorp" target="_blank" style="color: var(--accent-color); text-decoration: underline;">
     Sjoukje Dijkstralaan 83, 2134 CN Hoofddorp
 </a><br>
   📞: <a href="tel:0633399366" style="color: var(--accent-color); text-decoration: underline;">0622599566</a>`;
-      
+
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
     } else {
       infoBox.textContent = 'Wij bezorgen in de volgende postcodegebieden:\n2341, 2342, 2343, 2333, 2334, 2231, 2232, 2361, 2235';
-      
+
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
     }
+    updatePriceBreakdown(currentSubtotal);
   }
 
   // 初始化执行一次


### PR DESCRIPTION
## Summary
- add dynamic price breakdown to checkout
- implement tip selection dropdown and update totals
- compute subtotal, packaging, delivery, tax, and total amounts
- send new price details to backend

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_684fa303f98c833387df2b285319a000