### PR TITLE
Update order validation logic

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3117,11 +3117,44 @@ function getMaxSlide() {
   return trackWidth - buttonWidth - padding.left - padding.right;
 }
 
+function resetSlider() {
+  const padding = getHorizontalPadding(sliderTrack);
+  sliderButton.style.left = `${padding.left}px`;
+  sliderButton.innerHTML = '<img src="cart-icon.svg" class="cart-icon" />';
+  sliderText.innerText = 'Schuif om te bestellen';
+  sliderTrack.style.pointerEvents = 'auto';
+}
+
+function validateOrderAmount() {
+  const orderType = document.querySelector('input[name="orderType"]:checked').value;
+  const tip = parseFloat(document.getElementById('tipSelect').value || '0');
+  const amount = currentSubtotal + currentPackaging + tip; // excl. bezorgkosten en korting
+
+  if (orderType === 'bezorgen' && amount < 20) {
+    resetSlider();
+    alert('Sorry, de minimum bezorgbedrag is 20 euro.');
+    window.location.href = '/';
+    return false;
+  }
+
+  if (orderType === 'afhalen' && amount === 0) {
+    resetSlider();
+    alert('Sorry, u heeft nog niks gekozen.');
+    window.location.href = '/';
+    return false;
+  }
+
+  return true;
+}
+
 
 
 
 function triggerCheckout() {
   if (isSubmitting) return;
+  if (!validateOrderAmount()) {
+    return;
+  }
   isSubmitting = true;
 
   const padding = getHorizontalPadding(sliderTrack);


### PR DESCRIPTION
## Summary
- add order amount validation before checkout
- reset slide button when order amount too small
- alert and redirect on insufficient amount

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686108d676c08333ab9cdfd511631ffd