### PR TITLE
Show tip column in POS order table

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,6 +201,7 @@ class Order(db.Model):
     items = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     totaal = db.Column(db.Float)
+    fooi = db.Column(db.Float, default=0.0)
 
 
 class User(UserMixin):
@@ -331,7 +332,8 @@ def api_orders():
             city=data.get("city"),
             opmerking=data.get("opmerking") or data.get("remark"),
             items=json.dumps(data.get("items", {})),
-            order_number=order_number
+            order_number=order_number,
+            fooi=float(data.get("tip") or data.get("fooi") or 0)
         )
 
         # 2. 计算 subtotal / totaal
@@ -370,6 +372,7 @@ def api_orders():
                 "items": items,
                 "total": subtotal,
                 "totaal": order.totaal,
+                "fooi": order.fooi,
                 "order_number": order.order_number,
             }
             socketio.emit("new_order", order_payload, broadcast=True)
@@ -505,6 +508,7 @@ def pos_orders_today():
             "items": o.items_dict,
             "total": totaal,   # ✅ 关键是这里：使用数据库中的 totaal
             "totaal": totaal,
+            "fooi": o.fooi or 0,
             "order_number": o.order_number  # ✅ 加上这行
         })
 

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -50,7 +50,7 @@
           <th>Email</th>
           <th>Items</th>
           <th>Opmerking</th>
-          <th>Subtotaal (€)</th>
+          <th>Fooi (€)</th>
           <th>Totaal (€)</th>
           <th>Adres</th>
           <th>Tijdslot</th>
@@ -130,11 +130,11 @@
             const tr = document.createElement('tr');
             const isDelivery = ['delivery', 'bezorgen'].includes((order.order_type || '').toLowerCase());
             const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-            let subtotal = parseFloat(order.subtotal);
-            if (isNaN(subtotal)) {
-              subtotal = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+            let fooi = parseFloat(order.fooi);
+            if (isNaN(fooi)) {
+              fooi = 0;
             }
-            let tot = order.totaal ?? order.total ?? subtotal;
+            let tot = order.totaal ?? order.total ?? 0;
             if (typeof tot === 'string') {
               tot = parseFloat(tot.replace(/[^\d,.-]/g, '').replace(',', '.'));
             }
@@ -156,7 +156,7 @@
               <td>${order.email || '-'}</td>
               <td><ul>${items}</ul></td>
               <td>${order.opmerking || order.remark || '-'}</td>
-              <td>${formatCurrency(subtotal)}</td>
+              <td>${formatCurrency(fooi)}</td>
               <td>${formatCurrency(tot)}</td>
               <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
               <td>${isDelivery ? (order.delivery_time || order.deliveryTime || '-') : (order.pickup_time || order.pickupTime || '-')}</td>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -74,7 +74,7 @@ th:last-child {
        <th>Email</th>
        <th>Items</th>
        <th>Opmerking</th>
-       <th>Subtotaal</th>
+       <th>Fooi</th>
        <th>Totaal</th>
        <th>Adres</th>
        <th>Tijdslot</th>
@@ -100,8 +100,8 @@ th:last-child {
           </ul>
         </td>
        <td>{{ order.opmerking or '-' }}</td>
-       <td>€{{ '%.2f' % (order.total or 0) }}</td>
-        <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
+       <td>€{{ '%.2f' % (order.fooi or 0) }}</td>
+       <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
 
         <td>
           {% if is_delivery %}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1091,9 +1091,9 @@ function formatCurrency(value){
     if (order.id) tr.dataset.id = order.id;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-      let subtotal = parseFloat(order.subtotal);
-    if (isNaN(subtotal)) {
-      subtotal = Object.values(order.items || {}).reduce((s, i) => s + (parseFloat(i.price || 0) * parseInt(i.qty || 0)), 0);
+    let fooi = parseFloat(order.fooi);
+    if (isNaN(fooi)) {
+      fooi = 0;
     }
     if(!('totaal' in order)){
       console.warn('⚠️ totaal 字段缺失，请联系后端');
@@ -1121,7 +1121,7 @@ function formatCurrency(value){
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
-        <td>${subtotal.toFixed(2)}</td>
+        <td>${fooi.toFixed(2)}</td>
         <td>€${parseFloat(order.totaal).toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>


### PR DESCRIPTION
## Summary
- support `fooi` field in `Order`
- include `fooi` when creating an order and broadcasting order data
- output `fooi` in order list APIs
- rename **Subtotaal** column to **Fooi**
- display tip amounts in admin and POS tables

## Testing
- `python -m py_compile app.py`
- `python -m py_compile wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_68585c82fe04833390137a4c23255677