### PR TITLE
Position close button on mobile summary

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -338,6 +338,13 @@ button:active {
   border-bottom-left-radius: 16px;
   margin-top: 0px;
   padding: 16px 36px;
+  position: relative; /* allow absolute children like the close button */
+}
+
+/* Position close button inside summary on mobile */
+.cart-section.mobile-visible .cart-summary #closeCartBtn {
+  top: 16px;
+  right: 16px;
 }
 
 


### PR DESCRIPTION
## Summary
- adjust mobile CSS so the close button sits in the `cart-summary`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ec0872ca48333a35c5bd4a10033fa