### PR TITLE
Fix totals fallback

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -964,17 +964,17 @@ function submitOrder() {
     if (order.id) tr.dataset.id = order.id;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-      let subtotal = parseFloat(order.subtotal);
+    let subtotal = parseFloat(order.subtotal);
     if (isNaN(subtotal)) {
       subtotal = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
     }
     let total = parseFloat(order.totaal);
     if (isNaN(total)) {
-      total = parseFloat(order.total);
-    }
-    if (isNaN(total)) {
-      total = subtotal;
+      if(!('totaal' in order)){
+        console.warn('⚠️ totaal 字段缺失，请联系后端');
       }
+      total = subtotal;
+    }
     const remark = order.opmerking || order.remark || '';
     const pickup = order.pickup_time || order.pickupTime;
     const delivery = order.delivery_time || order.deliveryTime;
@@ -989,7 +989,7 @@ function submitOrder() {
       <td><ul>${items}</ul></td>
       <td>${remark || '-'}</td>
       <td>${subtotal.toFixed(2)}</td>
-      <td>${total.toFixed(2)}</td>
+      <td>€${total.toFixed(2)}</td>
       <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
       <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
       <td>${order.payment_method || ''}</td>`;
@@ -1000,6 +1000,9 @@ function submitOrder() {
   // Socket 监听新订单
   socket.on('new_order', order => {
     console.log('🆕 Nieuwe bestelling:', order);
+    if(!('totaal' in order)){
+      console.warn('⚠️ totaal 字段缺失，请联系后端');
+    }
     beep();
     alert('Nieuwe bestelling ontvangen!');
     addRow(order);

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -99,6 +99,9 @@
       }
       let total = parseFloat(order.totaal);
       if(isNaN(total)){
+        if(!('totaal' in order)){
+          console.warn('⚠️ totaal 字段缺失，请联系后端');
+        }
         total = subtotal;
       }
       const remark = order.opmerking || order.remark || '';
@@ -114,13 +117,19 @@
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
         <td>${subtotal.toFixed(2)}</td>
-        <td>${total.toFixed(2)}</td>
+        <td>€${total.toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>`;
       tbody.prepend(tr);
     }
-    socket.on('new_order', addRow);
+    socket.on('new_order', order => {
+      console.log(order);
+      if(!('totaal' in order)){
+        console.warn('⚠️ totaal 字段缺失，请联系后端');
+      }
+      addRow(order);
+    });
 
     function fetchOrders(){
       fetch('/pos/orders_today?json=1').then(r=>r.json()).then(data=>{


### PR DESCRIPTION
## Summary
- restore fallback logic for `totaal` in order tables
- keep warning checks but avoid page errors if `totaal` missing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6850db438df08333a79589231b6049ed