### PR TITLE
Fix order submission to backend

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2078,7 +2078,8 @@ function checkout() {
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
-   fetch('https://flask-order-api.onrender.com/submit_order', {
+   // Verstuur bestelling altijd naar eigen backend (App A)
+   fetch('/submit_order', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -971,7 +971,8 @@ function submitOrder() {
   };
 
   // ✅ 提交到后端
-  fetch('https://flask-order-api.onrender.com/submit_order', {
+  // Gebruik de eigen backend voor orderverwerking
+  fetch('/submit_order', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -1041,7 +1042,8 @@ function formatCurrency(value){
   
 <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
 <script>
-  const socket = io('https://flask-order-api.onrender.com', { transports: ['websocket'] });
+  // Verbind met de SocketIO-server van dezelfde host
+  const socket = io();
 
   let pollTimer;
   const baseTitle = document.title;


### PR DESCRIPTION
## Summary
- stop posting orders directly to the remote notifier
- send POS page orders to `/submit_order`
- connect Socket.IO to same host

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857008c0ab48333958d732a12574dac