### PR TITLE
Fix totals and tijdslot display

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -94,7 +94,8 @@
                 <td>{{ info.order.opmerking or '-' }}</td>
                 <td>{{ info.order.payment_method }}</td>
                 <td>{{ info.order.created_at_local.strftime('%Y-%m-%d %H:%M') }}</td>
-                <td>{{ '%.2f' % info.total }}</td>
+                {% set tot_val = info.order.totaal if info.order.totaal is defined else info.total %}
+                <td>{{ '%.2f' % tot_val }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -34,7 +34,8 @@
           </ul>
         </td>
         <td>{{ order.opmerking or '-' }}</td>
-        <td>{{ '%.2f' % order.total }}</td>
+        {% set tot_val = order.totaal if order.totaal is defined else order.total %}
+        <td>{{ '%.2f' % tot_val }}</td>
         <td>
           {% if is_delivery %}
             {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -964,10 +964,13 @@ function submitOrder() {
     if (order.id) tr.dataset.id = order.id;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-    const total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+    let total = order.totaal;
+    if (total === undefined) {
+      total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+    }
     const remark = order.opmerking || order.remark || '';
-    const pickup = order.pickupTime;
-    const delivery = order.deliveryTime;
+    const pickup = order.pickup_time || order.pickupTime;
+    const delivery = order.delivery_time || order.deliveryTime;
 
     tr.innerHTML = `
       <td>${order.created_date || ''}</td>

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -54,7 +54,8 @@
           </ul>
         </td>
         <td>{{ order.opmerking or '-' }}</td>
-        <td>{{ '%.2f' % order.total }}</td>
+        {% set tot_val = order.totaal if order.totaal is defined else order.total %}
+        <td>{{ '%.2f' % tot_val }}</td>
         <td>
           {% if is_delivery %}
             {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}
@@ -89,7 +90,10 @@
       const tr = document.createElement('tr');
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
-      const total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+      let total = order.totaal;
+      if(total === undefined){
+        total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+      }
       const remark = order.opmerking || order.remark || '';
       const pickup = order.pickup_time || order.pickupTime;
       const delivery = order.delivery_time || order.deliveryTime;


### PR DESCRIPTION
## Summary
- read `totaal` field for total amounts on all order tables
- support either `pickup_time` or `pickupTime` fields for tijdslot when receiving socket updates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684fd99b3db083338b5509427a746f7c