### PR TITLE
Synchronize pickup/delivery hours from dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3496,6 +3496,12 @@ function checkout() {
       close.setDate(close.getDate() + 1);
     }
 
+    // always include configured start time as the first option
+    const firstOpt = document.createElement('option');
+    firstOpt.value = oStr;
+    firstOpt.textContent = oStr;
+    select.appendChild(firstOpt);
+
     let start = now > open ? now : open;
     start = new Date(start);
     start.setMinutes(Math.ceil(start.getMinutes() / 15) * 15, 0, 0);
@@ -3504,11 +3510,19 @@ function checkout() {
       const hh = pad(t.getHours());
       const mm = pad(t.getMinutes());
       const timeStr = `${hh}:${mm}`;
+      if (timeStr === oStr || timeStr === cStr) continue; // avoid duplicates
       const opt = document.createElement('option');
       opt.value = timeStr;
       opt.textContent = timeStr;
       select.appendChild(opt);
     }
+
+    // ensure the configured end time appears as the last option
+    const lastOpt = document.createElement('option');
+    lastOpt.value = cStr;
+    lastOpt.textContent = cStr;
+    select.appendChild(lastOpt);
+
     if (prev) {
       const option = Array.from(select.options).find(o => o.value === prev);
       if (option) select.value = prev;


### PR DESCRIPTION
## Summary
- keep first and last dropdown items equal to dashboard start/end times

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6864f237ff048333b080ae02bd49a0c5