### PR TITLE
Add secondary order push to nova-asia backend

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2078,10 +2078,7 @@ function checkout() {
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
-   fetch('https://flask-order-api.onrender.com/submit_order', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
+  const orderData = {
       orderType: orderType,
       name: orderType === 'afhalen'
         ? document.getElementById('pickupName').value.trim()
@@ -2119,7 +2116,18 @@ function checkout() {
       btw: btw.toFixed(2),
       totaal: isNaN(total) ? "0.00" : total.toFixed(2),
       message, email // ✅ 仍然推送到 Telegram
-    })
+  };
+
+  fetch('https://nova-asia.onrender.com/submit_order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(orderData)
+  }).catch(err => console.error(err));
+
+  fetch('https://flask-order-api.onrender.com/submit_order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(orderData)
   })
     .then(res => res.json())
     .then(data => {


### PR DESCRIPTION
## Summary
- in **index.html**, send order data to the existing nova-asia backend in parallel
- keep original order submission flow unaffected

## Testing
- `python -m py_compile app.py`
- `flake8` *(fails: command not found)*
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857be7a144483339a357869e4d0cf8d