### PR TITLE
Restore floating order list button on mobile

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -369,6 +369,36 @@
     padding: 2px 6px;
     font-size: 0.75rem;
   }
+  .today-btn .badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background: #ff3b30;
+    color: #fff;
+    border-radius: 50%;
+    padding: 2px 6px;
+    font-size: 0.75rem;
+  }
+  .today-btn .label { margin-right: 4px; }
+
+  @media (max-width: 768px) {
+    .today-btn {
+      position: fixed;
+      bottom: 86px;
+      right: 20px;
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.4rem;
+      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+      z-index: 1100;
+    }
+    .today-btn .label { display: none; }
+  }
   #closeCartPanel {
     position: absolute;
     top: 10px;
@@ -414,7 +444,7 @@
       <a href="#snack">Snack</a>
       <a href="#vegan">Vegan</a>
     </div>
-    <button id="toggleToday" class="today-btn">Bestellingen Vandaag</button>
+    <button id="toggleToday" class="today-btn"><span class="label">Bestellingen Vandaag</span><span id="todayBadge" class="badge">0</span></button>
     <div class="indicator" id="indicator"></div>
   </nav>
 </div>
@@ -718,6 +748,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
   updateCart();
   toggleAddress();
+  fetchOrders();
   // 🔊 解锁 AudioContext
   document.body.addEventListener('click', () => {
     if (audioCtx.state === 'suspended') {
@@ -735,6 +766,7 @@ function toggleToday(){
     newOrderCount = 0;
     updateTabTitle();
   }
+  updateTodayBadge();
 }
 
 function toggleAddress(){
@@ -949,8 +981,15 @@ function formatCurrency(value){
   let pollTimer;
   const baseTitle = document.title;
   let newOrderCount = 0;
+  let todayOrderCount = 0;
   function updateTabTitle(){
     document.title = newOrderCount ? `${baseTitle} (${newOrderCount})` : baseTitle;
+  }
+  function updateTodayBadge(){
+    const badge=document.getElementById('todayBadge');
+    if(badge){
+      badge.textContent = todayOrderCount;
+    }
   }
 
   // 音效播放
@@ -1014,8 +1053,15 @@ function formatCurrency(value){
     beep();
     alert('Nieuwe bestelling ontvangen!');
     addRow(order);
-    newOrderCount++;
+    todayOrderCount++;
+    const panel=document.getElementById('todayOrders');
+    if(panel && panel.classList.contains('visible')){
+      newOrderCount = 0;
+    }else{
+      newOrderCount++;
+    }
     updateTabTitle();
+    updateTodayBadge();
   });
 
   // 断线后启用轮询
@@ -1042,6 +1088,8 @@ function formatCurrency(value){
       if (!tbody) return;
       tbody.innerHTML = '';
       data.reverse().forEach(addRow); // 让最新订单在最上面
+      todayOrderCount = data.length;
+      updateTodayBadge();
     }).catch(() => {});
  }
 
@@ -1060,7 +1108,7 @@ function formatCurrency(value){
   }
 
   window.addEventListener('beforeunload', () => socket.disconnect());
-  window.addEventListener('focus', () => { newOrderCount = 0; updateTabTitle(); });
+  window.addEventListener('focus', () => { newOrderCount = 0; updateTabTitle(); updateTodayBadge(); });
 </script>
 
 


### PR DESCRIPTION
## Summary
- keep `Bestellingen Vandaag` button but float it like the cart button on small screens
- hide text on mobile and show count badge

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852fc6c3c808333980deea880f142e3