### PR TITLE
Add order status features

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,12 @@ with app.app_context():
         if "opmerking" not in cols:
             with db.engine.begin() as conn:
                 conn.execute(text("ALTER TABLE orders ADD COLUMN opmerking TEXT"))
+        if "is_completed" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN is_completed BOOLEAN DEFAULT FALSE"))
+        if "is_cancelled" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN is_cancelled BOOLEAN DEFAULT FALSE"))
         cols = {c["name"] for c in inspector.get_columns("reviews")}
         if "rating" not in cols:
             with db.engine.begin() as conn:
@@ -72,12 +78,14 @@ def to_nl(dt: datetime) -> datetime:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt.astimezone(NL_TZ)
-def generate_excel_today():
+def generate_excel_today(include_cancelled: bool = False):
     today = datetime.now(NL_TZ).date()
     start_local = datetime.combine(today, datetime.min.time(), tzinfo=NL_TZ)
     start = start_local.astimezone(UTC).replace(tzinfo=None)
 
     orders = Order.query.filter(Order.created_at >= start).order_by(Order.created_at.desc()).all()
+    if not include_cancelled:
+        orders = [o for o in orders if not o.is_cancelled]
     data = []
     for o in orders:
         try:
@@ -86,7 +94,7 @@ def generate_excel_today():
             items = {}
 
         summary = ", ".join(f"{k} x {v.get('qty')}" for k, v in items.items())
-        data.append({
+        row = {
             "Datum": to_nl(o.created_at).strftime("%Y-%m-%d"),
             "Tijd": to_nl(o.created_at).strftime("%H:%M"),
             "Naam": o.customer_name,
@@ -96,7 +104,10 @@ def generate_excel_today():
             "Betaalwijze": o.payment_method,
             "Totaal": f"€{o.totaal:.2f}",
             "Items": summary,
-        })
+        }
+        if o.is_cancelled:
+            row["Status"] = "Cancelled"
+        data.append(row)
 
     df = pd.DataFrame(data)
     output = BytesIO()
@@ -105,18 +116,23 @@ def generate_excel_today():
     return output
 
 
-def generate_pdf_today():
+def generate_pdf_today(include_cancelled: bool = False):
     today = datetime.now(NL_TZ).date()
     start_local = datetime.combine(today, datetime.min.time(), tzinfo=NL_TZ)
     start = start_local.astimezone(UTC).replace(tzinfo=None)
 
     orders = Order.query.filter(Order.created_at >= start).order_by(Order.created_at.desc()).all()
+    if not include_cancelled:
+        orders = [o for o in orders if not o.is_cancelled]
 
     buffer = BytesIO()
     doc = SimpleDocTemplate(buffer, pagesize=A4)
     elements = []
 
-    data = [["Datum", "Tijd", "Naam", "Totaal", "Items"]]
+    header = ["Datum", "Tijd", "Naam", "Totaal", "Items"]
+    if include_cancelled:
+        header.append("Status")
+    data = [header]
     for o in orders:
         try:
             items = json.loads(o.items or "{}")
@@ -124,13 +140,16 @@ def generate_pdf_today():
             items = {}
 
         summary = ", ".join(f"{k} x {v.get('qty')}" for k, v in items.items())
-        data.append([
+        row = [
             to_nl(o.created_at).strftime("%Y-%m-%d"),
             to_nl(o.created_at).strftime("%H:%M"),
             o.customer_name,
             f"€{o.totaal:.2f}",
             summary
-        ])
+        ]
+        if o.is_cancelled:
+            row.append("Cancelled")
+        data.append(row)
 
     table = Table(data, repeatRows=1)
     table.setStyle(TableStyle([
@@ -150,7 +169,8 @@ def generate_pdf_today():
 @app.route("/admin/orders/download/pdf")
 @login_required
 def download_pdf():
-    output = generate_pdf_today()
+    include_cancelled = bool(request.args.get('include_cancelled'))
+    output = generate_pdf_today(include_cancelled)
     return send_file(
         output,
         mimetype='application/pdf',
@@ -160,7 +180,8 @@ def download_pdf():
 @app.route("/admin/orders/download/excel")
 @login_required
 def download_excel():
-    output = generate_excel_today()
+    include_cancelled = bool(request.args.get('include_cancelled'))
+    output = generate_excel_today(include_cancelled)
     return send_file(
         output,
         mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -227,6 +248,8 @@ class Order(db.Model):
     fooi = db.Column(db.Float, default=0.0)
     discount_code = db.Column(db.String(50))  # ✅ 新增
     discount_amount = db.Column(db.Float, default=0.0)  # ✅ 新增
+    is_completed = db.Column(db.Boolean, default=False)
+    is_cancelled = db.Column(db.Boolean, default=False)
 
 
 
@@ -496,6 +519,50 @@ def validate_discount():
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/orders/<int:order_id>/complete', methods=['POST'])
+@login_required
+def api_order_complete(order_id: int):
+    order = Order.query.get_or_404(order_id)
+    data = request.get_json() or {}
+    order.is_completed = bool(data.get('completed', True))
+    db.session.commit()
+    return jsonify({'status': 'ok', 'completed': order.is_completed})
+
+
+@app.route('/api/orders/<int:order_id>/cancel', methods=['POST'])
+@login_required
+def api_order_cancel(order_id: int):
+    order = Order.query.get_or_404(order_id)
+    data = request.get_json() or {}
+    order.is_cancelled = bool(data.get('cancel', True))
+    db.session.commit()
+    return jsonify({'status': 'ok', 'cancelled': order.is_cancelled})
+
+
+@app.route('/api/orders/<int:order_id>', methods=['PUT'])
+@login_required
+def api_order_update(order_id: int):
+    order = Order.query.get_or_404(order_id)
+    data = request.get_json() or {}
+
+    for field in [
+        'customer_name', 'phone', 'email', 'street', 'house_number', 'postcode',
+        'city', 'pickup_time', 'delivery_time', 'order_type', 'payment_method']:
+        if field in data:
+            setattr(order, field, data[field])
+
+    if 'items' in data:
+        order.items = json.dumps(data['items'])
+
+    if 'is_completed' in data:
+        order.is_completed = bool(data['is_completed'])
+    if 'is_cancelled' in data:
+        order.is_cancelled = bool(data['is_cancelled'])
+
+    db.session.commit()
+    return jsonify({'status': 'ok'})
 
 
 # 获取设置
@@ -954,7 +1021,9 @@ def pos_orders_today():
             "total": totaal,   # ✅ 关键是这里：使用数据库中的 totaal
             "totaal": totaal,
             "fooi": o.fooi or 0,
-            "order_number": o.order_number  # ✅ 加上这行
+            "order_number": o.order_number,  # ✅ 加上这行
+            "is_completed": o.is_completed,
+            "is_cancelled": o.is_cancelled
         })
 
     if request.args.get("json"):

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -26,6 +26,8 @@
       font-size: 14px;
       cursor: pointer;
     }
+    .completed { background-color: #c8e6c9; }
+    .cancelled { background-color: #e0e0e0; }
   </style>
 </head>
 <body>
@@ -129,6 +131,8 @@
 
           data.forEach(order => {
             const tr = document.createElement('tr');
+            if (order.is_cancelled) tr.classList.add('cancelled');
+            else if (order.is_completed) tr.classList.add('completed');
             const isDelivery = ['delivery', 'bezorgen'].includes((order.order_type || '').toLowerCase());
             const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
             let fooi = parseFloat(order.fooi);
@@ -140,12 +144,14 @@
               tot = parseFloat(tot.replace(/[^\d,.-]/g, '').replace(',', '.'));
             }
 
-            total += tot;
-            const method = String(order.payment_method || '').toLowerCase();
-            if (method.includes('pin')) pin += tot;
-            else if (method.includes('online')) online += tot;
-            else if (method.includes('contant')) contant += tot;
-            else if (method.includes('rekening')) credit += tot;
+            if (!order.is_cancelled) {
+              total += tot;
+              const method = String(order.payment_method || '').toLowerCase();
+              if (method.includes('pin')) pin += tot;
+              else if (method.includes('online')) online += tot;
+              else if (method.includes('contant')) contant += tot;
+              else if (method.includes('rekening')) credit += tot;
+            }
 
             tr.innerHTML = `
               <td>${order.id || ''}</td>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -45,6 +45,8 @@
     color: green;
     font-weight: bold;
   }
+  .completed { background-color: #c8e6c9; }
+  .cancelled { background-color: #e0e0e0; }
   
   table.orders-table {
     width: 100%;
@@ -95,7 +97,8 @@ th:last-child {
     </thead>
     <tbody>
     {% for order in orders %}
-      <tr>
+      <tr class="{% if order.is_cancelled %}cancelled{% elif order.is_completed %}completed{% endif %}">
+        {% set row_id = order.id %}
         <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
@@ -136,13 +139,20 @@ th:last-child {
         </td>
         <td>{{ order.payment_method }}</td>
         <td>{{ order.order_number or '' }}</td>
-        <td><button onclick="orderComplete(this)"
-          data-number="{{ order.order_number }}"
-          data-name="{{ order.customer_name or '' }}"
-          data-phone="{{ order.phone or '' }}"
-          data-email="{{ order.email or '' }}"
-          data-type="{{ 'bezorg' if is_delivery else 'afhaal' }}">订单完成</button>
-          <span class="notify"></span></td>
+        <td>
+          <button onclick="orderComplete(this)"
+            data-id="{{ row_id }}"
+            data-number="{{ order.order_number }}"
+            data-name="{{ order.customer_name or '' }}"
+            data-phone="{{ order.phone or '' }}"
+            data-email="{{ order.email or '' }}"
+            data-type="{{ 'bezorg' if is_delivery else 'afhaal' }}">
+            {{ 'Undone' if order.is_completed else '订单完成' }}
+          </button>
+          <button onclick="editOrder(this)" data-id="{{ row_id }}">编辑</button>
+          <button onclick="cancelOrder(this)" data-id="{{ row_id }}">取消</button>
+          <span class="notify"></span>
+        </td>
       </tr>
     {% endfor %}
     </tbody>
@@ -152,25 +162,73 @@ th:last-child {
 <script>
   function orderComplete(btn) {
     const status = btn.nextElementSibling;
-    const payload = {
-      order_number: btn.dataset.number,
-      name: btn.dataset.name,
-      phone: btn.dataset.phone,
-      email: btn.dataset.email,
-      order_type: btn.dataset.type
-    };
-    fetch('https://flask-order-api.onrender.com/api/order_complete', {
+    const completed = btn.textContent.trim() !== 'Undone';
+    fetch(`/api/orders/${btn.dataset.id}/complete`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    }).then(r => {
-      if (r.ok) {
-        status.textContent = '通知已发送';
+      body: JSON.stringify({ completed })
+    }).then(r => r.json()).then(() => {
+      const row = btn.closest('tr');
+      if (completed) {
+        row.classList.add('completed');
+        btn.textContent = 'Undone';
+        const payload = {
+          order_number: btn.dataset.number,
+          name: btn.dataset.name,
+          phone: btn.dataset.phone,
+          email: btn.dataset.email,
+          order_type: btn.dataset.type
+        };
+        fetch('https://flask-order-api.onrender.com/api/order_complete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        }).then(() => { status.textContent = ''; }).catch(() => {});
       } else {
-        status.textContent = '通知发送失败';
+        row.classList.remove('completed');
+        btn.textContent = '订单完成';
       }
-    }).catch(() => {
-      status.textContent = '通知发送失败';
+    });
+  }
+
+  function cancelOrder(btn) {
+    if (!confirm('确定取消该订单?')) return;
+    fetch(`/api/orders/${btn.dataset.id}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cancel: true })
+    }).then(() => {
+      const row = btn.closest('tr');
+      row.classList.remove('completed');
+      row.classList.add('cancelled');
+    });
+  }
+
+  function editOrder(btn) {
+    const id = btn.dataset.id;
+    const row = btn.closest('tr');
+    const cells = row.children;
+    const data = {
+      customer_name: prompt('Naam', cells[3].textContent) || cells[3].textContent,
+      phone: prompt('Telefoon', cells[4].textContent) || cells[4].textContent,
+      email: prompt('Email', cells[5].textContent) || cells[5].textContent,
+      street: prompt('Straat', cells[10].textContent.split(' ')[0]) || cells[10].textContent.split(' ')[0],
+      house_number: prompt('Huisnummer', cells[10].textContent.split(' ')[1] || '') || cells[10].textContent.split(' ')[1] || '',
+      postcode: prompt('Postcode', '') || '',
+      city: prompt('Stad', '') || '',
+      pickup_time: cells[11].textContent,
+      delivery_time: cells[11].textContent,
+      order_type: cells[2].textContent.toLowerCase() === 'bezorgen' ? 'bezorgen' : 'afhalen'
+    };
+    fetch(`/api/orders/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).then(() => {
+      cells[3].textContent = data.customer_name;
+      cells[4].textContent = data.phone;
+      cells[5].textContent = data.email;
+      cells[10].textContent = `${data.street} ${data.house_number}`;
     });
   }
 </script>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -514,6 +514,8 @@
   animation: highlightBlink 1s ease-in-out;
   animation-iteration-count: 10;
 }
+tr.completed { background-color: #c8e6c9; }
+tr.cancelled { background-color: #e0e0e0; }
 @keyframes highlightBlink {
   0%,100% { background-color: #eaffea; }
   50% { background-color: #fff; }
@@ -1569,6 +1571,8 @@ function formatCurrency(value){
 
     const tr = document.createElement('tr');
     if (order.id) tr.dataset.id = order.id;
+    if (order.is_cancelled) tr.classList.add('cancelled');
+    else if (order.is_completed) tr.classList.add('completed');
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     let fooi = parseFloat(order.fooi ?? order.tip);
@@ -1608,11 +1612,14 @@ function formatCurrency(value){
         <td>${order.payment_method || ''}</td>
         <td>${order.order_number || '-'}</td>
         <td><button onclick="orderComplete(this)"
+          data-id="${order.id}"
           data-number="${order.order_number}"
           data-name="${order.customer_name || ''}"
           data-phone="${order.phone || ''}"
           data-email="${order.email || ''}"
-          data-type="${isDelivery ? 'bezorg' : 'afhaal'}">订单完成</button>
+          data-type="${isDelivery ? 'bezorg' : 'afhaal'}">${order.is_completed ? 'Undone' : '订单完成'}</button>
+          <button onclick="editOrder(this)" data-id="${order.id}">编辑</button>
+          <button onclick="cancelOrder(this)" data-id="${order.id}">取消</button>
           <span class="notify"></span></td>`;
       
     tr.dataset.sortKey = getSortKey(order);

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -28,6 +28,8 @@ th:last-child {
   animation: highlightBlink 6s ease-in-out;
   animation-iteration-count: 10;
 }
+tr.completed { background-color: #c8e6c9; }
+tr.cancelled { background-color: #e0e0e0; }
 @keyframes highlightBlink {
   0%,100% { background-color: green; }
   50% { background-color: blue; }
@@ -172,6 +174,9 @@ function insertSorted(tbody,tr){
     function addRow(order, highlight=false) {
   const tbody = document.querySelector('table tbody');
   const tr = document.createElement('tr');
+  if (order.id) tr.dataset.id = order.id;
+  if (order.is_cancelled) tr.classList.add('cancelled');
+  else if (order.is_completed) tr.classList.add('completed');
   const isDelivery = ['delivery','bezorgen'].includes(order.order_type);
   const items = Object.entries(order.items || {}).map(([n,i]) => `<li>${n} x ${i.qty}</li>`).join('');
 
@@ -218,7 +223,7 @@ function insertSorted(tbody,tr){
   <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
   <td>${order.payment_method || '-'}</td>
   <td>${order.order_number || ''}</td>
-`;
+  <td><button onclick="orderComplete(this)" data-id="${order.id}" data-number="${order.order_number}" data-name="${order.customer_name || ''}" data-phone="${order.phone || ''}" data-email="${order.email || ''}" data-type="${isDelivery ? 'bezorg' : 'afhaal'}">${order.is_completed ? 'Undone' : '订单完成'}</button> <button onclick="editOrder(this)" data-id="${order.id}">编辑</button> <button onclick="cancelOrder(this)" data-id="${order.id}">取消</button> <span class="notify"></span></td>`;
 
   tr.dataset.sortKey = getSortKey(order);
   if(highlight){
@@ -262,6 +267,55 @@ function insertSorted(tbody,tr){
         pollTimer = null;
       }
     }
+
+  function orderComplete(btn){
+    const completed = btn.textContent.trim() !== 'Undone';
+    fetch(`/api/orders/${btn.dataset.id}/complete`, {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({completed})
+    }).then(()=>{
+      const row = btn.closest('tr');
+      if(completed){
+        row.classList.add('completed');
+        row.classList.remove('cancelled');
+        btn.textContent='Undone';
+      }else{
+        row.classList.remove('completed');
+        btn.textContent='订单完成';
+      }
+    });
+  }
+
+  function cancelOrder(btn){
+    if(!confirm('确定取消该订单?')) return;
+    fetch(`/api/orders/${btn.dataset.id}/cancel`, {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({cancel:true})
+    }).then(()=>{
+      const row = btn.closest('tr');
+      row.classList.remove('completed');
+      row.classList.add('cancelled');
+    });
+  }
+
+  function editOrder(btn){
+    const id = btn.dataset.id;
+    const row = btn.closest('tr');
+    const cells = row.children;
+    const data = {
+      customer_name: prompt('Naam', cells[2].textContent) || cells[2].textContent,
+      phone: prompt('Telefoon', cells[3].textContent) || cells[3].textContent,
+      email: prompt('Email', cells[4].textContent) || cells[4].textContent
+    };
+    fetch(`/api/orders/${id}`, {
+      method:'PUT', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify(data)
+    }).then(()=>{
+      cells[2].textContent = data.customer_name;
+      cells[3].textContent = data.phone;
+      cells[4].textContent = data.email;
+    });
+  }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support is_completed and is_cancelled fields in DB
- create APIs to update order status and edit orders
- exclude cancelled orders from totals and exports
- update POS pages to show status with edit/cancel actions
- keep export routes adjustable with include_cancelled flag

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866950929d483338c5f10f3a8088d94