### PR TITLE
Fix currency formatting on POS pages

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -955,6 +955,12 @@ function submitOrder() {
     osc.stop(audioCtx.currentTime + 0.2);
   }
 
+  // 格式化货币显示
+  function formatCurrency(value) {
+    const num = parseFloat(value);
+    return isNaN(num) ? "€0.00" : `€${num.toFixed(2)}`;
+  }
+
   // 添加订单到表格
   function addRow(order) {
     const tbody = document.querySelector('.orders-panel tbody');
@@ -984,8 +990,8 @@ function submitOrder() {
       <td>${order.email || '-'}</td>
       <td><ul>${items}</ul></td>
       <td>${remark || '-'}</td>
-      <td>${subtotal.toFixed(2)}</td>
-      <td>€${parseFloat(order.totaal).toFixed(2)}</td>
+      <td>${formatCurrency(subtotal)}</td>
+      <td>${formatCurrency(order.totaal)}</td>
       <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
       <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
       <td>${order.payment_method || ''}</td>`;

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -87,6 +87,11 @@
     socket.on('connect_error',()=>{setTimeout(()=>socket.connect(),1000);});
     socket.on('disconnect', startPolling);
     socket.on('connect', stopPolling);
+    function formatCurrency(value){
+      const num = parseFloat(value);
+      return isNaN(num) ? "€0.00" : `€${num.toFixed(2)}`;
+    }
+
     function addRow(order){
       const tbody = document.querySelector('table tbody');
       const tr = document.createElement('tr');
@@ -111,8 +116,8 @@
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
-        <td>${subtotal.toFixed(2)}</td>
-        <td>€${parseFloat(order.totaal).toFixed(2)}</td>
+        <td>${formatCurrency(subtotal)}</td>
+        <td>${formatCurrency(order.totaal)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>`;


### PR DESCRIPTION
## Summary
- add `formatCurrency` helper on POS pages
- use `formatCurrency` when rendering subtotal and total columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510fe7775c8333883d1431890ee755