### PR TITLE
Include discount info in orders

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2228,7 +2228,9 @@ function checkout() {
     tipLine = `\nFooi: €${tip.toFixed(2)}`;
   }
 
-  const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}${tipLine}\nTotaal: €${totalPrice}`;
+  const discountCode = document.getElementById('discountCode').value.trim();
+  const discountLine = `\nKorting: -€${currentDiscount.toFixed(2)} (Code: ${discountCode || 'geen'})`;
+  const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}${tipLine}${discountLine}\nTotaal: €${totalPrice}`;
 
   const itemsToSend = { ...cart };
   Object.keys(extras).forEach(id => {


### PR DESCRIPTION
## Summary
- show discount line in the order message on the main page so that recent korting and code are recorded

## Testing
- `python -m py_compile app.py`
- `python -m py_compile wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_685d850fed808333b5d8ff9bcf7641bd