### PR TITLE
Implement order number generation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1958,6 +1958,13 @@ function scrollToField(id) {
   }
 }
 
+function generateOrderNumber() {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const rand = Math.random().toString(36).substring(2, 6).toUpperCase();
+  return `NV${date}-${rand}`;
+}
+
 function checkout() {
   const paidItems = Object.values(cart).filter(item => item.price > 0 && item.qty > 0);
   if (paidItems.length === 0) {
@@ -2070,6 +2077,8 @@ function checkout() {
   const total = subtotal + packagingFee + deliveryFee + tip;
   const totalPrice = !isNaN(total) ? total.toFixed(2) : "0.00";
 
+  const orderNumber = generateOrderNumber();
+
   const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}\nTotaal: €${totalPrice}`;
 
   const itemsToSend = { ...cart };
@@ -2110,6 +2119,7 @@ function checkout() {
       city: orderType === 'bezorgen'
         ? document.getElementById('deliveryArea').value.trim()
         : '',
+      order_number: orderNumber,
       items: itemsToSend,
       opmerking: remark,
       tip: tip.toFixed(2),
@@ -2125,7 +2135,7 @@ function checkout() {
     .then(data => {
       if (data.status === 'ok') {
         beep();
-        showFeedback('Bestelling succesvol verzonden!');
+        showFeedback('Bestelling succesvol verzonden! Bestelnummer: ' + orderNumber);
         for (const k in cart) delete cart[k];
         updateCart();
         sliderText.innerText = 'Schuif om te betalen';


### PR DESCRIPTION
## Summary
- generate a unique order number when a customer checks out
- include the new `order_number` field in the order payload
- show the generated number in the success message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f440a5d883338ed33e14a8313af3