### PR TITLE
Add floating order list button on mobile

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -369,6 +369,31 @@
     padding: 2px 6px;
     font-size: 0.75rem;
   }
+  .today-toggle {
+    position: fixed;
+    bottom: 90px;
+    right: 20px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    border: none;
+    background: #fff;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    font-size: 1.4rem;
+    cursor: pointer;
+    z-index: 1100;
+    display: none;
+  }
+  .today-toggle .badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background: #ff3b30;
+    color: #fff;
+    border-radius: 50%;
+    padding: 2px 6px;
+    font-size: 0.75rem;
+  }
   #closeCartPanel {
     position: absolute;
     top: 10px;
@@ -383,6 +408,8 @@
   }
   @media (max-width: 768px) {
     .cart-toggle { display: block; }
+    .today-toggle { display: block; }
+    .today-btn { display: none; }
     .cart-panel {
       position: fixed;
       inset: 0;
@@ -529,6 +556,7 @@
   </div>
 </div>
 <button id="cartToggle" class="cart-toggle">🛒<span id="cartCount" class="badge">0</span></button>
+<button id="todayToggleMobile" class="today-toggle">📅<span id="todayBadge" class="badge">0</span></button>
 <audio id="notifySound" src="/sound/beep.mp3" preload="auto"></audio>
 
 <script>
@@ -690,6 +718,10 @@ document.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('discountType').addEventListener('change',updateCart);
   document.getElementById('discountValue').addEventListener('input',updateCart);
   document.getElementById('toggleToday').addEventListener('click',toggleToday);
+  const todayToggleMobile=document.getElementById('todayToggleMobile');
+  if(todayToggleMobile){
+    todayToggleMobile.addEventListener('click',toggleToday);
+  }
   document.getElementById('closeToday').addEventListener('click',toggleToday);
   document.getElementById('typePickup').addEventListener('change',toggleAddress);
   document.getElementById('typeDelivery').addEventListener('change',toggleAddress);
@@ -718,6 +750,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
   updateCart();
   toggleAddress();
+  updateTodayBadge();
   // 🔊 解锁 AudioContext
   document.body.addEventListener('click', () => {
     if (audioCtx.state === 'suspended') {
@@ -735,6 +768,7 @@ function toggleToday(){
     newOrderCount = 0;
     updateTabTitle();
   }
+  updateTodayBadge();
 }
 
 function toggleAddress(){
@@ -952,6 +986,12 @@ function formatCurrency(value){
   function updateTabTitle(){
     document.title = newOrderCount ? `${baseTitle} (${newOrderCount})` : baseTitle;
   }
+  function updateTodayBadge(){
+    const badge=document.getElementById('todayBadge');
+    if(badge){
+      badge.textContent = newOrderCount > 0 ? newOrderCount : '';
+    }
+  }
 
   // 音效播放
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -1014,8 +1054,14 @@ function formatCurrency(value){
     beep();
     alert('Nieuwe bestelling ontvangen!');
     addRow(order);
-    newOrderCount++;
+    const panel=document.getElementById('todayOrders');
+    if(panel && panel.classList.contains('visible')){
+      newOrderCount = 0;
+    }else{
+      newOrderCount++;
+    }
     updateTabTitle();
+    updateTodayBadge();
   });
 
   // 断线后启用轮询
@@ -1060,7 +1106,7 @@ function formatCurrency(value){
   }
 
   window.addEventListener('beforeunload', () => socket.disconnect());
-  window.addEventListener('focus', () => { newOrderCount = 0; updateTabTitle(); });
+  window.addEventListener('focus', () => { newOrderCount = 0; updateTabTitle(); updateTodayBadge(); });
 </script>
 
 


### PR DESCRIPTION
## Summary
- convert today order button to floating icon on small screens
- show unread order badge
- clear badge when order panel opened

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852fc6c3c808333980deea880f142e3