### PR TITLE
Update time logic and mobile cart

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -337,7 +337,7 @@ button:active {
   top: 0;
   right: 0;
   width: 90%;
-  height: 100%;
+  height: 100vh;
   background: var(--off-white);
   border-radius: 16px 0 0 16px;
   padding: 20px;
@@ -760,7 +760,7 @@ input:focus, select:focus, textarea:focus {
       <label>Email (optioneel):</label>
       <input id="pickupEmail" type="email" />
       <label>Tijd van afhalen:</label>
-      <input id="pickup_time" type="time" />
+      <select id="pickup_time"></select>
       <label>Betaalmethode:</label>
       <select id="pickupPayment">
         <option value="contant">Contant</option>
@@ -786,7 +786,7 @@ input:focus, select:focus, textarea:focus {
       <input id="deliveryArea" type="text" />
       <div id="mapLinkContainer" style="margin-top: 4px;"></div>
       <label>Bezorgtijd:</label>
-      <input id="delivery_time" type="time" />
+      <select id="delivery_time"></select>
       <label>Betaalmethode:</label>
       <select id="deliveryPayment">
         <option value="contant">Contant</option>
@@ -2003,6 +2003,37 @@ function checkout() {
 
 </script>
 <script>
+  function pad(num) {
+    return num.toString().padStart(2, '0');
+  }
+
+  function populateTimeOptions(selectId, offsetMinutes) {
+    const select = document.getElementById(selectId);
+    if (!select) return;
+    select.innerHTML = '';
+    const now = new Date();
+    now.setMinutes(now.getMinutes() + offsetMinutes);
+
+    const open = new Date();
+    open.setHours(12, 0, 0, 0);
+    const close = new Date();
+    close.setHours(20, 30, 0, 0);
+
+    let start = now > open ? now : open;
+    start = new Date(start);
+    start.setMinutes(Math.ceil(start.getMinutes() / 15) * 15, 0, 0);
+
+    for (let t = start; t <= close; t.setMinutes(t.getMinutes() + 15)) {
+      const hh = pad(t.getHours());
+      const mm = pad(t.getMinutes());
+      const timeStr = `${hh}:${mm}`;
+      const opt = document.createElement('option');
+      opt.value = timeStr;
+      opt.textContent = timeStr;
+      select.appendChild(opt);
+    }
+  }
+
   function toggleOrderType() {
     const afhalen = document.getElementById('afhalen');
     const infoBox = document.getElementById('locationInfo');
@@ -2018,11 +2049,13 @@ function checkout() {
 
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
+      populateTimeOptions('pickup_time', 30);
     } else {
       infoBox.textContent = 'Wij bezorgen in de volgende postcodegebieden:\n2341, 2342, 2343, 2333, 2334, 2231, 2232, 2361, 2235';
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
+      populateTimeOptions('delivery_time', 45);
     }
     updatePriceBreakdown(currentSubtotal, currentPackaging);
   }


### PR DESCRIPTION
## Summary
- show pickup/delivery time dropdowns
- fill dropdowns from 12:00-20:30 with 15-min slots
- load pickup times 30 min out and delivery times 45 min out
- let mobile cart cover full screen

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_68511d4a381c833386bcc3e1853bf50a