### PR TITLE
Implement centralized price management

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -54,6 +54,24 @@
         <button type="submit">保存</button>
     </form>
 
+    <h2>Menu prijzen</h2>
+    <table>
+    {% for section in sections %}
+        <tr><th colspan="2">{{ section.name }}</th></tr>
+        {% for item in section.items %}
+        <tr>
+            <td>{{ item.name }}</td>
+            <td>
+                <form action="{{ url_for('update_item', item_id=item.id) }}" method="post" style="display:inline;">
+                    <input type="number" step="0.01" name="price" value="{{ '%.2f' % item.price }}">
+                    <button type="submit">Opslaan</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    {% endfor %}
+    </table>
+
     <script>
         document.getElementById('settingForm').addEventListener('submit', function(e) {
             e.preventDefault();  // 防止页面刷新

--- a/templates/index.html
+++ b/templates/index.html
@@ -4246,10 +4246,32 @@ function fetchStatus(){
     .then(r => r.json())
     .then(updateStatus);
 }
-fetchStatus();
-const socket = io();
-socket.on('setting_update', updateStatus);
-const overlay = document.getElementById('closed-overlay');
+  fetchStatus();
+  const socket = io();
+  socket.on('setting_update', updateStatus);
+  function applyMenuPrices(items){
+    const map={};
+    items.forEach(i=>{map[i.name]=i.price;});
+    document.querySelectorAll('.menu-item').forEach(el=>{
+      const name=el.dataset.name;
+      if(name&&map[name]!==undefined){
+        const p=parseFloat(map[name]);
+        el.dataset.price=p;
+        const pe=el.querySelector('p');
+        if(pe) pe.textContent=`€ ${p.toFixed(2)}`;
+      }
+    });
+  }
+  async function loadMenu(){
+    const r=await fetch('/api/menu');
+    if(r.ok){
+      const d=await r.json();
+      applyMenuPrices(d);
+    }
+  }
+  loadMenu();
+  socket.on('menu_update', applyMenuPrices);
+  const overlay = document.getElementById('closed-overlay');
 if(overlay){
   overlay.addEventListener('click', () => {
     showFeedback(closedMessage, true);

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1341,6 +1341,26 @@ function formatCurrency(value){
   const socketUrl = (typeof process !== 'undefined' && process.env && process.env.SOCKET_URL) ? process.env.SOCKET_URL : 'https://flask-order-api.onrender.com';
   const socket = io(socketUrl, { transports: ['websocket'] });
 
+  function applyMenuPrices(items){
+    const map={};
+    items.forEach(i=>{map[i.name]=i.price;});
+    document.querySelectorAll('.menu-item').forEach(el=>{
+      const name=el.dataset.name;
+      if(name&&map[name]!==undefined){
+        const p=parseFloat(map[name]);
+        el.dataset.price=p;
+        const pe=el.querySelector('p');
+        if(pe) pe.textContent=`€${p.toFixed(2)}`;
+      }
+    });
+  }
+  async function loadMenu(){
+    const r=await fetch('/api/menu');
+    if(r.ok){ const d=await r.json(); applyMenuPrices(d); }
+  }
+  loadMenu();
+  socket.on('menu_update', applyMenuPrices);
+
   let pollTimer;
   const baseTitle = document.title;
   let newOrderCount = 0; // unseen orders for title


### PR DESCRIPTION
## Summary
- add `/api/menu` for price and item data
- broadcast `menu_update` events on price updates
- allow editing item prices via dashboard
- update index and POS pages to fetch prices from the API and listen for updates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686381c572d08333906a8df610b366dc