### PR TITLE
Implement order number in POS flow

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1958,6 +1958,13 @@ function scrollToField(id) {
   }
 }
 
+function generateOrderNumber() {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const rand = Math.random().toString(36).substring(2, 6).toUpperCase();
+  return `NV${date}-${rand}`;
+}
+
 function checkout() {
   const paidItems = Object.values(cart).filter(item => item.price > 0 && item.qty > 0);
   if (paidItems.length === 0) {
@@ -2070,6 +2077,8 @@ function checkout() {
   const total = subtotal + packagingFee + deliveryFee + tip;
   const totalPrice = !isNaN(total) ? total.toFixed(2) : "0.00";
 
+  const orderNumber = generateOrderNumber();
+
   const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}\nTotaal: €${totalPrice}`;
 
   const itemsToSend = { ...cart };
@@ -2110,6 +2119,7 @@ function checkout() {
       city: orderType === 'bezorgen'
         ? document.getElementById('deliveryArea').value.trim()
         : '',
+      order_number: orderNumber,
       items: itemsToSend,
       opmerking: remark,
       tip: tip.toFixed(2),
@@ -2125,7 +2135,7 @@ function checkout() {
     .then(data => {
       if (data.status === 'ok') {
         beep();
-        showFeedback('Bestelling succesvol verzonden!');
+        showFeedback('Bestelling succesvol verzonden! Bestelnummer: ' + orderNumber);
         for (const k in cart) delete cart[k];
         updateCart();
         sliderText.innerText = 'Schuif om te betalen';

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -871,6 +871,13 @@ function clearForm(){
   updateCart();
   toggleAddress();
 }
+
+function generateOrderNumber(){
+  const now = new Date();
+  const date = now.toISOString().slice(0,10).replace(/-/g,'');
+  const rand = Math.random().toString(36).substring(2,6).toUpperCase();
+  return `NV${date}-${rand}`;
+}
 function submitOrder() {
   const name = document.getElementById('custName').value.trim();
   const phone = document.getElementById('custPhone').value.trim();
@@ -920,6 +927,8 @@ function submitOrder() {
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
+  const orderNumber = generateOrderNumber();
+
   // ✅ 获取结账明细数据
   const subtotal = Object.values(cart).reduce((sum, item) => sum + item.price * item.qty, 0);
   const packagingTotal = Object.values(cart).reduce((sum, item) => sum + (item.packaging || 0) * item.qty, 0);
@@ -964,6 +973,7 @@ function submitOrder() {
     house_number: delivery ? document.getElementById('houseNumber').value.trim() : '',
     street: delivery ? document.getElementById('street').value.trim() : '',
     city: delivery ? document.getElementById('city').value.trim() : '',
+    order_number: orderNumber,
     items: itemsToSend,
     message: orderText,
     opmerking: remark,
@@ -981,7 +991,7 @@ function submitOrder() {
     .then(r => r.json())
     .then(res => {
       if (res.success || res.status === 'ok') {
-        alert('Bestelling succesvol verzonden!');
+        alert('Bestelling succesvol verzonden! Bestelnummer: ' + orderNumber);
         clearForm();
         fetchOrders();
       } else {


### PR DESCRIPTION
## Summary
- add `generateOrderNumber` helper in `pos.html`
- include the generated order number when submitting a POS order
- display the order number after a successful submission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857f440a5d883338ed33e14a8313af3