### PR TITLE
Update POS table to show tips

### DIFF
--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -74,7 +74,7 @@ th:last-child {
        <th>Email</th>
        <th>Items</th>
        <th>Opmerking</th>
-       <th>Subtotaal</th>
+       <th>Fooi</th>
        <th>Totaal</th>
        <th>Adres</th>
        <th>Tijdslot</th>
@@ -100,7 +100,7 @@ th:last-child {
           </ul>
         </td>
        <td>{{ order.opmerking or '-' }}</td>
-       <td>€{{ '%.2f' % (order.subtotal or 0) }}</td>   ← 正确显示 Subtotaal
+       <td>€{{ '%.2f' % (order.fooi or order.tip or 0) }}</td>
 
         <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
 

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1128,7 +1128,7 @@ function formatCurrency(value){
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
-        <td>${fooi.toFixed(2)}</td>
+        <td>€${parseFloat(fooi).toFixed(2)}</td>
         <td>€${parseFloat(order.totaal).toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>


### PR DESCRIPTION
## Summary
- rename Subtotaal column to **Fooi** in the orders table
- display `order.fooi` (tip) in that column formatted with euro sign
- show the tip with the same style when new orders are added on the POS page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858e793b550833388c714c94ec89470