### PR TITLE
Fix mobile order-type slider text position

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -940,6 +940,7 @@ input:focus, select:focus, textarea:focus {
   width: 100%;
   height: 100%;
   padding: 0 8px;
+  box-sizing: border-box;
 }
 .order-type-button {
   position: absolute;
@@ -952,6 +953,7 @@ input:focus, select:focus, textarea:focus {
   background-color: var(--accent-color);
   color: #fff;
   font-weight: 600;
+  font-size: 0.85rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -960,7 +962,7 @@ input:focus, select:focus, textarea:focus {
 }
 .order-type-text {
   position: absolute;
-  right: 12px;
+  right: 4px;
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none;
@@ -981,6 +983,10 @@ input:focus, select:focus, textarea:focus {
   -webkit-text-fill-color: transparent;
   animation: shine 4s linear infinite;
 }
+.order-type-text.left {
+  left: 12px;
+  right: auto;
+}
 
 @keyframes spin {
   to {
@@ -988,9 +994,9 @@ input:focus, select:focus, textarea:focus {
   }
 }
 .order-type-text {
-  font-size: 13px; /* ✅ 改成你想要的大小 */
-  font-weight: 500; /* ✅ 建议加粗 */
- /* ✅ 防止文字换行被压缩 */
+  font-size: 12px; /* slightly smaller text */
+  font-weight: 500; /* keep bold */
+  /* prevent text wrapping */
 }
 
 
@@ -2615,9 +2621,15 @@ window.addEventListener('DOMContentLoaded', () => {
     if (orderType === 'afhalen') {
       button.innerText = 'Pick Up';
       text.innerText = 'Slide to Deliver';
+      text.classList.remove('left');
+      text.style.right = '4px';
+      text.style.left = 'auto';
     } else {
       button.innerText = 'Deliver';
       text.innerText = 'Slide to Pick Up';
+      text.classList.add('left');
+      text.style.left = '12px';
+      text.style.right = 'auto';
     }
   }
 
@@ -2673,14 +2685,12 @@ window.addEventListener('DOMContentLoaded', () => {
     if (movedRatio > 0.5) {
       // 推到右边
       setLeftPosition(maxSlide);
-      button.innerText = 'Deliver';
-      text.innerText = 'Slide to Pick Up';
+      updateTexts('bezorgen');
       bezorgen.checked = true;
     } else {
       // 回到左边
       setLeftPosition(0);
-      button.innerText = 'Pick Up';
-      text.innerText = 'Slide to Deliver';
+      updateTexts('afhalen');
       afhalen.checked = true;
     }
 
@@ -2824,86 +2834,3 @@ sliderTrack.addEventListener('touchmove', (e) => {
 
 </body>
 </html>
-
-<script>
-window.addEventListener('DOMContentLoaded', () => {
-  const track = document.getElementById('typeSliderTrack');
-  const button = document.getElementById('typeSliderButton');
-  const text = document.getElementById('typeSliderText');
-  const afhalen = document.getElementById('afhalen');
-  const bezorgen = document.getElementById('bezorgen');
-  if (!track || !button || !text) return;
-
-  const getPad = (el) => {
-    const s = window.getComputedStyle(el);
-    return {
-      left: parseInt(s.paddingLeft) || 0,
-      right: parseInt(s.paddingRight) || 0,
-    };
-  };
-
-  const getMax = () => {
-    const p = getPad(track);
-    return track.offsetWidth - button.offsetWidth - p.left - p.right;
-  };
-
-  const moveSlider = (isDeliver) => {
-    const p = getPad(track);
-    const max = getMax();
-    if (isDeliver) {
-      button.style.left = `${p.left + max}px`;
-      button.textContent = 'Deliver';
-      text.textContent = 'Slide to Pick Up';
-      text.style.left = '12px';
-    } else {
-      button.style.left = `${p.left}px`;
-      button.textContent = 'Pick Up';
-      text.textContent = 'Slide to Deliver';
-      text.style.left = 'calc(100% - 140px)';
-    }
-  };
-
-  if (bezorgen.checked) {
-    moveSlider(true);
-  } else {
-    moveSlider(false);
-  }
-
-  afhalen.addEventListener('change', () => moveSlider(false));
-  bezorgen.addEventListener('change', () => moveSlider(true));
-
-  let sliding = false;
-  let startX = 0;
-  let initialLeft = 0;
-
-  button.addEventListener('touchstart', (e) => {
-    sliding = true;
-    startX = e.touches[0].clientX;
-    initialLeft = parseInt(button.style.left) || getPad(track).left;
-  });
-
-  track.addEventListener('touchmove', (e) => {
-    if (!sliding) return;
-    const p = getPad(track);
-    const max = getMax();
-    const delta = e.touches[0].clientX - startX;
-    const moveX = Math.max(0, Math.min(initialLeft + delta - p.left, max));
-    button.style.left = `${p.left + moveX}px`;
-  });
-
-  track.addEventListener('touchend', () => {
-    sliding = false;
-    const p = getPad(track);
-    const max = getMax();
-    const currentLeft = parseInt(button.style.left || '0') - p.left;
-    if (currentLeft > max / 2) {
-      bezorgen.checked = true;
-      moveSlider(true);
-    } else {
-      afhalen.checked = true;
-      moveSlider(false);
-    }
-    toggleOrderType();
-  });
-});
-</script>


### PR DESCRIPTION
## Summary
- ensure mobile order type text swaps sides when sliding

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859c865aed88333b03c000aade2ece6