### PR TITLE
Add real-time Xbento option management

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -134,6 +134,96 @@
         <button type="submit">Toevoegen</button>
     </form>
 
+    <h2>Xbento Opties</h2>
+
+    <h3>Hoofdgerecht</h3>
+    <ul>
+    {% for o in xbento_main %}
+        <li>
+            <form action="/dashboard/xbento_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/xbento_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/xbento_options/add" method="post">
+        <input type="hidden" name="category" value="main">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
+    <h3>Bijgerecht</h3>
+    <ul>
+    {% for o in xbento_side %}
+        <li>
+            <form action="/dashboard/xbento_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/xbento_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/xbento_options/add" method="post">
+        <input type="hidden" name="category" value="side">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
+    <h3>Rijstsoort</h3>
+    <ul>
+    {% for o in xbento_rice %}
+        <li>
+            <form action="/dashboard/xbento_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/xbento_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/xbento_options/add" method="post">
+        <input type="hidden" name="category" value="rice">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
+    <h3>Groente</h3>
+    <ul>
+    {% for o in xbento_groente %}
+        <li>
+            <form action="/dashboard/xbento_options/{{ o.id }}" method="post" style="display:inline;">
+                <input type="text" name="name" value="{{ o.name }}">
+                <input type="number" step="0.01" name="price" value="{{ o.price }}">
+                <button type="submit">Opslaan</button>
+            </form>
+            <form action="/dashboard/xbento_options/{{ o.id }}/delete" method="post" style="display:inline;">
+                <button type="submit">Verwijder</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+    <form action="/dashboard/xbento_options/add" method="post">
+        <input type="hidden" name="category" value="groente">
+        <input type="text" name="name" placeholder="Naam">
+        <input type="number" step="0.01" name="price" placeholder="Prijs">
+        <button type="submit">Toevoegen</button>
+    </form>
+
     <script>
         document.getElementById('settingForm').addEventListener('submit', function(e) {
             e.preventDefault();  // 防止页面刷新

--- a/templates/index.html
+++ b/templates/index.html
@@ -1670,31 +1670,21 @@ input:focus, select:focus, textarea:focus {
 <div class="bubble-option">
 <select id="xBentoMain">
 <option value="">Hoofdgerecht</option>
-<option value="Teriyaki beef">Teriyaki beef</option>
-<option value="Lamskotelet">Lamskotelet</option>
-<option value="Ebi">Ebi</option>
-<option value="Zalm">Zalm</option>
-<option value="Usuyaki(biefroll)">Usuyaki(biefroll)</option>
-
-<option value="Teriyaki chicken">Teriyaki chicken</option>
 </select>
 </div>
 <div class="bubble-option">
 <select id="xBentoSide">
 <option value="">Bijgerecht</option>
-<option value="Gyoza">Gyoza</option>
-<option value="Edamame">Edamame</option>
-<option value="Ebi fry">Ebi fry</option>
-<option value="Chicken karaage">Chicken karaage</option>
-<option value="Chicken spring roll">Chicken spring roll</option>
 </select>
 </div>
 <div class="bubble-option">
   <select id="xBentoRice">
 <option value="">Rijstsoort</option>
-<option value="White rice">White rice</option>
-<option value="Fried rice (+€5)">Fried rice (+€5)</option>
-  <option value="Sushi rice">Sushi rice</option>
+  </select>
+</div>
+<div class="bubble-option">
+  <select id="xBentoVeg">
+    <option value="">Groente</option>
   </select>
 </div>
     <div class="new-set-wrap hidden" id="xBentoNewWrap">
@@ -2459,6 +2449,7 @@ const DEFAULT_PACKAGING_FEE = 0.20;
 const DELIVERY_FEE = 2.50;
 let milkTeaPrice = 0;
 let bubbleOptions = {base: [], smaak: [], topping: []};
+let xbentoOptions = {main: [], side: [], rice: [], groente: []};
 let currentPackaging = 0;
 let currentSubtotal = 0;
 let finalTotal = 0;
@@ -2488,6 +2479,29 @@ function updateMilkTeaDisplay(){
   }
 }
 
+function getXbentoOptionPrice(cat, name){
+  const opt = (xbentoOptions[cat]||[]).find(o=>o.name===name);
+  return opt ? parseFloat(opt.price) : 0;
+}
+
+function getXbentoPrice(){
+  const main=document.getElementById('xBentoMain').value;
+  const side=document.getElementById('xBentoSide').value;
+  const rice=document.getElementById('xBentoRice').value;
+  const veg=document.getElementById('xBentoVeg').value;
+  return getXbentoOptionPrice('main',main)+getXbentoOptionPrice('side',side)+getXbentoOptionPrice('rice',rice)+getXbentoOptionPrice('groente',veg);
+}
+
+function updateXbentoDisplay(){
+  const price=getXbentoPrice();
+  const item=document.querySelector('.menu-item[data-name="Xbento"]');
+  if(item){
+    item.dataset.price=price;
+    const p=item.querySelector('p');
+    if(p) p.textContent=`€ ${price.toFixed(2)}`;
+  }
+}
+
 function saveCart() {
   sessionStorage.setItem('novaCart', JSON.stringify(cart));
 }
@@ -2513,11 +2527,37 @@ function populateBubbleSelectors(){
   bubbleOptions.topping.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curTopping) opt.selected=true;toppingSel.appendChild(opt);});
 }
 
+function populateXbentoSelectors(){
+  const mainSel=document.getElementById('xBentoMain');
+  const sideSel=document.getElementById('xBentoSide');
+  const riceSel=document.getElementById('xBentoRice');
+  const vegSel=document.getElementById('xBentoVeg');
+  const curMain=mainSel.value,curSide=sideSel.value,curRice=riceSel.value,curVeg=vegSel.value;
+  mainSel.innerHTML='<option value="">Hoofdgerecht</option>';
+  xbentoOptions.main.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curMain) opt.selected=true;mainSel.appendChild(opt);});
+  sideSel.innerHTML='<option value="">Bijgerecht</option>';
+  xbentoOptions.side.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curSide) opt.selected=true;sideSel.appendChild(opt);});
+  riceSel.innerHTML='<option value="">Rijstsoort</option>';
+  xbentoOptions.rice.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curRice) opt.selected=true;riceSel.appendChild(opt);});
+  vegSel.innerHTML='<option value="">Groente</option>';
+  xbentoOptions.groente.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curVeg) opt.selected=true;vegSel.appendChild(opt);});
+}
+
 function updateBubbleCartPrices(){
   Object.entries(cart).forEach(([name,item])=>{
     const m=name.match(/^Bubble Tea \(([^,]+), ([^,]+), ([^)]+)\)$/);
     if(!m) return;
     const price=getOptionPrice('base',m[1])+getOptionPrice('smaak',m[2])+getOptionPrice('topping',m[3]);
+    item.price=price;
+  });
+  updateCart();
+}
+
+function updateXbentoCartPrices(){
+  Object.entries(cart).forEach(([name,item])=>{
+    const m=name.match(/^Xbento \(([^,]+), ([^,]+), ([^,]+), ([^)]+)\)$/);
+    if(!m) return;
+    const price=getXbentoOptionPrice('main',m[1])+getXbentoOptionPrice('side',m[2])+getXbentoOptionPrice('rice',m[3])+getXbentoOptionPrice('groente',m[4]);
     item.price=price;
   });
   updateCart();
@@ -2529,6 +2569,15 @@ function fetchBubbleOptions(){
     populateBubbleSelectors();
     updateMilkTeaDisplay();
     updateBubbleCartPrices();
+  });
+}
+
+function fetchXbentoOptions(){
+  fetch('/api/xbento_options').then(r=>r.json()).then(data=>{
+    xbentoOptions=data;
+    populateXbentoSelectors();
+    updateXbentoDisplay();
+    updateXbentoCartPrices();
   });
 }
 
@@ -2664,20 +2713,18 @@ function changeXbentoQty(delta) {
   const main = document.getElementById("xBentoMain").value;
   const side = document.getElementById("xBentoSide").value;
   const rice = document.getElementById("xBentoRice").value;
+  const veg = document.getElementById("xBentoVeg").value;
 
   // 如果没选完配料，不更新数量也不更新购物车
-  if (!main || !side || !rice) return;
+  if (!main || !side || !rice || !veg) return;
 
   val = Math.max(0, Math.min(20, val + delta));
   qtySel.value = val;  // ✅ 只有当所有项都选择后再更新数量
 
-  let basePrice = 14;
-  if (rice.includes("Fried rice")) {
-    basePrice += 5;
-  }
+  const price = getXbentoPrice();
 
-  const fullName = `Xbento (${main}, ${side}, ${rice})`;
-  setQty(fullName, basePrice, val, DEFAULT_PACKAGING_FEE);
+  const fullName = `Xbento (${main}, ${side}, ${rice}, ${veg})`;
+  setQty(fullName, price, val, DEFAULT_PACKAGING_FEE);
   if (xbentoSetControls) xbentoSetControls.update();
 }
 
@@ -2796,7 +2843,8 @@ function setDragonQty() {
     const main = document.getElementById("xBentoMain").value;
     const side = document.getElementById("xBentoSide").value;
     const rice = document.getElementById("xBentoRice").value;
-    return main && side && rice;
+    const veg = document.getElementById("xBentoVeg").value;
+    return main && side && rice && veg;
   }
 
   function isXbowlValid() {
@@ -2818,11 +2866,17 @@ function setDragonQty() {
     });
   });
 
+  ['xBentoMain','xBentoSide','xBentoRice','xBentoVeg'].forEach(id=>{
+    document.getElementById(id).addEventListener('change', () => {
+      updateXbentoDisplay();
+    });
+  });
+
   xbentoSetControls = initNewSetControls({
     qtyId: 'xBentoQty',
     wrapId: 'xBentoNewWrap',
     buttonId: 'xBentoNew',
-    fieldIds: ['xBentoMain','xBentoSide','xBentoRice']
+    fieldIds: ['xBentoMain','xBentoSide','xBentoRice','xBentoVeg']
   });
   xbentoSetControls.update();
 
@@ -2846,7 +2900,7 @@ function setDragonQty() {
   // 🍱 Xbento 按钮加减（保留一次即可）
   document.querySelector('.qty-plus[data-target="xBentoQty"]').addEventListener('click', () => {
     if (!isXbentoValid()) {
-      alert("🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.");
+      alert("🍱 Kies eerst hoofdgerecht, bijgerecht, rijstsoort en groente voor je Xbento.");
       return;
     }
     changeXbentoQty(1);
@@ -2854,7 +2908,7 @@ function setDragonQty() {
 
   document.querySelector('.qty-minus[data-target="xBentoQty"]').addEventListener('click', () => {
     if (!isXbentoValid()) {
-      alert("🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.");
+      alert("🍱 Kies eerst hoofdgerecht, bijgerecht, rijstsoort en groente voor je Xbento.");
       return;
     }
     changeXbentoQty(-1);
@@ -2891,7 +2945,7 @@ function setDragonQty() {
   // 🍱 Xbento select 直接选择数量时
   document.getElementById('xBentoQty').addEventListener('change', () => {
     if (!isXbentoValid()) {
-      alert("🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.");
+      alert("🍱 Kies eerst hoofdgerecht, bijgerecht, rijstsoort en groente voor je Xbento.");
       document.getElementById('xBentoQty').value = 0;
       return;
     }
@@ -4324,6 +4378,7 @@ function fetchStatus(){
 }
 fetchStatus();
 fetchBubbleOptions();
+fetchXbentoOptions();
 const socket = io();
 socket.on('setting_update', updateStatus);
 socket.on('time_update', updateTimes);
@@ -4336,6 +4391,12 @@ socket.on('bubble_options_update', data => {
   populateBubbleSelectors();
   updateMilkTeaDisplay();
   updateBubbleCartPrices();
+});
+socket.on('xbento_options_update', data => {
+  xbentoOptions = data;
+  populateXbentoSelectors();
+  updateXbentoDisplay();
+  updateXbentoCartPrices();
 });
 const overlay = document.getElementById('closed-overlay');
 if(overlay){

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -257,29 +257,24 @@
     <div class="bubble-option">
       <select id="xBentoMain">
         <option value="">Hoofdgerecht</option>
-        <option value="Teriyaki beef">Teriyaki beef</option>
-        <option value="Karaage chicken">Karaage chicken</option>
-        <option value="Ebi fry">Ebi fry</option>
-        <option value="Zalm">Zalm</option>
-        <option value="Teriyaki chicken">Teriyaki chicken</option>
       </select>
     </div>
 
     <div class="bubble-option">
       <select id="xBentoSide">
         <option value="">Bijgerecht</option>
-        <option value="Gyoza">Gyoza</option>
-        <option value="Edamame">Edamame</option>
-        <option value="Spring Roll">Spring Roll</option>
       </select>
     </div>
 
     <div class="bubble-option">
       <select id="xBentoRice">
         <option value="">Rijstsoort</option>
-        <option value="White rice">White rice</option>
-        <option value="Fried rice (+€5)">Fried rice (+€5)</option>
-       <option value="Sushi rice">Sushi rice</option>
+      </select>
+    </div>
+
+    <div class="bubble-option">
+      <select id="xBentoVeg">
+        <option value="">Groente</option>
       </select>
     </div>
 

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -680,6 +680,7 @@ const extras = {
 };
 let milkTeaPrice = 0;
 let bubbleOptions = {base: [], smaak: [], topping: []};
+let xbentoOptions = {main: [], side: [], rice: [], groente: []};
 
 function getOptionPrice(cat,name){
   const opt=(bubbleOptions[cat]||[]).find(o=>o.name===name);
@@ -703,6 +704,29 @@ function updateMilkTeaDisplay(){
   }
 }
 
+function getXbentoOptionPrice(cat,name){
+  const opt=(xbentoOptions[cat]||[]).find(o=>o.name===name);
+  return opt?parseFloat(opt.price):0;
+}
+
+function getXbentoPrice(){
+  const main=document.getElementById('xBentoMain').value;
+  const side=document.getElementById('xBentoSide').value;
+  const rice=document.getElementById('xBentoRice').value;
+  const veg=document.getElementById('xBentoVeg').value;
+  return getXbentoOptionPrice('main',main)+getXbentoOptionPrice('side',side)+getXbentoOptionPrice('rice',rice)+getXbentoOptionPrice('groente',veg);
+}
+
+function updateXbentoDisplay(){
+  const price=getXbentoPrice();
+  const item=document.querySelector('.menu-item[data-name="Xbento"]');
+  if(item){
+    item.dataset.price=price;
+    const p=item.querySelector('p');
+    if(p) p.textContent=`€${price.toFixed(2)}`;
+  }
+}
+
 function changeBubbleQty(delta){
   const sel=document.getElementById('bubbleTeaQty');
   let val=parseInt(sel.value||0);
@@ -723,12 +747,12 @@ function changeXbentoQty(delta){
   const main=document.getElementById('xBentoMain').value;
   const side=document.getElementById('xBentoSide').value;
   const rice=document.getElementById('xBentoRice').value;
-  if(!main||!side||!rice) return;
+  const veg=document.getElementById('xBentoVeg').value;
+  if(!main||!side||!rice||!veg) return;
   val=Math.max(0,Math.min(20,val+delta));
   sel.value=val;
-  let price=14;
-  if(rice.includes('Fried rice')) price+=5;
-  const name=`Xbento (${main}, ${side}, ${rice})`;
+  const price=getXbentoPrice();
+  const name=`Xbento (${main}, ${side}, ${rice}, ${veg})`;
   setQty(name,price,val,0.2);
 }
 
@@ -913,7 +937,7 @@ function updateCart(){
 }
 
 document.addEventListener('DOMContentLoaded',()=>{
-  const skip=['bubbleTeaQty','bubbleType','bubbleFlavor','bubbleTopping','xBentoMain','xBentoSide','xBentoRice',
+  const skip=['bubbleTeaQty','bubbleType','bubbleFlavor','bubbleTopping','xBentoMain','xBentoSide','xBentoRice','xBentoVeg',
     'ebiBase','ebiSmaak','ebiQty','chickenBase','chickenSmaak','chickenQty','beefBase','beefSmaak','beefQty',
     'ribeyeBase','ribeyeSmaak','ribeyeQty','chasiuBase','chasiuSmaak','chasiuQty'];
   document.querySelectorAll('.menu-item select').forEach(sel=>{
@@ -940,6 +964,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   ['bubbleType','bubbleFlavor','bubbleTopping'].forEach(id=>{
     document.getElementById(id).addEventListener('change',()=>{updateMilkTeaDisplay();});
   });
+  ['xBentoMain','xBentoSide','xBentoRice','xBentoVeg'].forEach(id=>{
+    document.getElementById(id).addEventListener('change',()=>{updateXbentoDisplay();});
+  });
 
   document.querySelector('.qty-plus[data-target="bubbleTeaQty"]').addEventListener('click',()=>{
     if(!document.getElementById('bubbleType').value||!document.getElementById('bubbleFlavor').value||!document.getElementById('bubbleTopping').value){alert('🧋 Kies eerst type, smaak en topping voor je bubble tea.');return;}changeBubbleQty(1);});
@@ -948,10 +975,10 @@ document.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('bubbleTeaQty').addEventListener('change',()=>{if(!document.getElementById('bubbleType').value||!document.getElementById('bubbleFlavor').value||!document.getElementById('bubbleTopping').value){alert('🧋 Kies eerst type, smaak en topping voor je bubble tea.');document.getElementById('bubbleTeaQty').value=0;return;}changeBubbleQty(0);});
 
   document.querySelector('.qty-plus[data-target="xBentoQty"]').addEventListener('click',()=>{
-    if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.');return;}changeXbentoQty(1);});
+    if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value||!document.getElementById('xBentoVeg').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht, rijstsoort en groente voor je Xbento.');return;}changeXbentoQty(1);});
   document.querySelector('.qty-minus[data-target="xBentoQty"]').addEventListener('click',()=>{
-    if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.');return;}changeXbentoQty(-1);});
-  document.getElementById('xBentoQty').addEventListener('change',()=>{if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht en rijstsoort voor je Xbento.');document.getElementById('xBentoQty').value=0;return;}changeXbentoQty(0);});
+    if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value||!document.getElementById('xBentoVeg').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht, rijstsoort en groente voor je Xbento.');return;}changeXbentoQty(-1);});
+  document.getElementById('xBentoQty').addEventListener('change',()=>{if(!document.getElementById('xBentoMain').value||!document.getElementById('xBentoSide').value||!document.getElementById('xBentoRice').value||!document.getElementById('xBentoVeg').value){alert('🍱 Kies eerst hoofdgerecht, bijgerecht, rijstsoort en groente voor je Xbento.');document.getElementById('xBentoQty').value=0;return;}changeXbentoQty(0);});
 
   const ramenIds=['ebiQty','chickenQty','beefQty','ribeyeQty','chasiuQty'];
   document.querySelectorAll('.qty-plus').forEach(btn=>{
@@ -1396,11 +1423,37 @@ function formatCurrency(value){
     bubbleOptions.topping.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curTopping) opt.selected=true;toppingSel.appendChild(opt);});
   }
 
+  function populateXbentoSelectors(){
+    const mainSel=document.getElementById('xBentoMain');
+    const sideSel=document.getElementById('xBentoSide');
+    const riceSel=document.getElementById('xBentoRice');
+    const vegSel=document.getElementById('xBentoVeg');
+    const curMain=mainSel.value,curSide=sideSel.value,curRice=riceSel.value,curVeg=vegSel.value;
+    mainSel.innerHTML='<option value="">Hoofdgerecht</option>';
+    xbentoOptions.main.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curMain) opt.selected=true;mainSel.appendChild(opt);});
+    sideSel.innerHTML='<option value="">Bijgerecht</option>';
+    xbentoOptions.side.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curSide) opt.selected=true;sideSel.appendChild(opt);});
+    riceSel.innerHTML='<option value="">Rijstsoort</option>';
+    xbentoOptions.rice.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curRice) opt.selected=true;riceSel.appendChild(opt);});
+    vegSel.innerHTML='<option value="">Groente</option>';
+    xbentoOptions.groente.forEach(o=>{const opt=document.createElement('option');opt.value=o.name;opt.textContent=o.name;if(o.name===curVeg) opt.selected=true;vegSel.appendChild(opt);});
+  }
+
   function updateBubbleCartPrices(){
     Object.entries(cart).forEach(([name,item])=>{
       const m=name.match(/^Bubble Tea \(([^,]+), ([^,]+), ([^)]+)\)$/);
       if(!m) return;
       const price=getOptionPrice('base',m[1])+getOptionPrice('smaak',m[2])+getOptionPrice('topping',m[3]);
+      item.price=price;
+    });
+    updateCart();
+  }
+
+  function updateXbentoCartPrices(){
+    Object.entries(cart).forEach(([name,item])=>{
+      const m=name.match(/^Xbento \(([^,]+), ([^,]+), ([^,]+), ([^)]+)\)$/);
+      if(!m) return;
+      const price=getXbentoOptionPrice('main',m[1])+getXbentoOptionPrice('side',m[2])+getXbentoOptionPrice('rice',m[3])+getXbentoOptionPrice('groente',m[4]);
       item.price=price;
     });
     updateCart();
@@ -1414,6 +1467,15 @@ function formatCurrency(value){
       updateBubbleCartPrices();
     });
   }
+
+  function fetchXbentoOptions(){
+    fetch('/api/xbento_options').then(r=>r.json()).then(data=>{
+      xbentoOptions=data;
+      populateXbentoSelectors();
+      updateXbentoDisplay();
+      updateXbentoCartPrices();
+    });
+  }
   async function loadMenu(){
     const r=await fetch('/api/menu');
     if(r.ok){ const d=await r.json(); applyMenuPrices(d); }
@@ -1421,6 +1483,7 @@ function formatCurrency(value){
   loadMenu();
   fetch('/api/settings').then(r=>r.json()).then(s=>{ if(s.milktea_price){ milkTeaPrice=parseFloat(s.milktea_price); updateMilkTeaDisplay(); }});
   fetchBubbleOptions();
+  fetchXbentoOptions();
   socket.on('menu_update', applyMenuPrices);
   socket.on('milktea_price_update', data => {
     milkTeaPrice = parseFloat(data.price || data);
@@ -1431,6 +1494,12 @@ function formatCurrency(value){
     populateBubbleSelectors();
     updateMilkTeaDisplay();
     updateBubbleCartPrices();
+  });
+  socket.on('xbento_options_update', data => {
+    xbentoOptions=data;
+    populateXbentoSelectors();
+    updateXbentoDisplay();
+    updateXbentoCartPrices();
   });
 
   let pollTimer;


### PR DESCRIPTION
## Summary
- support xbento option categories via new `XbentoOption` model
- expose `/api/xbento_options` endpoint
- manage xbento options from the dashboard and emit websocket updates
- load xbento options dynamically on the index and POS pages
- add Groente selection and price calculation for Xbento

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6865217243cc8333acc5dea965e66271