### PR TITLE
Refine checkout slider colors

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -490,9 +490,9 @@ button:active {
   cursor: pointer;
   z-index: 999;
   box-shadow:
-    inset 0 1px 1px rgba(255, 255, 255, 0.4),
-    0 4px 8px rgba(10, 132, 255, 0.35),
-    0 6px 20px rgba(10, 132, 255, 0.2);
+    inset 0 2px 4px rgba(255, 255, 255, 0.6),
+    0 4px 8px rgba(0, 0, 0, 0.2),
+    0 6px 12px rgba(0, 0, 0, 0.1);
 
   
 }
@@ -981,7 +981,10 @@ input:focus, select:focus, textarea:focus {
   margin-left: -20px;
   height: 100%;
   border-radius: 32px;
-  background-color:linear-gradient(to right, rgba(10,132,255,0.15), rgba(255,255,255,0.05));
+  background: var(--off-white);
+  box-shadow:
+    inset 0 1px 2px rgba(255, 255, 255, 0.6),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.08);
   padding: 0 20px;
   display: flex;
   align-items: center;
@@ -991,7 +994,7 @@ input:focus, select:focus, textarea:focus {
 .slider-button {
   width: 60px;
   height: 60px;
-  background: linear-gradient(145deg, var(--accent-gradient-start), var(--accent-gradient-end));
+  background: var(--off-white);
   border-radius: 50%;
   position: absolute;
   left: 0px;
@@ -1000,9 +1003,9 @@ input:focus, select:focus, textarea:focus {
   z-index: 10;
   transition: left 0.3s ease, box-shadow 0.3s ease;
   box-shadow:
-    inset 0 1px 1px rgba(255, 255, 255, 0.4),
-    0 4px 8px rgba(10, 132, 255, 0.35),
-    0 6px 20px rgba(10, 132, 255, 0.2);
+    0 4px 8px rgba(0, 0, 0, 0.2),
+    0 6px 12px rgba(0, 0, 0, 0.1),
+    inset 0 2px 4px rgba(255, 255, 255, 0.6);
 
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- adjust slider track and button color to `var(--off-white)` for iOS style
- add subtle inner shadows for depth

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ffd871188833395d84db04f87896a