### PR TITLE
Fix mobile checkout centering

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -303,7 +303,6 @@ button:active {
 
 
 .cart-section.mobile-visible {
-  right: 0 !important;
   display: block !important;
 }
 
@@ -352,21 +351,22 @@ button:active {
   }
 
   .cart-section.mobile-visible {
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: 100%;
-  height: 100vh;
-  background: var(--off-white);
-  border-radius: 16px 0 0 16px;
-  padding: 20px;
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.2);
-  display: flex;
-  flex-direction: column;
-  /* Allow internal scrolling on mobile */
-  overflow-y: auto;
-  transition: right 0.3s ease-in-out;
-  z-index: 1000;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90%;
+    max-width: 420px;
+    max-height: 90vh;
+    background: var(--off-white);
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    /* Allow internal scrolling on mobile */
+    overflow-y: auto;
+    z-index: 1000;
   }
 
   .cart-items,


### PR DESCRIPTION
## Summary
- center cart checkout overlay on small screens

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_685e502da9f08333a3bd9682d2eab5e7