### PR TITLE
Add basic management dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Mijn Nova Asia</title>
+<h1>Mijn Nova Asia</h1>
+<form method="post" action="{{ url_for('update_setting') }}">
+  <label>营业状态:</label>
+  <select name="is_open">
+    <option value="true" {% if is_open == 'true' %}selected{% endif %}>营业</option>
+    <option value="false" {% if is_open == 'false' %}selected{% endif %}>暂停接单</option>
+  </select>
+  <button type="submit">保存</button>
+</form>
+<p><a href="{{ url_for('logout') }}">Logout</a></p>
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1003,6 +1003,7 @@ input:focus, select:focus, textarea:focus {
 
 </head>
 <body>
+<div id="status-banner"></div>
 <div class="feedback" id="feedback"></div>
 <div class="navbar-container" id="navbar-container">
 <nav class="navbar" id="navbar">
@@ -2818,6 +2819,28 @@ sliderTrack.addEventListener('touchmove', (e) => {
     document.getElementById('afhalen').addEventListener('change', scheduleHide);
     document.getElementById('bezorgen').addEventListener('change', scheduleHide);
   })();
+</script>
+<script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+<script>
+function updateStatus(val){
+  const banner = document.getElementById('status-banner');
+  if(val === 'false'){
+    banner.textContent = '暂不接单';
+    banner.style.display = 'block';
+  }else{
+    banner.textContent = '';
+    banner.style.display = 'none';
+  }
+}
+function fetchStatus(){
+  fetch('/api/settings/is_open')
+    .then(r => r.json())
+    .then(d => updateStatus(d.is_open));
+}
+fetchStatus();
+setInterval(fetchStatus, 30000);
+const socket = io();
+socket.on('setting_update', d => { if(d.key === 'is_open'){ updateStatus(d.value); }});
 </script>
 
 


### PR DESCRIPTION
## Summary
- add `Setting` model with DB initialization
- create `/dashboard` page to manage open status
- expose `/api/settings/<key>` endpoint for reading settings
- update index page to display banner and update via Socket.IO

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a91665b4c8333aa33ab29ae199c1e