### PR TITLE
Fix totals display in POS tables

### DIFF
--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -10,6 +10,7 @@
         <th>Email</th>
         <th>Items</th>
         <th>Opmerking</th>
+        <th>Subtotaal (&euro;)</th>
         <th>Totaal (&euro;)</th>
         <th>Adres</th>
         <th>Tijdslot</th>
@@ -34,7 +35,9 @@
           </ul>
         </td>
         <td>{{ order.opmerking or '-' }}</td>
-        {% set tot_val = order.totaal if order.totaal is defined else order.total %}
+        {% set sub_val = order.subtotal if order.subtotal is defined else order.total %}
+        <td>{{ '%.2f' % sub_val }}</td>
+        {% set tot_val = order.totaal if order.totaal is defined else sub_val %}
         <td>{{ '%.2f' % tot_val }}</td>
         <td>
           {% if is_delivery %}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -964,9 +964,16 @@ function submitOrder() {
     if (order.id) tr.dataset.id = order.id;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-    let total = order.totaal;
-    if (total === undefined) {
-      total = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+    let subtotal = parseFloat(order.subtotal);
+    if (isNaN(subtotal)) {
+      subtotal = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+    }
+    let total = parseFloat(order.totaal);
+    if (isNaN(total)) {
+      total = parseFloat(order.total);
+    }
+    if (isNaN(total)) {
+      total = subtotal;
     }
     const remark = order.opmerking || order.remark || '';
     const pickup = order.pickup_time || order.pickupTime;
@@ -981,6 +988,7 @@ function submitOrder() {
       <td>${order.email || '-'}</td>
       <td><ul>${items}</ul></td>
       <td>${remark || '-'}</td>
+      <td>${subtotal.toFixed(2)}</td>
       <td>${total.toFixed(2)}</td>
       <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
       <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -941,6 +941,14 @@ function submitOrder() {
     document.title = newOrderCount ? `${baseTitle} (${newOrderCount})` : baseTitle;
   }
 
+  function parseEuro(val){
+    if(val===undefined||val===null) return NaN;
+    if(typeof val==='string'){
+      val = val.replace(/[^0-9,.-]/g,'').replace(',','.');
+    }
+    return parseFloat(val);
+  }
+
   // 音效播放
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   function beep() {
@@ -964,13 +972,13 @@ function submitOrder() {
     if (order.id) tr.dataset.id = order.id;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-    let subtotal = parseFloat(order.subtotal);
+    let subtotal = parseEuro(order.subtotal);
     if (isNaN(subtotal)) {
-      subtotal = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+      subtotal = Object.values(order.items || {}).reduce((s, i) => s + (parseEuro(i.price) * parseInt(i.qty || 0)), 0);
     }
-    let total = parseFloat(order.totaal);
+    let total = parseEuro(order.totaal);
     if (isNaN(total)) {
-      total = parseFloat(order.total);
+      total = parseEuro(order.total);
     }
     if (isNaN(total)) {
       total = subtotal;

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -84,6 +84,14 @@
   <script>
     const socket = io({transports:['websocket']});
     let pollTimer;
+
+    function parseEuro(val){
+      if(val===undefined||val===null) return NaN;
+      if(typeof val==='string'){
+        val = val.replace(/[^0-9,.-]/g,'').replace(',','.');
+      }
+      return parseFloat(val);
+    }
     window.addEventListener('beforeunload',()=>socket.disconnect());
     socket.on('connect_error',()=>{setTimeout(()=>socket.connect(),1000);});
     socket.on('disconnect', startPolling);
@@ -93,11 +101,14 @@
       const tr = document.createElement('tr');
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
-      let subtotal = parseFloat(order.subtotal);
+      let subtotal = parseEuro(order.subtotal);
       if(isNaN(subtotal)){
-        subtotal = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+        subtotal = Object.values(order.items || {}).reduce((s,i)=>s + (parseEuro(i.price)*parseInt(i.qty||0)),0);
       }
-      let total = parseFloat(order.totaal);
+      let total = parseEuro(order.totaal);
+      if(isNaN(total)){
+        total = parseEuro(order.total);
+      }
       if(isNaN(total)){
         total = subtotal;
       }

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -30,6 +30,7 @@
         <th>Email</th>
         <th>Items</th>
         <th>Opmerking</th>
+        <th>Subtotaal (&euro;)</th>
         <th>Totaal (&euro;)</th>
         <th>Adres</th>
         <th>Tijdslot</th>
@@ -54,7 +55,9 @@
           </ul>
         </td>
         <td>{{ order.opmerking or '-' }}</td>
-        {% set tot_val = order.totaal if order.totaal is defined else order.total %}
+        {% set sub_val = order.subtotal if order.subtotal is defined else order.total %}
+        <td>{{ '%.2f' % sub_val }}</td>
+        {% set tot_val = order.totaal if order.totaal is defined else sub_val %}
         <td>{{ '%.2f' % tot_val }}</td>
         <td>
           {% if is_delivery %}
@@ -90,9 +93,13 @@
       const tr = document.createElement('tr');
       const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
       const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
-      let total = order.totaal;
-      if(total === undefined){
-        total = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+      let subtotal = parseFloat(order.subtotal);
+      if(isNaN(subtotal)){
+        subtotal = Object.values(order.items || {}).reduce((s,i)=>s + (parseFloat(i.price||0)*parseInt(i.qty||0)),0);
+      }
+      let total = parseFloat(order.totaal);
+      if(isNaN(total)){
+        total = subtotal;
       }
       const remark = order.opmerking || order.remark || '';
       const pickup = order.pickup_time || order.pickupTime;
@@ -106,6 +113,7 @@
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
+        <td>${subtotal.toFixed(2)}</td>
         <td>${total.toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>


### PR DESCRIPTION
## Summary
- add new column for subtotal in orders tables
- display backend `totaal` when available for totals
- keep subtotal calculation as fallback

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fe021b4188333a0ffd4383b76424b