### PR TITLE
Adjust ramen menu interaction

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1670,7 +1670,7 @@ input:focus, select:focus, textarea:focus {
       <img alt="Ebi Furai Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Ebi Furai Ramen</h3>
+      <h3>Ebi Furai</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="ebiBase">
@@ -1686,12 +1686,12 @@ input:focus, select:focus, textarea:focus {
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="ebiNew">New Set</button>
       <div class="qty-box">
         <label for="ebiQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="ebiQty" type="button">-</button>
         <select id="ebiQty"></select>
         <button class="qty-plus add-button" data-target="ebiQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="ebiNew">New Set</button>
       </div>
     </div>
   </div>
@@ -1701,7 +1701,7 @@ input:focus, select:focus, textarea:focus {
       <img alt="Chicken Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Chicken Ramen</h3>
+      <h3>Chicken</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="chickenBase">
@@ -1717,12 +1717,12 @@ input:focus, select:focus, textarea:focus {
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="chickenNew">New Set</button>
       <div class="qty-box">
         <label for="chickenQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="chickenQty" type="button">-</button>
         <select id="chickenQty"></select>
         <button class="qty-plus add-button" data-target="chickenQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="chickenNew">New Set</button>
       </div>
     </div>
   </div>
@@ -1732,7 +1732,7 @@ input:focus, select:focus, textarea:focus {
       <img alt="Beef Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Beef Ramen</h3>
+      <h3>Beef</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="beefBase">
@@ -1748,12 +1748,12 @@ input:focus, select:focus, textarea:focus {
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="beefNew">New Set</button>
       <div class="qty-box">
         <label for="beefQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="beefQty" type="button">-</button>
         <select id="beefQty"></select>
         <button class="qty-plus add-button" data-target="beefQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="beefNew">New Set</button>
       </div>
     </div>
   </div>
@@ -1763,7 +1763,7 @@ input:focus, select:focus, textarea:focus {
       <img alt="Ribeye Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Ribeye Ramen</h3>
+      <h3>Ribeye</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="ribeyeBase">
@@ -1779,12 +1779,12 @@ input:focus, select:focus, textarea:focus {
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="ribeyeNew">New Set</button>
       <div class="qty-box">
         <label for="ribeyeQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="ribeyeQty" type="button">-</button>
         <select id="ribeyeQty"></select>
         <button class="qty-plus add-button" data-target="ribeyeQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="ribeyeNew">New Set</button>
       </div>
     </div>
   </div>
@@ -1794,7 +1794,7 @@ input:focus, select:focus, textarea:focus {
       <img alt="Chasiu Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Chasiu Ramen</h3>
+      <h3>Chasiu</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="chasiuBase">
@@ -1810,12 +1810,12 @@ input:focus, select:focus, textarea:focus {
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="chasiuNew">New Set</button>
       <div class="qty-box">
         <label for="chasiuQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="chasiuQty" type="button">-</button>
         <select id="chasiuQty"></select>
         <button class="qty-plus add-button" data-target="chasiuQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="chasiuNew">New Set</button>
       </div>
     </div>
   </div>
@@ -2448,13 +2448,7 @@ function isRamenValid(code) {
 }
 
 function updateRamenControls(code) {
-  const plus = document.querySelector(`.qty-plus[data-target="${code}Qty"]`);
-  const minus = document.querySelector(`.qty-minus[data-target="${code}Qty"]`);
-  const sel = document.getElementById(code + 'Qty');
-  const valid = isRamenValid(code);
-  if (plus) plus.disabled = !valid;
-  if (minus) minus.disabled = !valid;
-  if (sel) sel.disabled = !valid;
+  // controls remain enabled; validation handled on click
 }
 
 function changeRamenQty(code, delta) {

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -312,7 +312,7 @@
       <img alt="Ebi Furai Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Ebi Furai Ramen</h3>
+      <h3>Ebi Furai</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="ebiBase">
@@ -328,12 +328,12 @@
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="ebiNew">New Set</button>
       <div class="qty-box">
         <label for="ebiQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="ebiQty" type="button">-</button>
         <select id="ebiQty"></select>
         <button class="qty-plus add-button" data-target="ebiQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="ebiNew">New Set</button>
       </div>
     </div>
   </div>
@@ -343,7 +343,7 @@
       <img alt="Chicken Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Chicken Ramen</h3>
+      <h3>Chicken</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="chickenBase">
@@ -359,12 +359,12 @@
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="chickenNew">New Set</button>
       <div class="qty-box">
         <label for="chickenQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="chickenQty" type="button">-</button>
         <select id="chickenQty"></select>
         <button class="qty-plus add-button" data-target="chickenQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="chickenNew">New Set</button>
       </div>
     </div>
   </div>
@@ -374,7 +374,7 @@
       <img alt="Beef Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Beef Ramen</h3>
+      <h3>Beef</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="beefBase">
@@ -390,12 +390,12 @@
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="beefNew">New Set</button>
       <div class="qty-box">
         <label for="beefQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="beefQty" type="button">-</button>
         <select id="beefQty"></select>
         <button class="qty-plus add-button" data-target="beefQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="beefNew">New Set</button>
       </div>
     </div>
   </div>
@@ -405,7 +405,7 @@
       <img alt="Ribeye Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Ribeye Ramen</h3>
+      <h3>Ribeye</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="ribeyeBase">
@@ -421,12 +421,12 @@
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="ribeyeNew">New Set</button>
       <div class="qty-box">
         <label for="ribeyeQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="ribeyeQty" type="button">-</button>
         <select id="ribeyeQty"></select>
         <button class="qty-plus add-button" data-target="ribeyeQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="ribeyeNew">New Set</button>
       </div>
     </div>
   </div>
@@ -436,7 +436,7 @@
       <img alt="Chasiu Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
     </div>
     <div class="menu-content">
-      <h3>Chasiu Ramen</h3>
+      <h3>Chasiu</h3>
       <p>€ 13.00</p>
       <div class="bubble-option">
         <select id="chasiuBase">
@@ -452,12 +452,12 @@
           <option value="Soyu">Soyu</option>
         </select>
       </div>
+      <button type="button" class="new-set-button" id="chasiuNew">New Set</button>
       <div class="qty-box">
         <label for="chasiuQty">Aantal</label>
         <button class="qty-minus remove-button" data-target="chasiuQty" type="button">-</button>
         <select id="chasiuQty"></select>
         <button class="qty-plus add-button" data-target="chasiuQty" type="button">+</button>
-        <button type="button" class="new-set-button" id="chasiuNew">New Set</button>
       </div>
     </div>
   </div>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -778,6 +778,26 @@ function setDragonQty(){
   const price=parseFloat(document.querySelector('[data-name="Dragon Roll Omakase"]').dataset.price);
   setQty('Dragon Roll Omakase',price,qty,0.2,prefs);
 }
+
+function isRamenValid(code){
+  return document.getElementById(code+'Base').value && document.getElementById(code+'Smaak').value;
+}
+
+function changeRamenQty(code,delta){
+  const sel=document.getElementById(code+'Qty');
+  let val=parseInt(sel.value||0);
+  val=Math.max(0,Math.min(20,val+delta));
+  sel.value=val;
+  const item=document.querySelector(`.menu-item[data-code="${code}"]`);
+  const base=document.getElementById(code+'Base').value;
+  const smaak=document.getElementById(code+'Smaak').value;
+  if(!base||!smaak) return;
+  const name=item.dataset.name;
+  const price=parseFloat(item.dataset.price);
+  const pack=parseFloat(item.dataset.packaging||0);
+  const fullName=`${name} - ${base} - ${smaak}`;
+  setQty(fullName,price,val,pack);
+}
 function populateSelect(sel){
   for(let i=0;i<=20;i++){ const opt=document.createElement('option'); opt.value=i; opt.textContent=i; sel.appendChild(opt); }
 }
@@ -867,7 +887,9 @@ function updateCart(){
 }
 
 document.addEventListener('DOMContentLoaded',()=>{
-  const skip=['bubbleTeaQty','bubbleType','bubbleFlavor','bubbleTopping','xBentoMain','xBentoSide','xBentoRice'];
+  const skip=['bubbleTeaQty','bubbleType','bubbleFlavor','bubbleTopping','xBentoMain','xBentoSide','xBentoRice',
+    'ebiBase','ebiSmaak','ebiQty','chickenBase','chickenSmaak','chickenQty','beefBase','beefSmaak','beefQty',
+    'ribeyeBase','ribeyeSmaak','ribeyeQty','chasiuBase','chasiuSmaak','chasiuQty'];
   document.querySelectorAll('.menu-item select').forEach(sel=>{
     if(!skip.includes(sel.id)){
       populateSelect(sel);
@@ -902,8 +924,9 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.');return;}changeXbentoQty(-1);});
   document.getElementById('xBentoQty').addEventListener('change',()=>{if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.');document.getElementById('xBentoQty').value=0;return;}changeXbentoQty(0);});
 
+  const ramenIds=['ebiQty','chickenQty','beefQty','ribeyeQty','chasiuQty'];
   document.querySelectorAll('.qty-plus').forEach(btn=>{
-    if(['bubbleTeaQty','xBentoQty'].includes(btn.dataset.target)) return;
+    if(['bubbleTeaQty','xBentoQty',...ramenIds].includes(btn.dataset.target)) return;
     btn.addEventListener('click',()=>{
       const sel=document.getElementById(btn.dataset.target);
       let val=parseInt(sel.value);
@@ -920,7 +943,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     });
   });
   document.querySelectorAll('.qty-minus').forEach(btn=>{
-    if(['bubbleTeaQty','xBentoQty'].includes(btn.dataset.target)) return;
+    if(['bubbleTeaQty','xBentoQty',...ramenIds].includes(btn.dataset.target)) return;
     btn.addEventListener('click',()=>{
       const sel=document.getElementById(btn.dataset.target);
       let val=parseInt(sel.value);
@@ -934,6 +957,30 @@ document.addEventListener('DOMContentLoaded',()=>{
       } else {
         setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0));
       }
+    });
+  });
+
+  const ramenCodes=['ebi','chicken','beef','ribeye','chasiu'];
+  ramenCodes.forEach(code=>{
+    const qty=document.getElementById(code+'Qty');
+    populateSelect(qty);
+    qty.value=0;
+    document.querySelector(`.qty-plus[data-target="${code}Qty"]`).addEventListener('click',()=>{
+      if(!isRamenValid(code)){alert('🍜 Kies eerst base en smaak voor je ramen.');return;}
+      changeRamenQty(code,1);
+    });
+    document.querySelector(`.qty-minus[data-target="${code}Qty"]`).addEventListener('click',()=>{
+      if(!isRamenValid(code)){alert('🍜 Kies eerst base en smaak voor je ramen.');return;}
+      changeRamenQty(code,-1);
+    });
+    qty.addEventListener('change',()=>{
+      if(!isRamenValid(code)){alert('🍜 Kies eerst base en smaak voor je ramen.');qty.value=0;return;}
+      changeRamenQty(code,0);
+    });
+    document.getElementById(code+'New').addEventListener('click',()=>{
+      document.getElementById(code+'Base').value='';
+      document.getElementById(code+'Smaak').value='';
+      qty.value=0;
     });
   });
   ['chopstickCount','soyCount','gemberCount','wasabiCount'].forEach(id=>{


### PR DESCRIPTION
## Summary
- shorten ramen item names
- position "New Set" buttons below flavour selectors
- keep ramen controls active and validate on click
- add ramen prompts in POS view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615e6b2a908333af49d47be004674a