### PR TITLE
Enhance mobile menu image sizing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -179,6 +179,18 @@
     object-fit: cover;
   }
 
+  /* Adjust menu image on mobile to show more text without cropping */
+  @media (max-width: 600px) {
+    .menu-item {
+      width: 95%;
+      aspect-ratio: 4 / 3;
+    }
+
+    .menu-item img {
+      object-fit: contain;
+    }
+  }
+
   img.supply-img {
     width: 32px;
     height: 32px;


### PR DESCRIPTION
## Summary
- enlarge menu images for mobile to allow more text space
- ensure images stay clear using `object-fit: contain`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860501f49d483338748db00196c4c9e