### PR TITLE
Unified order notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ SMTP_PORT=587
 SMTP_USERNAME=qianchennl@gmail.com
 SMTP_PASSWORD=wtuyxljsjwftyzfm
 FROM_EMAIL=qianchennl@gmail.com
+ADMIN_EMAIL=qianchennl@gmail.com
 
 # Payment URL for online orders
 TIKKIE_URL=https://tikkie.me/pay/example

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Create a new Web Service on Render, link this repository, and it will deploy usi
 - `DATABASE_URL` - database connection URI.
 - `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` - optional Telegram notification settings.
 - `SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `FROM_EMAIL` - optional SMTP settings.
+- `ADMIN_EMAIL` - address to receive order notifications.
 - `TIKKIE_URL` - URL to redirect customers for online payments.
 
 For local development copy `.env.example` to `.env` and fill in the values.

--- a/app.py
+++ b/app.py
@@ -220,6 +220,38 @@ def send_email(to_email: str, subject: str, body: str):
     except Exception as e:
         print(f"Email send error: {e}")
 
+
+def format_notification(order: "Order") -> str:
+    """Return a unified notification text for Telegram and email."""
+    try:
+        items = json.loads(order.items or "{}")
+    except Exception:
+        items = {}
+
+    summary = "\n".join(f"{name} x {item.get('qty')}" for name, item in items.items())
+
+    if order.order_type in ["afhalen", "pickup"]:
+        details = f"[Afhalen]\nNaam: {order.customer_name}\nTelefoon: {order.phone}"
+        if order.email:
+            details += f"\nEmail: {order.email}"
+        details += f"\nAfhaaltijd: {order.pickup_time}\nBetaalwijze: {order.payment_method}"
+    else:
+        details = f"[Bezorgen]\nNaam: {order.customer_name}\nTelefoon: {order.phone}"
+        if order.email:
+            details += f"\nEmail: {order.email}"
+        details += (
+            f"\nAdres: {order.street} {order.house_number}"\
+            f"\nPostcode: {order.postcode}\nBezorgtijd: {order.delivery_time}"\
+            f"\nBetaalwijze: {order.payment_method}"
+        )
+
+    totaal = order.totaal or 0
+    return (
+        "📦 Nieuwe bestelling bij *Nova Asia*:\n\n"
+        f"Bestelnummer: {order.order_number}\n"
+        f"{summary}\n{details}\nTotaal: €{totaal:.2f}"
+    )
+
 # 设置登录管理
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
@@ -421,14 +453,15 @@ def api_orders():
 
         
 
-        # 5. Telegram / Email 通知（保留原逻辑）
-        if data.get("message"):
-            order_number_line = f"🧾 Bestelnummer: {order.order_number}\n"
-            full_message = order_number_line + data["message"]
+        # 5. Telegram / Email 通知（统一格式）
+        notify_text = format_notification(order)
+        send_telegram(notify_text)
 
-            send_telegram(full_message)
-            if order.email:
-                send_email(order.email, "Orderbevestiging", full_message)
+        admin_email = os.getenv("ADMIN_EMAIL") or os.getenv("FROM_EMAIL")
+        if admin_email:
+            send_email(admin_email, "Nova Asia - Nieuwe bestelling", notify_text)
+        if order.email:
+            send_email(order.email, "Nova Asia - Bevestiging van je bestelling", notify_text)
 
         print("✅ 接收到订单:", data)
 


### PR DESCRIPTION
## Summary
- create `format_notification` helper to generate consistent order text
- send Telegram and email alerts using the unified format
- add `ADMIN_EMAIL` setting for admin notification

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68551e7252c48333adcfbe968547fd3a