### PR TITLE
Freeze POS checkout area

### DIFF
--- a/templates/pos.html
+++ b/templates/pos.html
@@ -182,27 +182,6 @@
   border: 1px solid rgba(0, 0, 0, 0.06);
 }
 
- .checkout-panel button {
-  background: linear-gradient(to bottom, #d8f4e7, #a9e5cd);
-  color: #1a2e28;
-  font-weight: 600;
-  padding: 12px;
-  width: 100%;
-  font-size: 1.1rem;
-  border: none;
-  border-radius: 14px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12),
-              inset 0 1px 0 rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(6px);
-  transition: all 0.2s ease-in-out;
-  cursor: pointer;
-}
-  
-  .checkout-panel button:hover {
-    background: linear-gradient(to bottom, #b2eadd, #86dcc3);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2),
-              inset 0 1px 0 rgba(255, 255, 255, 0.5);
-  }
 
   .order-type-switch {
     display: flex;
@@ -279,7 +258,7 @@
     cursor:pointer;
   }
   #closeToday:hover { background:#e0e0e0; }
-  .cart-area {
+  .cart-items {
     background: linear-gradient(to bottom right, #fdfaf6, #f0e6d7);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
     border: 1px solid rgba(0, 0, 0, 0.06);
@@ -288,9 +267,34 @@
     border-radius: 16px;
     padding: 20px;
     margin-bottom:20px;
-    position: sticky;
-    top: 70px;
+    flex: 1;
+    overflow-y: auto;
   }
+
+  .checkout-area {
+    background: linear-gradient(to bottom, #fdfaf6, #f0e6d7);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.08);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 16px;
+    padding: 20px;
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+  }
+
+  .checkout-area button {
+    width:100%;
+    margin-top:10px;
+    padding:12px;
+    font-size:1.1rem;
+    background:#b3d4ff;
+    color:#333;
+    border:none;
+    border-radius:12px;
+    transition: background 0.3s ease;
+  }
+
+  .checkout-area button:hover { background:#a3c8ff; }
   .supply-row {
     display:flex;
     align-items:center;
@@ -311,18 +315,6 @@
     .side-tools { flex:0 0 180px; }
     .center-area { flex:2; margin-right:20px; }
   }
-  .cart-area button {
-    width:100%;
-    margin-top:10px;
-    padding:12px;
-    font-size:1.1rem;
-    background:#b3d4ff;
-    color:#333;
-    border:none;
-    border-radius:12px;
-    transition: background 0.3s ease;
-  }
-  .cart-area button:hover { background:#a3c8ff; }
   .hidden { display:none; }
 @media (min-width: 768px) {
   .pos-layout {
@@ -347,6 +339,10 @@
     align-self: flex-start;
     flex: 1.4;
     max-width: 420px;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 80px);
+    overflow: hidden;
   }
   .close-btn { display:none; }
   .cart-toggle {
@@ -428,11 +424,11 @@
   }
   @media (max-width: 768px) {
     .cart-toggle { display: block; }
-  
+
     .cart-panel {
       position: fixed;
       inset: 0;
-      overflow-y: auto;
+      overflow: hidden;
       background: rgba(255,255,255,0.95);
       padding: 20px;
       z-index: 1050;
@@ -440,7 +436,12 @@
     }
     .cart-panel.open { display: block; }
     .close-btn { display: block; }
-    .cart-panel .cart-area { position: static; top: auto; }
+    .cart-panel .cart-items {
+      position: static;
+      top: auto;
+      flex: 1;
+      overflow-y: auto;
+    }
     .pos-layout { flex-direction: column; align-items: center; }
     .center-area { width:100%; margin-right:0; }
   }
@@ -510,41 +511,9 @@
   </div>
   <div id="cartPanel" class="cart-panel">
     <button id="closeCartPanel" class="close-btn">×</button>
-    <div class="cart-area">
+    <div class="cart-items">
       <h2>Overzicht</h2>
       <ul id="cart"></ul>
-      <div class="supply-row">
-        <label for="chopstickCount">Aantal stokjes</label>
-        <select id="chopstickCount" class="supply-select"></select>
-      </div>
-      <div class="supply-row">
-        <label for="soyCount">Aantal sojasaus flesjes</label>
-        <select id="soyCount" class="supply-select"></select>
-      </div>
-      <div class="supply-row">
-        <label for="gemberCount">Aantal gember porties</label>
-        <select id="gemberCount" class="supply-select"></select>
-      </div>
-      <div class="supply-row">
-        <label for="wasabiCount">Aantal wasabi flesjes</label>
-        <select id="wasabiCount" class="supply-select"></select>
-      </div>
-      <div>Subtotaal: <span id="summarySubtotal">€0,00</span></div>
-      <div>Verpakkingskosten: <span id="summaryPackaging">€0,00</span></div>
-      <div id="summaryDeliveryRow" class="hidden">Bezorgkosten: <span id="summaryDelivery">€0,00</span></div>
-      <div>
-        Korting:
-        <select id="discountType">
-          <option value="amount">€</option>
-          <option value="percent">%</option>
-        </select>
-        <input id="discountValue" type="number" value="0" min="0" step="0.01" />
-        <span id="summaryDiscount">€0,00</span>
-      </div>
-      <div>BTW (9%): <span id="summaryBtw">€0,00</span></div>
-      <div><strong>Totaal: <span id="total">€0,00</span></strong></div>
-      <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
-      <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
     </div>
     <div class="checkout-panel">
       <section id="customer-info">
@@ -599,6 +568,40 @@
         </div>
         </div>
       </section>
+    </div>
+    <div class="checkout-area">
+      <div class="supply-row">
+        <label for="chopstickCount">Aantal stokjes</label>
+        <select id="chopstickCount" class="supply-select"></select>
+      </div>
+      <div class="supply-row">
+        <label for="soyCount">Aantal sojasaus flesjes</label>
+        <select id="soyCount" class="supply-select"></select>
+      </div>
+      <div class="supply-row">
+        <label for="gemberCount">Aantal gember porties</label>
+        <select id="gemberCount" class="supply-select"></select>
+      </div>
+      <div class="supply-row">
+        <label for="wasabiCount">Aantal wasabi flesjes</label>
+        <select id="wasabiCount" class="supply-select"></select>
+      </div>
+      <label for="remark" style="display:block;margin-top:10px;">Opmerking:</label>
+      <textarea id="remark" rows="2" placeholder="Bijv. geen komkomer, extra mayo"></textarea>
+      <div>Subtotaal: <span id="summarySubtotal">€0,00</span></div>
+      <div>Verpakkingskosten: <span id="summaryPackaging">€0,00</span></div>
+      <div id="summaryDeliveryRow" class="hidden">Bezorgkosten: <span id="summaryDelivery">€0,00</span></div>
+      <div>
+        Korting:
+        <select id="discountType">
+          <option value="amount">€</option>
+          <option value="percent">%</option>
+        </select>
+        <input id="discountValue" type="number" value="0" min="0" step="0.01" />
+        <span id="summaryDiscount">€0,00</span>
+      </div>
+      <div>BTW (9%): <span id="summaryBtw">€0,00</span></div>
+      <div><strong>Totaal: <span id="total">€0,00</span></strong></div>
       <button id="submitOrder">Submit Order</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- restructure cart markup so Extras and remark sit above totals
- fix checkout button and summary in `.checkout-area` and keep at bottom
- make only the cart list scrollable

## Testing
- `pytest -q`
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_685dac07e5b08333ab29429fe9fb7065