### PR TITLE
Add dashboard time interval setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -270,6 +270,7 @@ with app.app_context():
         "pickup_end": "21:00",
         "delivery_start": "11:00",
         "delivery_end": "21:00",
+        "time_interval": "15",
     }
     for k, v in defaults.items():
         if not Setting.query.filter_by(key=k).first():
@@ -546,6 +547,7 @@ def dashboard():
         pickup_end=get_value('pickup_end', '21:00'),
         delivery_start=get_value('delivery_start', '11:00'),
         delivery_end=get_value('delivery_end', '21:00'),
+        time_interval=get_value('time_interval', '15'),
         sections=sections,
     )
 
@@ -564,6 +566,7 @@ def update_setting():
     pickup_end_val = data.get('pickup_end', '21:00')
     delivery_start_val = data.get('delivery_start', '11:00')
     delivery_end_val = data.get('delivery_end', '21:00')
+    time_interval_val = data.get('time_interval', '15')
 
     for key, val in [
         ('is_open', is_open_val),
@@ -576,6 +579,7 @@ def update_setting():
         ('pickup_end', pickup_end_val),
         ('delivery_start', delivery_start_val),
         ('delivery_end', delivery_end_val),
+        ('time_interval', time_interval_val),
     ]:
         s = Setting.query.filter_by(key=key).first()
         if not s:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -50,6 +50,13 @@
         <input type="time" id="delivery_start_input" value="{{ delivery_start }}"> -
         <input type="time" id="delivery_end_input" value="{{ delivery_end }}">
         <br><br>
+        <label>Tijd interval:</label>
+        <select id="interval_select">
+            {% for n in [5,10,15,30] %}
+            <option value="{{ n }}" {% if time_interval == n|string %}selected{% endif %}>{{ n }} min</option>
+            {% endfor %}
+        </select>
+        <br><br>
 
         <button type="submit">保存</button>
     </form>
@@ -68,6 +75,7 @@
             const pickup_end = document.getElementById('pickup_end_input').value;
             const delivery_start = document.getElementById('delivery_start_input').value;
             const delivery_end = document.getElementById('delivery_end_input').value;
+            const time_interval = document.getElementById('interval_select').value;
 
             fetch('/dashboard/update', {
                 method: 'POST',
@@ -82,7 +90,8 @@
                     pickup_start: pickup_start,
                     pickup_end: pickup_end,
                     delivery_start: delivery_start,
-                    delivery_end: delivery_end
+                    delivery_end: delivery_end,
+                    time_interval: time_interval
                 })
             })
             .then(response => response.json())

--- a/templates/index.html
+++ b/templates/index.html
@@ -3196,6 +3196,7 @@ let pickupOpenTime = '12:00';
 let pickupCloseTime = '23:59';
 let deliveryOpenTime = '12:00';
 let deliveryCloseTime = '23:59';
+let timeInterval = 15;
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
   el.textContent = msg;
@@ -3504,9 +3505,8 @@ function checkout() {
 
     let start = now > open ? now : open;
     start = new Date(start);
-    start.setMinutes(Math.ceil(start.getMinutes() / 15) * 15, 0, 0);
-
-    for (let t = new Date(start); t <= close; t.setMinutes(t.getMinutes() + 15)) {
+    start.setMinutes(Math.ceil(start.getMinutes() / timeInterval) * timeInterval, 0, 0);
+    for (let t = new Date(start); t <= close; t.setMinutes(t.getMinutes() + timeInterval)) {
       const hh = pad(t.getHours());
       const mm = pad(t.getMinutes());
       const timeStr = `${hh}:${mm}`;
@@ -4165,6 +4165,7 @@ function updateStatus(settings){
   pickupCloseTime = settings.pickup_end || pickupCloseTime;
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
+  timeInterval = parseInt(settings.time_interval || timeInterval);
   populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
   populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
 


### PR DESCRIPTION
## Summary
- allow storing a `time_interval` setting alongside other defaults
- expose the value in the dashboard form with a dropdown
- send the interval to the backend and broadcast via Socket.IO
- update front-end logic so dropdown times use the configured step

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_6864fa0740508333bb255bc0e9776b37