### PR TITLE
Fix mobile order type slider style

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -940,6 +940,7 @@ input:focus, select:focus, textarea:focus {
   width: 100%;
   height: 100%;
   padding: 0 8px;
+  box-sizing: border-box;
 }
 .order-type-button {
   position: absolute;
@@ -952,6 +953,7 @@ input:focus, select:focus, textarea:focus {
   background-color: var(--accent-color);
   color: #fff;
   font-weight: 600;
+  font-size: 0.85rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -960,7 +962,7 @@ input:focus, select:focus, textarea:focus {
 }
 .order-type-text {
   position: absolute;
-  right: 12px;
+  right: 4px;
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none;
@@ -988,9 +990,9 @@ input:focus, select:focus, textarea:focus {
   }
 }
 .order-type-text {
-  font-size: 13px; /* ✅ 改成你想要的大小 */
-  font-weight: 500; /* ✅ 建议加粗 */
- /* ✅ 防止文字换行被压缩 */
+  font-size: 12px; /* slightly smaller text */
+  font-weight: 500; /* keep bold */
+  /* prevent text wrapping */
 }
 
 


### PR DESCRIPTION
## Summary
- keep slider padding symmetrical by accounting for padding in `.order-type-track`
- reduce font size for order type slider text and button for better fit
- nudge delivery text right so it no longer overlaps slider

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859c865aed88333b03c000aade2ece6