### PR TITLE
Handle discount code on order submission

### DIFF
--- a/app.py
+++ b/app.py
@@ -337,6 +337,24 @@ def api_orders():
         db.session.add(order)
         db.session.commit()
 
+        # 4. 如有折扣码，记录到 discount_codes 表
+        discount_code = data.get("discount_code") or data.get("discountCode")
+        customer_email = (
+            data.get("customer_email")
+            or data.get("customerEmail")
+            or order.email
+        )
+        if discount_code and customer_email:
+            disc = DiscountCode(
+                code=discount_code,
+                customer_email=customer_email,
+                discount_percentage=3.0,
+                is_used=False,
+            )
+            db.session.add(disc)
+            db.session.commit()
+            print(f"✅ 折扣码保存成功: {discount_code} for {customer_email}")
+
        
 
         print("✅ 接收到订单:", data)
@@ -362,23 +380,6 @@ def submit_order():
     return api_orders()
 
 
-@app.route("/api/discounts", methods=["POST"])
-def create_discount():
-    try:
-        data = request.get_json()
-        code = data.get("code")
-        email = data.get("customer_email")
-
-        if not code or not email:
-            return jsonify({"error": "Missing code or customer_email"}), 400
-
-        disc = DiscountCode(code=code, customer_email=email, discount_percentage=3.0)
-        db.session.add(disc)
-        db.session.commit()
-
-        return jsonify({"status": "success"}), 200
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/api/discounts/validate", methods=["POST"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -2228,7 +2228,7 @@ function checkout() {
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
-   fetch('https://flask-order-api.onrender.com/submit_order', {
+   fetch('/api/orders', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1025,7 +1025,7 @@ function submitOrder() {
   };
 
   // ✅ 提交到后端
-  fetch('https://flask-order-api.onrender.com/submit_order', {
+  fetch('/api/orders', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- store discount code info when an order is submitted
- remove unused `/api/discounts` route
- submit orders to `/api/orders` in frontend templates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685d4c6b78348333801e4499b8abd8c2