### PR TITLE
Add order complete button in POS

### DIFF
--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -90,6 +90,7 @@ th:last-child {
        <th>Tijdslot</th>
        <th>Betaalwijze</th>
        <th>Ordernummer</th>
+       <th>操作</th>
       </tr>
     </thead>
     <tbody>
@@ -135,8 +136,41 @@ th:last-child {
         </td>
         <td>{{ order.payment_method }}</td>
         <td>{{ order.order_number or '' }}</td>
+        <td><button onclick="orderComplete(this)"
+          data-number="{{ order.order_number }}"
+          data-name="{{ order.customer_name or '' }}"
+          data-phone="{{ order.phone or '' }}"
+          data-email="{{ order.email or '' }}"
+          data-type="{{ 'bezorg' if is_delivery else 'afhaal' }}">订单完成</button>
+          <span class="notify"></span></td>
       </tr>
     {% endfor %}
     </tbody>
   </table>
 </div>
+
+<script>
+  function orderComplete(btn) {
+    const status = btn.nextElementSibling;
+    const payload = {
+      order_number: btn.dataset.number,
+      name: btn.dataset.name,
+      phone: btn.dataset.phone,
+      email: btn.dataset.email,
+      order_type: btn.dataset.type
+    };
+    fetch('https://flask-order-api.onrender.com/api/order_complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(r => {
+      if (r.ok) {
+        status.textContent = '通知已发送';
+      } else {
+        status.textContent = '通知发送失败';
+      }
+    }).catch(() => {
+      status.textContent = '通知发送失败';
+    });
+  }
+</script>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1606,7 +1606,14 @@ function formatCurrency(value){
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>
-        <td>${order.order_number || '-'}</td>`;
+        <td>${order.order_number || '-'}</td>
+        <td><button onclick="orderComplete(this)"
+          data-number="${order.order_number}"
+          data-name="${order.customer_name || ''}"
+          data-phone="${order.phone || ''}"
+          data-email="${order.email || ''}"
+          data-type="${isDelivery ? 'bezorg' : 'afhaal'}">订单完成</button>
+          <span class="notify"></span></td>`;
       
     tr.dataset.sortKey = getSortKey(order);
     if(highlight){


### PR DESCRIPTION
## Summary
- add a new `操作` column and `订单完成` button in orders table
- implement API call to mark order complete with success/fail messages
- include same functionality for dynamically added rows in POS interface

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_686654b2527483338cc9e904bb8bd60e