### PR TITLE
Fix earliest time calculation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3658,11 +3658,14 @@ function checkout() {
       close.setDate(close.getDate() + 1);
     }
 
-    // always include configured start time as the first option
-    const firstOpt = document.createElement('option');
-    firstOpt.value = oStr;
-    firstOpt.textContent = oStr;
-    select.appendChild(firstOpt);
+    // only include Dashboard start time if it is not in the past
+    const includeStart = open.getTime() >= now.getTime();
+    if (includeStart) {
+      const firstOpt = document.createElement('option');
+      firstOpt.value = oStr;
+      firstOpt.textContent = oStr;
+      select.appendChild(firstOpt);
+    }
 
     let start = now > open ? now : open;
     start = new Date(start);


### PR DESCRIPTION
## Summary
- ensure earliest time option never precedes current time plus preparation time

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_68656fe582c083338f843c2ac6263226