### PR TITLE
Add milk tea price control with WebSocket updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -548,6 +548,7 @@ def dashboard():
         delivery_start=get_value('delivery_start', '11:00'),
         delivery_end=get_value('delivery_end', '21:00'),
         time_interval=get_value('time_interval', '15'),
+        milktea_price=get_value('milktea_price', '5'),
         sections=sections,
     )
 
@@ -676,6 +677,26 @@ def update_item(item_id):
     ]
     socketio.emit('menu_update', items)
     return redirect(url_for('dashboard'))
+
+
+@app.route('/update_milktea_price', methods=['POST'])
+@login_required
+def update_milktea_price():
+    data = request.get_json() or {}
+    try:
+        price_val = float(data.get('price'))
+    except (TypeError, ValueError):
+        return jsonify({'success': False, 'error': 'invalid_price'}), 400
+
+    setting = Setting.query.filter_by(key='milktea_price').first()
+    if not setting:
+        setting = Setting(key='milktea_price', value=str(price_val))
+        db.session.add(setting)
+    else:
+        setting.value = str(price_val)
+    db.session.commit()
+    socketio.emit('milktea_price_update', {'price': price_val})
+    return jsonify({'success': True})
 
 
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -58,6 +58,11 @@
         </select>
         <br><br>
 
+        <label>奶茶价格 (€):</label>
+        <input type="number" step="0.01" id="milktea_price_input" value="{{ milktea_price }}">
+        <button type="button" id="update_milktea_btn">更新价格</button>
+        <br><br>
+
         <button type="submit">保存</button>
     </form>
 
@@ -106,6 +111,17 @@
                 console.error('Error:', error);
                 alert('请求失败，请检查网络。');
             });
+        });
+
+        document.getElementById('update_milktea_btn').addEventListener('click', function(){
+            const price = parseFloat(document.getElementById('milktea_price_input').value || '0');
+            fetch('/update_milktea_price', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({price: price})
+            }).then(r => r.json()).then(d => {
+                alert(d.success ? 'Prijs bijgewerkt!' : 'Fout bij bijwerken');
+            }).catch(() => alert('Request failed'));
         });
     </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2457,12 +2457,22 @@ const extras = {
 
 const DEFAULT_PACKAGING_FEE = 0.20;
 const DELIVERY_FEE = 2.50;
+let milkTeaPrice = 5;
 let currentPackaging = 0;
 let currentSubtotal = 0;
 let finalTotal = 0;
 let currentDiscount = 0;
 let bubbleSetControls;
 let xbentoSetControls;
+
+function updateMilkTeaDisplay(){
+  const item = document.querySelector('.menu-item[data-name="Bubble Tea"]');
+  if(item){
+    item.dataset.price = milkTeaPrice;
+    const p = item.querySelector('p');
+    if(p) p.textContent = `€ ${milkTeaPrice.toFixed(2)}`;
+  }
+}
 
 function saveCart() {
   sessionStorage.setItem('novaCart', JSON.stringify(cart));
@@ -2596,7 +2606,7 @@ function changeBubbleQty(delta) {
   if (!type || !flavor || !topping) return;
 
   const fullName = `Bubble Tea (${type}, ${flavor}, ${topping})`;
-  setQty(fullName, 5, val, DEFAULT_PACKAGING_FEE);
+  setQty(fullName, milkTeaPrice, val, DEFAULT_PACKAGING_FEE);
   if (bubbleSetControls) bubbleSetControls.update();
 }
 
@@ -4148,6 +4158,11 @@ function updateStatus(settings){
   const afhalen = document.getElementById('afhalen');
   const bezorgen = document.getElementById('bezorgen');
 
+  if(settings.milktea_price){
+    milkTeaPrice = parseFloat(settings.milktea_price);
+    updateMilkTeaDisplay();
+  }
+
   const closedDays = (settings.closed_days || '').split(',').filter(d => d);
   const allClosed = closedDays.length === 7;
   const dayNames = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
@@ -4259,6 +4274,10 @@ fetchStatus();
 const socket = io();
 socket.on('setting_update', updateStatus);
 socket.on('time_update', updateTimes);
+socket.on('milktea_price_update', data => {
+  milkTeaPrice = parseFloat(data.price || data);
+  updateMilkTeaDisplay();
+});
 const overlay = document.getElementById('closed-overlay');
 if(overlay){
   overlay.addEventListener('click', () => {

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -678,6 +678,16 @@ const extras = {
   gemberCount: { label: 'Gember', price: 0 },
   wasabiCount: { label: 'Wasabi', price: 0 }
 };
+let milkTeaPrice = 5;
+
+function updateMilkTeaDisplay(){
+  const item = document.querySelector('.menu-item[data-name="Bubble Tea"]');
+  if(item){
+    item.dataset.price = milkTeaPrice;
+    const p = item.querySelector('p');
+    if(p) p.textContent = `€${milkTeaPrice.toFixed(2)}`;
+  }
+}
 
 function changeBubbleQty(delta){
   const sel=document.getElementById('bubbleTeaQty');
@@ -689,7 +699,7 @@ function changeBubbleQty(delta){
   const topping=document.getElementById('bubbleTopping').value;
   if(!type||!flavor||!topping) return;
   const name=`Bubble Tea (${type}, ${flavor}, ${topping})`;
-  setQty(name,5,val,0.2);
+  setQty(name,milkTeaPrice,val,0.2);
 }
 
 function changeXbentoQty(delta){
@@ -1359,7 +1369,12 @@ function formatCurrency(value){
     if(r.ok){ const d=await r.json(); applyMenuPrices(d); }
   }
   loadMenu();
+  fetch('/api/settings').then(r=>r.json()).then(s=>{ if(s.milktea_price){ milkTeaPrice=parseFloat(s.milktea_price); updateMilkTeaDisplay(); }});
   socket.on('menu_update', applyMenuPrices);
+  socket.on('milktea_price_update', data => {
+    milkTeaPrice = parseFloat(data.price || data);
+    updateMilkTeaDisplay();
+  });
 
   let pollTimer;
   const baseTitle = document.title;


### PR DESCRIPTION
## Summary
- allow setting `milktea_price` and expose on dashboard
- broadcast `milktea_price_update` when price changes
- update dashboard to modify milk tea price
- handle live milk tea price updates in index and POS pages

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68650e6aae908333a072d8c29576a456