### PR TITLE
Implement configurable closed days

### DIFF
--- a/app.py
+++ b/app.py
@@ -263,6 +263,7 @@ with app.app_context():
         "is_open": "true",
         "open_time": "11:00",
         "close_time": "21:00",
+        "closed_days": "",
         "pickup_enabled": "true",
         "delivery_enabled": "true",
         "pickup_start": "11:00",
@@ -522,6 +523,7 @@ def dashboard():
         is_open=get_value('is_open', 'true'),
         open_time=get_value('open_time', '11:00'),
         close_time=get_value('close_time', '21:00'),
+        closed_days=get_value('closed_days', ''),
         pickup_enabled=get_value('pickup_enabled', 'true'),
         delivery_enabled=get_value('delivery_enabled', 'true'),
         pickup_start=get_value('pickup_start', '11:00'),
@@ -539,6 +541,7 @@ def update_setting():
     is_open_val = data.get('is_open', 'true')
     open_time_val = data.get('open_time', '11:00')
     close_time_val = data.get('close_time', '21:00')
+    closed_days_val = data.get('closed_days', '')
     pickup_enabled_val = data.get('pickup_enabled', 'true')
     delivery_enabled_val = data.get('delivery_enabled', 'true')
     pickup_start_val = data.get('pickup_start', '11:00')
@@ -550,6 +553,7 @@ def update_setting():
         ('is_open', is_open_val),
         ('open_time', open_time_val),
         ('close_time', close_time_val),
+        ('closed_days', closed_days_val),
         ('pickup_enabled', pickup_enabled_val),
         ('delivery_enabled', delivery_enabled_val),
         ('pickup_start', pickup_start_val),

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
   "is_open": "true",
   "open_time": "11:00",
-  "close_time": "21:00"
+  "close_time": "21:00",
+  "closed_days": ""
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -20,6 +20,15 @@
         <input type="time" name="close_time" id="close_time_input" value="{{ close_time }}">
         <br><br>
 
+        <label>Gesloten dagen:</label><br>
+        {% set days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'] %}
+        {% for day in days %}
+        <label>
+            <input type="checkbox" name="closed_days" value="{{ day }}" {% if day in closed_days.split(',') %}checked{% endif %}> {{ day }}
+        </label>
+        {% endfor %}
+        <br><br>
+
         <label>Afhalen aan/uit:</label>
         <select id="pickup_enabled_select">
             <option value="true" {% if pickup_enabled == 'true' %}selected{% endif %}>Aan</option>
@@ -52,6 +61,7 @@
             const is_open = document.getElementById('is_open_select').value;
             const open_time = document.getElementById('open_time_input').value;
             const close_time = document.getElementById('close_time_input').value;
+            const closedDays = Array.from(document.querySelectorAll('input[name="closed_days"]:checked')).map(cb => cb.value).join(',');
             const pickup_enabled = document.getElementById('pickup_enabled_select').value;
             const delivery_enabled = document.getElementById('delivery_enabled_select').value;
             const pickup_start = document.getElementById('pickup_start_input').value;
@@ -66,6 +76,7 @@
                     is_open: is_open,
                     open_time: open_time,
                     close_time: close_time,
+                    closed_days: closedDays,
                     pickup_enabled: pickup_enabled,
                     delivery_enabled: delivery_enabled,
                     pickup_start: pickup_start,

--- a/templates/index.html
+++ b/templates/index.html
@@ -4134,7 +4134,19 @@ function updateStatus(settings){
   const afhalen = document.getElementById('afhalen');
   const bezorgen = document.getElementById('bezorgen');
 
-  hoursEl.textContent = `Afhalen: ${settings.pickup_start} - ${settings.pickup_end} | Bezorg: ${settings.delivery_start} - ${settings.delivery_end}`;
+  const closedDays = (settings.closed_days || '').split(',').filter(d => d);
+  const allClosed = closedDays.length === 7;
+  const dayNames = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+  const todayName = dayNames[new Date().getDay()];
+
+  const hoursText = `Daily ${settings.open_time} - ${settings.close_time}`;
+  let closedText = '';
+  if(allClosed){
+    closedText = ', Closed All Week';
+  }else if(closedDays.length){
+    closedText = ', Closed on ' + closedDays.join(', ');
+  }
+  hoursEl.textContent = hoursText + closedText;
   pickupOpenTime = settings.pickup_start || pickupOpenTime;
   pickupCloseTime = settings.pickup_end || pickupCloseTime;
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
@@ -4142,12 +4154,16 @@ function updateStatus(settings){
   populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
   populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
 
-  const websiteOn = settings.is_open !== 'false';
-  pickupAvailable = websiteOn && settings.pickup_enabled !== 'false' && inRange(settings.pickup_start, settings.pickup_end);
-  deliveryAvailable = websiteOn && settings.delivery_enabled !== 'false' && inRange(settings.delivery_start, settings.delivery_end);
+  const websiteOn = settings.is_open !== 'false' && !allClosed;
+  const dayOpen = closedDays.indexOf(todayName) === -1;
+  pickupAvailable = websiteOn && dayOpen && settings.pickup_enabled !== 'false' && inRange(settings.pickup_start, settings.pickup_end);
+  deliveryAvailable = websiteOn && dayOpen && settings.delivery_enabled !== 'false' && inRange(settings.delivery_start, settings.delivery_end);
 
   let message = '';
-  if(!websiteOn){
+  if(allClosed){
+    storeOpen = false;
+    message = 'This week the store is closed.';
+  }else if(!websiteOn){
     storeOpen = false;
     message = 'De website is momenteel gesloten';
   }else if(!pickupAvailable && !deliveryAvailable){
@@ -4178,11 +4194,10 @@ function updateStatus(settings){
   }
 
   closedMessage = message;
-  businessHours = `Afhalen ${settings.pickup_start} - ${settings.pickup_end} | Bezorg ${settings.delivery_start} - ${settings.delivery_end}`;
+  businessHours = hoursEl.textContent;
 
   if(storeOpen){
     banner.textContent = '';
-    banner.style.display = 'none';
     if(overlayEl) overlayEl.style.display = 'none';
     if(checkoutBtn) checkoutBtn.disabled = false;
     if(sliderTrack){
@@ -4191,7 +4206,6 @@ function updateStatus(settings){
     }
   }else{
     banner.textContent = message;
-    banner.style.display = 'block';
     if(overlayEl) overlayEl.style.display = 'block';
     window.scrollTo({top: 0, behavior: 'smooth'});
     if(checkoutBtn) checkoutBtn.disabled = true;
@@ -4200,6 +4214,7 @@ function updateStatus(settings){
       if(sliderText) sliderText.textContent = 'Momenteel gesloten';
     }
   }
+  banner.style.display = 'block';
 }
 
 function fetchStatus(){


### PR DESCRIPTION
## Summary
- add `closed_days` setting and defaults
- show closed day checkboxes in dashboard
- send closed days value on setting update
- display business hours and closed days on index page
- keep banner visible and disable ordering when closed

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6863740f064083339639dda9d461810c