### PR TITLE
Add POS order done notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,9 @@ from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import Table, TableStyle
 from reportlab.lib import colors
+import smtplib
+import requests
+import re
 
 import traceback
 
@@ -214,6 +217,57 @@ def build_maps_link(street: str, house_number: str, postcode: str, city: str) ->
         return None
     address = f"{street} {house_number}, {postcode} {city}"
     return f"https://www.google.com/maps?q={quote(address)}"
+
+def get_telegram_chat_id(phone: str) -> str | None:
+    """Lookup Telegram chat ID by phone number."""
+    phone_digits = re.sub(r"\D", "", phone or "")
+    mapping = {}
+    data = os.getenv("TELEGRAM_CONTACTS")
+    if data:
+        try:
+            mapping = json.loads(data)
+        except Exception:
+            pass
+    else:
+        path = os.path.join(BASE_DIR, "telegram_contacts.json")
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    mapping = json.load(f)
+            except Exception:
+                pass
+    return mapping.get(phone_digits)
+
+def send_email(to_addr: str, subject: str, body: str) -> bool:
+    server = os.getenv("SMTP_SERVER")
+    username = os.getenv("SMTP_USERNAME")
+    password = os.getenv("SMTP_PASSWORD")
+    from_addr = os.getenv("FROM_EMAIL", username)
+    port = int(os.getenv("SMTP_PORT", "587"))
+    if not (server and username and password and from_addr and to_addr):
+        return False
+    try:
+        with smtplib.SMTP(server, port, timeout=10) as smtp:
+            smtp.starttls()
+            smtp.login(username, password)
+            msg = f"Subject: {subject}\nFrom: {from_addr}\nTo: {to_addr}\n\n{body}"
+            smtp.sendmail(from_addr, [to_addr], msg)
+        return True
+    except Exception as e:
+        print("Email send failed", e)
+        return False
+
+def send_telegram(chat_id: str, text: str) -> bool:
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not (token and chat_id):
+        return False
+    try:
+        url = f"https://api.telegram.org/bot{token}/sendMessage"
+        requests.post(url, data={"chat_id": chat_id, "text": text}, timeout=5)
+        return True
+    except Exception as e:
+        print("Telegram send failed", e)
+        return False
 
 
 def get_bubble_options_dict():
@@ -1001,6 +1055,20 @@ def pos_orders_today():
         return jsonify(order_dicts)
 
     return render_template("pos_orders.html", orders=orders)
+
+@app.route('/pos/order_done/<int:order_id>', methods=['POST'])
+@login_required
+def order_done(order_id):
+    order = Order.query.get_or_404(order_id)
+    is_pickup = order.order_type in ['afhalen', 'pickup']
+    message = 'Your order is ready for pickup.' if is_pickup else 'Your order has been delivered.'
+    if order.email and '@' in order.email:
+        send_email(order.email, 'Order update', message)
+    chat_id = get_telegram_chat_id(order.phone)
+    if chat_id:
+        send_telegram(chat_id, message)
+    socketio.emit('order_done', {'id': order_id})
+    return jsonify({'status': 'ok'})
 @app.route('/login', methods=["GET", "POST"])
 def login():
     if request.method == "POST":

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -90,6 +90,7 @@ th:last-child {
        <th>Tijdslot</th>
        <th>Betaalwijze</th>
        <th>Ordernummer</th>
+       <th>Actie</th>
       </tr>
     </thead>
     <tbody>
@@ -135,6 +136,7 @@ th:last-child {
         </td>
         <td>{{ order.payment_method }}</td>
         <td>{{ order.order_number or '' }}</td>
+        <td><button class="done-btn" data-id="{{ order.id }}">Done</button></td>
       </tr>
     {% endfor %}
     </tbody>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -498,6 +498,10 @@
   white-space: nowrap;
   padding: 8px;
 }
+.done-btn{
+  padding:4px 8px;
+  border-radius:4px;
+}
 /* 默认隐藏圆按钮 */
 .today-toggle {
   display: none;
@@ -517,6 +521,10 @@
 @keyframes highlightBlink {
   0%,100% { background-color: #eaffea; }
   50% { background-color: #fff; }
+}
+/* ✅ Mark order as done */
+.order-done {
+  background-color: #c8f7c5 !important;
 }
 
 /* 桌面显示长按钮，确保隐藏圆按钮 */
@@ -1088,6 +1096,10 @@ document.addEventListener('DOMContentLoaded',()=>{
   if (audioCtx.state === 'suspended') {
     audioCtx.resume().catch(() => {});
   }
+  document.querySelectorAll('.orders-panel .done-btn').forEach(btn => {
+    const tr = btn.closest('tr');
+    if(tr) attachDoneHandler(tr, btn.dataset.id);
+  });
 
 });
 
@@ -1562,6 +1574,20 @@ function formatCurrency(value){
     tbody.appendChild(tr);
   }
 
+  function attachDoneHandler(tr, id){
+    const btn = tr.querySelector('.done-btn');
+    if(!btn) return;
+    btn.addEventListener('click', () => {
+      if(!confirm('Are you sure you want to mark this order as done and send the notification?')) return;
+      fetch(`/pos/order_done/${id}`, {method: 'POST'})
+        .then(r => r.json())
+        .then(() => {
+          tr.classList.add('order-done');
+          btn.disabled = true;
+        });
+    });
+  }
+
   // 添加订单到表格
   function addRow(order, highlight=false) {
     const tbody = document.querySelector('.orders-panel tbody');
@@ -1606,14 +1632,16 @@ function formatCurrency(value){
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>
-        <td>${order.order_number || '-'}</td>`;
-      
+        <td>${order.order_number || '-'}</td>
+        <td><button class="done-btn" data-id="${order.id}">Done</button></td>`;
+
     tr.dataset.sortKey = getSortKey(order);
     if(highlight){
       tr.classList.add('new-order');
       setTimeout(()=>tr.classList.remove('new-order'),10000);
     }
     insertSorted(tbody, tr);
+    attachDoneHandler(tr, order.id);
     updateTodayBadge();
     return tr;
   }
@@ -1634,6 +1662,11 @@ function formatCurrency(value){
     updateTodayBadge();
   }
 });
+
+  socket.on('order_done', data => {
+    const row = document.querySelector(`tr[data-id="${data.id}"]`);
+    if(row) row.classList.add('order-done');
+  });
 
   // 断线后启用轮询
   socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- add Done button column to order table
- style completed orders and buttons in POS page
- implement frontend logic to mark orders as done and send POST request
- notify other sessions via Socket.IO when orders are marked done
- backend endpoint to handle Done action and send email/Telegram alerts

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68660ec73f648333a820c671bc3114c7