### PR TITLE
Implement dynamic bubble tea options

### DIFF
--- a/app.py
+++ b/app.py
@@ -180,6 +180,13 @@ def build_maps_link(street: str, house_number: str, postcode: str, city: str) ->
     return f"https://www.google.com/maps?q={quote(address)}"
 
 
+def get_bubble_options_dict():
+    opts = {'base': [], 'smaak': [], 'topping': []}
+    for o in BubbleOption.query.order_by(BubbleOption.id).all():
+        opts[o.category].append({'id': o.id, 'name': o.name, 'price': o.price})
+    return opts
+
+
 # Socket.IO for real-time updates
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
 
@@ -257,6 +264,14 @@ class MenuItem(db.Model):
     section = db.relationship('MenuSection', backref=db.backref('items', lazy=True))
 
 
+class BubbleOption(db.Model):
+    __tablename__ = 'bubble_options'
+    id = db.Column(db.Integer, primary_key=True)
+    category = db.Column(db.String(20))  # base, smaak, topping
+    name = db.Column(db.String(100), nullable=False)
+    price = db.Column(db.Float, default=0.0)
+
+
 with app.app_context():
     db.create_all()
     defaults = {
@@ -276,6 +291,18 @@ with app.app_context():
         if not Setting.query.filter_by(key=k).first():
             db.session.add(Setting(key=k, value=v))
     db.session.commit()
+
+    if BubbleOption.query.count() == 0:
+        defaults_base = ['Green Tea', 'Milk Tea', 'Milkshake']
+        defaults_smaak = ['Mango', 'Appel', 'Matcha', 'Brown Sugar']
+        defaults_topping = ['Appel Popping', 'Perzik Popping', 'Tapioca']
+        for n in defaults_base:
+            db.session.add(BubbleOption(category='base', name=n, price=0.0))
+        for n in defaults_smaak:
+            db.session.add(BubbleOption(category='smaak', name=n, price=0.0))
+        for n in defaults_topping:
+            db.session.add(BubbleOption(category='topping', name=n, price=0.0))
+        db.session.commit()
 
 
 class User(UserMixin):
@@ -483,6 +510,10 @@ def api_menu():
     ]
     return jsonify(data)
 
+@app.route('/api/bubble_options')
+def api_bubble_options():
+    return jsonify(get_bubble_options_dict())
+
 # ----- Review API -----
 @app.route('/api/reviews', methods=['GET', 'POST'])
 def reviews_api():
@@ -535,6 +566,9 @@ def dashboard():
         return s.value if s else default
 
     sections = MenuSection.query.all()
+    bases = BubbleOption.query.filter_by(category='base').all()
+    smaken = BubbleOption.query.filter_by(category='smaak').all()
+    toppings = BubbleOption.query.filter_by(category='topping').all()
     return render_template(
         'dashboard.html',
         is_open=get_value('is_open', 'true'),
@@ -550,6 +584,9 @@ def dashboard():
         time_interval=get_value('time_interval', '15'),
         milktea_price=get_value('milktea_price', '5'),
         sections=sections,
+        base_options=bases,
+        smaak_options=smaken,
+        topping_options=toppings,
     )
 
 
@@ -697,6 +734,48 @@ def update_milktea_price():
     db.session.commit()
     socketio.emit('milktea_price_update', {'price': price_val})
     return jsonify({'success': True})
+
+
+@app.route('/dashboard/bubble_options/add', methods=['POST'])
+@login_required
+def add_bubble_option():
+    name = request.form.get('name', '').strip()
+    category = request.form.get('category')
+    price = request.form.get('price', '0')
+    try:
+        price_val = float(price)
+    except ValueError:
+        price_val = 0.0
+    if name and category in ['base', 'smaak', 'topping']:
+        opt = BubbleOption(name=name, category=category, price=price_val)
+        db.session.add(opt)
+        db.session.commit()
+        socketio.emit('bubble_options_update', get_bubble_options_dict())
+    return redirect(url_for('dashboard'))
+
+
+@app.route('/dashboard/bubble_options/<int:opt_id>', methods=['POST'])
+@login_required
+def update_bubble_option(opt_id):
+    opt = BubbleOption.query.get_or_404(opt_id)
+    opt.name = request.form.get('name', opt.name)
+    try:
+        opt.price = float(request.form.get('price', opt.price))
+    except ValueError:
+        pass
+    db.session.commit()
+    socketio.emit('bubble_options_update', get_bubble_options_dict())
+    return redirect(url_for('dashboard'))
+
+
+@app.route('/dashboard/bubble_options/<int:opt_id>/delete', methods=['POST'])
+@login_required
+def delete_bubble_option(opt_id):
+    opt = BubbleOption.query.get_or_404(opt_id)
+    db.session.delete(opt)
+    db.session.commit()
+    socketio.emit('bubble_options_update', get_bubble_options_dict())
+    return redirect(url_for('dashboard'))
 
 
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -66,6 +66,74 @@
         <button type="submit">保存</button>
     </form>
 
+    <h2>Bubble Tea Opties</h2>
+
+    <h3>Base</h3>
+    <ul>
+    {% for o in base_options %}
+        <li>
+            <form action="/dashboard/bubble_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/bubble_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/bubble_options/add" method="post">
+        <input type="hidden" name="category" value="base">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
+    <h3>Smaak</h3>
+    <ul>
+    {% for o in smaak_options %}
+        <li>
+            <form action="/dashboard/bubble_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/bubble_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/bubble_options/add" method="post">
+        <input type="hidden" name="category" value="smaak">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
+    <h3>Topping</h3>
+    <ul>
+    {% for o in topping_options %}
+        <li>
+            <form action="/dashboard/bubble_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/bubble_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/bubble_options/add" method="post">
+        <input type="hidden" name="category" value="topping">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
     <script>
         document.getElementById('settingForm').addEventListener('submit', function(e) {
             e.preventDefault();  // 防止页面刷新

--- a/templates/index.html
+++ b/templates/index.html
@@ -2457,7 +2457,8 @@ const extras = {
 
 const DEFAULT_PACKAGING_FEE = 0.20;
 const DELIVERY_FEE = 2.50;
-let milkTeaPrice = 5;
+let milkTeaPrice = 0;
+let bubbleOptions = {base: [], smaak: [], topping: []};
 let currentPackaging = 0;
 let currentSubtotal = 0;
 let finalTotal = 0;
@@ -2465,7 +2466,20 @@ let currentDiscount = 0;
 let bubbleSetControls;
 let xbentoSetControls;
 
+function getOptionPrice(cat, name){
+  const opt = (bubbleOptions[cat]||[]).find(o=>o.name===name);
+  return opt ? parseFloat(opt.price) : 0;
+}
+
+function getBubbleTeaPrice(){
+  const type = document.getElementById('bubbleType').value;
+  const flavor = document.getElementById('bubbleFlavor').value;
+  const topping = document.getElementById('bubbleTopping').value;
+  return getOptionPrice('base', type)+getOptionPrice('smaak', flavor)+getOptionPrice('topping', topping);
+}
+
 function updateMilkTeaDisplay(){
+  milkTeaPrice = getBubbleTeaPrice();
   const item = document.querySelector('.menu-item[data-name="Bubble Tea"]');
   if(item){
     item.dataset.price = milkTeaPrice;
@@ -2484,6 +2498,38 @@ function loadCart() {
     const data = JSON.parse(stored);
     Object.keys(data).forEach(k => { cart[k] = data[k]; });
   }
+}
+
+function populateBubbleSelectors(){
+  const baseSel=document.getElementById('bubbleType');
+  const flavorSel=document.getElementById('bubbleFlavor');
+  const toppingSel=document.getElementById('bubbleTopping');
+  const curBase=baseSel.value; const curFlavor=flavorSel.value; const curTopping=toppingSel.value;
+  baseSel.innerHTML='<option value="">Base</option>';
+  bubbleOptions.base.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curBase) opt.selected=true;baseSel.appendChild(opt);});
+  flavorSel.innerHTML='<option value="">Smaak</option>';
+  bubbleOptions.smaak.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curFlavor) opt.selected=true;flavorSel.appendChild(opt);});
+  toppingSel.innerHTML='<option value="">Topping</option>';
+  bubbleOptions.topping.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curTopping) opt.selected=true;toppingSel.appendChild(opt);});
+}
+
+function updateBubbleCartPrices(){
+  Object.entries(cart).forEach(([name,item])=>{
+    const m=name.match(/^Bubble Tea \(([^,]+), ([^,]+), ([^)]+)\)$/);
+    if(!m) return;
+    const price=getOptionPrice('base',m[1])+getOptionPrice('smaak',m[2])+getOptionPrice('topping',m[3]);
+    item.price=price;
+  });
+  updateCart();
+}
+
+function fetchBubbleOptions(){
+  fetch('/api/bubble_options').then(r=>r.json()).then(data=>{
+    bubbleOptions=data;
+    populateBubbleSelectors();
+    updateMilkTeaDisplay();
+    updateBubbleCartPrices();
+  });
 }
 
 const FORM_KEY = 'orderForm';
@@ -2606,7 +2652,8 @@ function changeBubbleQty(delta) {
   if (!type || !flavor || !topping) return;
 
   const fullName = `Bubble Tea (${type}, ${flavor}, ${topping})`;
-  setQty(fullName, milkTeaPrice, val, DEFAULT_PACKAGING_FEE);
+  const price = getBubbleTeaPrice();
+  setQty(fullName, price, val, DEFAULT_PACKAGING_FEE);
   if (bubbleSetControls) bubbleSetControls.update();
 }
 
@@ -2765,6 +2812,11 @@ function setDragonQty() {
     fieldIds: ['bubbleType','bubbleFlavor','bubbleTopping']
   });
   bubbleSetControls.update();
+  ['bubbleType','bubbleFlavor','bubbleTopping'].forEach(id=>{
+    document.getElementById(id).addEventListener('change', () => {
+      updateMilkTeaDisplay();
+    });
+  });
 
   xbentoSetControls = initNewSetControls({
     qtyId: 'xBentoQty',
@@ -4271,12 +4323,19 @@ function fetchStatus(){
     .then(updateStatus);
 }
 fetchStatus();
+fetchBubbleOptions();
 const socket = io();
 socket.on('setting_update', updateStatus);
 socket.on('time_update', updateTimes);
 socket.on('milktea_price_update', data => {
   milkTeaPrice = parseFloat(data.price || data);
   updateMilkTeaDisplay();
+});
+socket.on('bubble_options_update', data => {
+  bubbleOptions = data;
+  populateBubbleSelectors();
+  updateMilkTeaDisplay();
+  updateBubbleCartPrices();
 });
 const overlay = document.getElementById('closed-overlay');
 if(overlay){

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -18,31 +18,21 @@
        
           <select id="bubbleType">
             <option value="">Base</option>
-            <option value="Green Tea">Green Tea</option>
-            <option value="Milk Tea">Milk Tea</option>
-            <option value="Milkshake">Milkshake</option>
           </select>
         </div>
 
         <div class="bubble-option">
-         
+
           <select id="bubbleFlavor">
             <option value="">Smaak</option>
-            <option value="Mango">Mango</option>
-            <option value="Appel">Appel</option>
-            <option value="Matcha">Matcha</option>
-            <option value="Brown Sugar">Brown Sugar</option>
           </select>
         </div>
 
         <div class="bubble-option">
-    
+
           <select id="bubbleTopping">
             <option value="">Topping</option>
-            <option value="Appel Popping">Appel Popping</option>
-            <option value="Perzik Popping">Perzik Popping</option>
-          <option value="Tapioca">Tapioca</option>
-        </select>
+          </select>
       </div>
 
       <div class="new-set-wrap hidden" id="bubbleNewWrap">

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -678,14 +678,28 @@ const extras = {
   gemberCount: { label: 'Gember', price: 0 },
   wasabiCount: { label: 'Wasabi', price: 0 }
 };
-let milkTeaPrice = 5;
+let milkTeaPrice = 0;
+let bubbleOptions = {base: [], smaak: [], topping: []};
+
+function getOptionPrice(cat,name){
+  const opt=(bubbleOptions[cat]||[]).find(o=>o.name===name);
+  return opt?parseFloat(opt.price):0;
+}
+
+function getBubbleTeaPrice(){
+  const type=document.getElementById('bubbleType').value;
+  const flavor=document.getElementById('bubbleFlavor').value;
+  const topping=document.getElementById('bubbleTopping').value;
+  return getOptionPrice('base',type)+getOptionPrice('smaak',flavor)+getOptionPrice('topping',topping);
+}
 
 function updateMilkTeaDisplay(){
-  const item = document.querySelector('.menu-item[data-name="Bubble Tea"]');
+  milkTeaPrice=getBubbleTeaPrice();
+  const item=document.querySelector('.menu-item[data-name="Bubble Tea"]');
   if(item){
-    item.dataset.price = milkTeaPrice;
-    const p = item.querySelector('p');
-    if(p) p.textContent = `€${milkTeaPrice.toFixed(2)}`;
+    item.dataset.price=milkTeaPrice;
+    const p=item.querySelector('p');
+    if(p) p.textContent=`€${milkTeaPrice.toFixed(2)}`;
   }
 }
 
@@ -699,7 +713,8 @@ function changeBubbleQty(delta){
   const topping=document.getElementById('bubbleTopping').value;
   if(!type||!flavor||!topping) return;
   const name=`Bubble Tea (${type}, ${flavor}, ${topping})`;
-  setQty(name,milkTeaPrice,val,0.2);
+  const price=getBubbleTeaPrice();
+  setQty(name,price,val,0.2);
 }
 
 function changeXbentoQty(delta){
@@ -921,6 +936,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   ['bubbleTeaQty','xBentoQty'].forEach(id=>{
     const s=document.getElementById(id);
     for(let i=0;i<=20;i++){const opt=document.createElement('option');opt.value=i;opt.text=i;s.appendChild(opt);} s.value=0;
+  });
+  ['bubbleType','bubbleFlavor','bubbleTopping'].forEach(id=>{
+    document.getElementById(id).addEventListener('change',()=>{updateMilkTeaDisplay();});
   });
 
   document.querySelector('.qty-plus[data-target="bubbleTeaQty"]').addEventListener('click',()=>{
@@ -1364,16 +1382,55 @@ function formatCurrency(value){
       }
     });
   }
+
+  function populateBubbleSelectors(){
+    const baseSel=document.getElementById('bubbleType');
+    const flavorSel=document.getElementById('bubbleFlavor');
+    const toppingSel=document.getElementById('bubbleTopping');
+    const curBase=baseSel.value,curFlavor=flavorSel.value,curTopping=toppingSel.value;
+    baseSel.innerHTML='<option value="">Base</option>';
+    bubbleOptions.base.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curBase) opt.selected=true;baseSel.appendChild(opt);});
+    flavorSel.innerHTML='<option value="">Smaak</option>';
+    bubbleOptions.smaak.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curFlavor) opt.selected=true;flavorSel.appendChild(opt);});
+    toppingSel.innerHTML='<option value="">Topping</option>';
+    bubbleOptions.topping.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curTopping) opt.selected=true;toppingSel.appendChild(opt);});
+  }
+
+  function updateBubbleCartPrices(){
+    Object.entries(cart).forEach(([name,item])=>{
+      const m=name.match(/^Bubble Tea \(([^,]+), ([^,]+), ([^)]+)\)$/);
+      if(!m) return;
+      const price=getOptionPrice('base',m[1])+getOptionPrice('smaak',m[2])+getOptionPrice('topping',m[3]);
+      item.price=price;
+    });
+    updateCart();
+  }
+
+  function fetchBubbleOptions(){
+    fetch('/api/bubble_options').then(r=>r.json()).then(data=>{
+      bubbleOptions=data;
+      populateBubbleSelectors();
+      updateMilkTeaDisplay();
+      updateBubbleCartPrices();
+    });
+  }
   async function loadMenu(){
     const r=await fetch('/api/menu');
     if(r.ok){ const d=await r.json(); applyMenuPrices(d); }
   }
   loadMenu();
   fetch('/api/settings').then(r=>r.json()).then(s=>{ if(s.milktea_price){ milkTeaPrice=parseFloat(s.milktea_price); updateMilkTeaDisplay(); }});
+  fetchBubbleOptions();
   socket.on('menu_update', applyMenuPrices);
   socket.on('milktea_price_update', data => {
     milkTeaPrice = parseFloat(data.price || data);
     updateMilkTeaDisplay();
+  });
+  socket.on('bubble_options_update', data => {
+    bubbleOptions=data;
+    populateBubbleSelectors();
+    updateMilkTeaDisplay();
+    updateBubbleCartPrices();
   });
 
   let pollTimer;


### PR DESCRIPTION
## Summary
- add `BubbleOption` model with CRUD API
- send bubble option updates over Socket.IO
- initialize default bubble options
- extend dashboard to manage bubble tea options
- fetch bubble tea options dynamically on index and POS pages
- compute bubble tea price based on selected options

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6865141c2d888333916b048474b921aa