### PR TITLE
Implement new order UX improvements

### DIFF
--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -35,6 +35,16 @@
   th:last-child {
     padding-right: 20px;
   }
+
+  .type-bezorging {
+    color: red;
+    font-weight: bold;
+  }
+
+  .type-afhalen {
+    color: green;
+    font-weight: bold;
+  }
   
   table.orders-table {
     width: 100%;
@@ -88,7 +98,11 @@ th:last-child {
         <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
-        <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
+        <td>
+          <span class="{{ 'type-bezorging' if is_delivery else 'type-afhalen' }}">
+            {{ 'Bezorging' if is_delivery else 'Afhalen' }}
+          </span>
+        </td>
         <td>{{ order.customer_name or '' }}</td>
         <td>{{ order.phone or '' }}</td>
         <td>{{ order.email or '-' }}</td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -828,9 +828,18 @@ function toggleToday(){
   if(panel.classList.contains('visible')){
     fetchOrders();
     newOrderCount = 0;
+    hasNewOrder = false;
     updateTabTitle();
   }
   updateTodayBadge();
+}
+
+function showTodayOrders(){
+  const panel=document.getElementById('todayOrders');
+  if(!panel.classList.contains('visible')){
+    panel.classList.add('visible');
+    fetchOrders();
+  }
 }
 
 function toggleAddress(){
@@ -1090,13 +1099,19 @@ function formatCurrency(value){
 
   let pollTimer;
   const baseTitle = document.title;
-  let newOrderCount = 0;
+  let newOrderCount = 0; // unseen orders for title
+  let hasNewOrder = false;
   function updateTabTitle(){
     document.title = newOrderCount ? `${baseTitle} (${newOrderCount})` : baseTitle;
   }
+  function getOrderCount(){
+    const tbody = document.querySelector('.orders-panel tbody');
+    return tbody ? tbody.children.length : 0;
+  }
   function updateTodayBadge(){
+    const count = getOrderCount();
     document.querySelectorAll('.today-badge').forEach(badge => {
-      badge.textContent = newOrderCount > 0 ? newOrderCount : '';
+      badge.textContent = hasNewOrder ? 'New' : count;
     });
   }
 
@@ -1194,20 +1209,25 @@ function formatCurrency(value){
       setTimeout(()=>tr.classList.remove('new-order'),10000);
     }
     insertSorted(tbody, tr);
+    updateTodayBadge();
+    return tr;
   }
 
   // Socket 监听新订单
   socket.on('new_order', order => {
   console.log('🆕 Nieuwe bestelling ontvangen!', order);
   beep();
-  alert('Nieuwe bestelling ontvangen!');
-  addRow(order, true);
-  
-  // ✅ 修改这里，不再重置
-  newOrderCount++;
-
-  updateTabTitle();
+  hasNewOrder = true;
+  const row = addRow(order, true);
   updateTodayBadge();
+  newOrderCount++;
+  updateTabTitle();
+  if(confirm('Nieuwe bestelling ontvangen!')){
+    showTodayOrders();
+    if(row) row.scrollIntoView({behavior:'smooth', block:'center'});
+    hasNewOrder = false;
+    updateTodayBadge();
+  }
 });
 
   // 断线后启用轮询
@@ -1234,6 +1254,7 @@ function formatCurrency(value){
       if (!tbody) return;
       tbody.innerHTML = '';
       data.sort((a,b)=>getSortKey(a)-getSortKey(b)).forEach(o=>addRow(o));
+      updateTodayBadge();
     }).catch(() => {});
  }
 
@@ -1252,7 +1273,7 @@ function formatCurrency(value){
   }
 
   window.addEventListener('beforeunload', () => socket.disconnect());
-  window.addEventListener('focus', () => { newOrderCount = 0; updateTabTitle(); updateTodayBadge(); });
+  window.addEventListener('focus', () => { newOrderCount = 0; hasNewOrder = false; updateTabTitle(); updateTodayBadge(); });
 </script>
 
 

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -20,6 +20,9 @@ th:last-child {
   padding-right: 20px;
 }
 
+.type-bezorging { color: red; font-weight: bold; }
+.type-afhalen { color: green; font-weight: bold; }
+
 /* 新订单动画效果 */
 .new-order {
   animation: highlightBlink 1s ease-in-out;
@@ -60,7 +63,7 @@ th:last-child {
       <td>{{ order.order_number or '' }}</td>
       
       {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
-      <td>{{ 'Bezorgen' if is_delivery else 'Afhalen' }}</td>
+      <td><span class="{{ 'type-bezorging' if is_delivery else 'type-afhalen' }}">{{ 'Bezorging' if is_delivery else 'Afhalen' }}</span></td>
 
       <td>{{ order.customer_name or '' }}</td>
       <td>{{ order.phone or '' }}</td>
@@ -224,6 +227,7 @@ function insertSorted(tbody,tr){
     beep();
   }
   insertSorted(tbody, tr);
+  return tr;
 }
 
     socket.on('new_order', order => {
@@ -231,7 +235,10 @@ function insertSorted(tbody,tr){
       if(!('totaal' in order) && !('total' in order)){
         console.warn('⚠️ totaal 字段缺失，请联系后端');
       }
-      addRow(order, true);
+      const row = addRow(order, true);
+      if(confirm('Nieuwe bestelling ontvangen!')){
+        if(row) row.scrollIntoView({behavior:'smooth', block:'center'});
+      }
     });
 
     function fetchOrders(){


### PR DESCRIPTION
## Summary
- highlight order type in order tables
- show badge text 'New' until confirmation and scroll to row on confirm
- auto-open order list when confirming new order
- add popup+scroll to POS orders page

## Testing
- `python -m py_compile app.py`
- `python -m py_compile wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_685903353058833391a37393aa23c28b