### PR TITLE
Preserve order form data on toggle

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2166,6 +2166,7 @@ function checkout() {
   function populateTimeOptions(selectId, offsetMinutes) {
     const select = document.getElementById(selectId);
     if (!select) return;
+    const prev = select.value; // keep current selection
     select.innerHTML = '';
     const now = new Date();
     now.setMinutes(now.getMinutes() + offsetMinutes);
@@ -2187,6 +2188,10 @@ function checkout() {
       opt.value = timeStr;
       opt.textContent = timeStr;
       select.appendChild(opt);
+    }
+    if (prev) {
+      const option = Array.from(select.options).find(o => o.value === prev);
+      if (option) select.value = prev;
     }
   }
 


### PR DESCRIPTION
## Summary
- preserve previously selected time when switching between order modes

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_685419dcbed483338a1568617bc740eb