### PR TITLE
Center cart panels on mobile

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -372,11 +372,22 @@ button:active {
     z-index: 1000;
   }
 
-  .cart-items,
-  .cart-summary {
+  .cart-items {
     width: 100%;
     margin: 0 auto;
     font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .cart-summary {
+    width: 100%;
+    margin: 20px 0 0 -20px;
+    font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .slider-container {


### PR DESCRIPTION
## Summary
- center `.cart-items` inside the mobile cart section
- move `.cart-summary` slightly left and down on mobile

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_685e6b6a5cc08333be89f41b5777830f