### PR TITLE
Relocate store status to delivery options

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1268,8 +1268,6 @@ input:focus, select:focus, textarea:focus {
 
 </head>
 <body>
-<div id="status-banner"></div>
-<div id="hours-info"></div>
 <div id="closed-overlay"></div>
 <div class="feedback" id="feedback"></div>
 <div class="navbar-container" id="navbar-container">
@@ -1295,6 +1293,8 @@ input:focus, select:focus, textarea:focus {
 <section id="delivery-options">
 <div class="delivery-options">
 <h2>Kies uw bestelmethode</h2>
+<div id="status-banner"></div>
+<div id="hours-info"></div>
 <div class="order-type-slider">
   <input id="afhalen" name="orderType" type="radio" value="afhalen" onchange="toggleOrderType()" checked class="hidden">
   <input id="bezorgen" name="orderType" type="radio" value="bezorgen" onchange="toggleOrderType()" class="hidden">


### PR DESCRIPTION
## Summary
- move `status-banner` and `hours-info` into delivery options section
- keep overlay at the top of the page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862f331accc8333be06aa29b69d5be0