### PR TITLE
Improve mobile order flow

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1934,6 +1934,45 @@ let currentSubtotal = 0;
 let finalTotal = 0;
 let currentDiscount = 0;
 
+function saveCart() {
+  sessionStorage.setItem('novaCart', JSON.stringify(cart));
+}
+
+function loadCart() {
+  const stored = sessionStorage.getItem('novaCart');
+  if (stored) {
+    const data = JSON.parse(stored);
+    Object.keys(data).forEach(k => { cart[k] = data[k]; });
+  }
+}
+
+function saveFormData() {
+  const data = {};
+  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select').forEach(el => {
+    if (el.id) data[el.id] = el.value;
+  });
+  const type = document.querySelector('input[name="orderType"]:checked');
+  if (type) data.orderType = type.value;
+  sessionStorage.setItem('novaForm', JSON.stringify(data));
+}
+
+function loadFormData() {
+  const stored = sessionStorage.getItem('novaForm');
+  if (!stored) return;
+  const data = JSON.parse(stored);
+  Object.keys(data).forEach(k => {
+    if (k === 'orderType') return;
+    const el = document.getElementById(k);
+    if (el) el.value = data[k];
+  });
+  if (data.orderType === 'bezorgen') {
+    document.getElementById('bezorgen').checked = true;
+  } else if (data.orderType === 'afhalen') {
+    document.getElementById('afhalen').checked = true;
+  }
+  toggleOrderType();
+}
+
 function formatEuro(val) {
   return `€${val.toFixed(2).replace('.', ',')}`;
 }
@@ -2197,6 +2236,7 @@ function setQty(name, price, qty, packaging = DEFAULT_PACKAGING_FEE, prefs = nul
     else if (cart[name] && cart[name].prefs) delete cart[name].prefs;
   }
   updateCart();
+  saveCart();
 }
 
 function updateCart() {
@@ -2293,7 +2333,17 @@ function updateCart() {
   const badge = document.getElementById('cart-count');
   badge.textContent = totalQty;
   badge.style.display = totalQty > 0 ? 'inline-block' : 'none';
+  saveCart();
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadCart();
+  loadFormData();
+  updateCart();
+  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, input[name="orderType"]').forEach(el => {
+    el.addEventListener('change', saveFormData);
+  });
+});
 
 document.addEventListener('DOMContentLoaded', () => {
   const bubbleSel = document.getElementById("bubbleTeaQty");
@@ -3127,13 +3177,23 @@ function resetSlider() {
 
 function validateOrderAmount() {
   const orderType = document.querySelector('input[name="orderType"]:checked').value;
-  const tip = parseFloat(document.getElementById('tipSelect').value || '0');
+  const amount = finalTotal;
 
+  if (orderType === 'bezorgen' && amount < 20) {
+    resetSlider();
+    isSubmitting = false;
+    alert('Sorry, de minimum bezorgbedrag is 20 euro.');
+    saveFormData();
+    window.location.href = '/';
     return false;
   }
 
   if (orderType === 'afhalen' && amount === 0) {
-
+    resetSlider();
+    isSubmitting = false;
+    alert('Sorry, u heeft nog niks gekozen.');
+    saveFormData();
+    window.location.href = '/';
     return false;
   }
 


### PR DESCRIPTION
## Summary
- persist cart in sessionStorage
- restore cart on page load
- reset cart slider on invalid amount and show messages
- preserve order form values between redirects

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68611437ab6883338fbfa40b74f3d427