### PR TITLE
Fix discount validation double submit

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1144,7 +1144,7 @@ input:focus, select:focus, textarea:focus {
 <div class="price-row" id="deliveryRow"><span>Bezorgkosten:</span> <span id="deliveryDisplay">€2,50</span></div>
 <div class="price-row"><label for="discountCode">Kortingscode:</label>
   <input id="discountCode" />
-  <button id="validateDiscountBtn" class="apply-discount-btn" type="button" onclick="applyDiscount()">Apply</button>
+  <button id="validateDiscountBtn" class="apply-discount-btn" type="button">Apply</button>
 </div>
 <div class="price-row" id="discountRow" style="display:none;"><span>Korting:</span> <span id="discountDisplay">- €0,00</span></div>
 <div class="price-row"><span></span> <span id=""> </span></div>


### PR DESCRIPTION
## Summary
- remove inline onclick handler from discount button to avoid double validation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d7ecc09cc83339ad6f9420b7963ee