### PR TITLE
Update menu item layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -149,7 +149,8 @@
     overflow: hidden;
     border-radius: 16px;
     margin: 10px auto;
-    max-width: 280px;
+    width: 100%;
+    max-width: none;
   }
 
   img {


### PR DESCRIPTION
## Summary
- enlarge menu images on index page by allowing `.menu-item` elements to stretch to the container width

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e47c33dcc83339e28e7b20466f16d