### PR TITLE
Center cart panels on mobile

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -377,6 +377,9 @@ button:active {
     width: 100%;
     margin: 0 auto;
     font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   .slider-container {


### PR DESCRIPTION
## Summary
- center `.cart-items` and `.cart-summary` inside the mobile cart section

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_685e6b6a5cc08333be89f41b5777830f