### PR TITLE
Fix fooi showing 0 on new POS orders

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1113,7 +1113,7 @@ function formatCurrency(value){
     if (order.id) tr.dataset.id = order.id;
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
-    let fooi = parseFloat(order.fooi);
+    let fooi = parseFloat(order.fooi ?? order.tip);
     if (isNaN(fooi)) {
       fooi = 0;
     }


### PR DESCRIPTION
## Summary
- handle `order.tip` when rendering new orders in POS so the tip shows immediately

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f56517e08333abe6178c72383fc6