### PR TITLE
Add order number column

### DIFF
--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -4,6 +4,7 @@
       <tr>
         <th>Datum</th>
         <th>Tijd</th>
+        <th>Bestelnummer</th>
         <th>Type</th>
         <th>Klant</th>
         <th>Telefoon</th>
@@ -22,6 +23,7 @@
       <tr>
         <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
+        <td>{{ order.order_number or '' }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
         <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
         <td>{{ order.customer_name or '' }}</td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1086,11 +1086,12 @@ function formatCurrency(value){
     const pickup = order.pickup_time || order.pickupTime;
     const delivery = order.delivery_time || order.deliveryTime;
 
-    tr.innerHTML = `
-      <td>${order.created_date || ''}</td>
-      <td>${order.created_at || ''}</td>
-      <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
-      <td>${order.customer_name || ''}</td>
+      tr.innerHTML = `
+        <td>${order.created_date || ''}</td>
+        <td>${order.created_at || ''}</td>
+        <td>${order.order_number || ''}</td>
+        <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
+        <td>${order.customer_name || ''}</td>
       <td>${order.phone || ''}</td>
       <td>${order.email || '-'}</td>
       <td><ul>${items}</ul></td>

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -24,6 +24,7 @@
     <tr>
       <th>Datum</th>
       <th>Tijd</th>
+      <th>Bestelnummer</th>
       <th>Type</th>
       <th>Klant</th>
       <th>Telefoon</th>
@@ -41,7 +42,8 @@
     <tr>
       <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
       <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
-
+      <td>{{ order.order_number or '' }}</td>
+      
       {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
       <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
 
@@ -132,6 +134,7 @@
   tr.innerHTML = `
     <td>${order.created_date || ''}</td>
     <td>${order.created_at || ''}</td>
+    <td>${order.order_number || ''}</td>
     <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
     <td>${order.customer_name || ''}</td>
     <td>${order.phone || ''}</td>


### PR DESCRIPTION
## Summary
- show order numbers in the POS order tables

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68547f582fd483339918666322d0d8dc