### PR TITLE
Adjust mobile checkout overlay

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -352,14 +352,17 @@ button:active {
 
   .cart-section.mobile-visible {
     position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 90%;
-    max-width: 420px;
-    max-height: 90vh;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100vh;
+    max-width: none;
+    max-height: none;
+    transform: none;
     background: var(--off-white);
-    border-radius: 16px;
+    border-radius: 0;
     padding: 20px;
     box-shadow: 0 0 12px rgba(0, 0, 0, 0.2);
     display: flex;


### PR DESCRIPTION
## Summary
- extend the mobile checkout panel to use the full viewport

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e632936388333ac03556c6c872ec2