### PR TITLE
Add order management features

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -131,6 +131,8 @@
 
           data.forEach(order => {
             const tr = document.createElement('tr');
+            tr.dataset.id = order.id;
+            tr.dataset.order = JSON.stringify(order);
             if (order.is_cancelled) tr.classList.add('cancelled');
             else if (order.is_completed) tr.classList.add('completed');
             const isDelivery = ['delivery', 'bezorgen'].includes((order.order_type || '').toLowerCase());
@@ -168,12 +170,15 @@
               <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
               <td>${isDelivery ? (order.delivery_time || order.deliveryTime || '-') : (order.pickup_time || order.pickupTime || '-')}</td>
               <td>${order.payment_method || ''}</td>
-              <td><button onclick="orderComplete(this)" 
+              <td><button onclick="toggleComplete(this)"
                 data-number="${order.order_number}"
                 data-name="${order.customer_name || ''}"
                 data-phone="${order.phone || ''}"
                 data-email="${order.email || ''}"
-                data-type="${isDelivery ? 'bezorg' : 'afhaal'}">订单完成</button> <span class="notify"></span></td>
+                data-type="${isDelivery ? 'bezorg' : 'afhaal'}">${order.is_completed ? 'Undone' : '订单完成'}</button>
+                <button onclick="editOrder(this)">编辑</button>
+                <button onclick="cancelOrder(this)">取消</button>
+                <span class="notify"></span></td>
             `;
             tbody.appendChild(tr);
           });
@@ -210,8 +215,61 @@
           status.textContent = '通知发送失败';
         }
       }).catch(() => {
-        status.textContent = '通知发送失败';
-      });
+      status.textContent = '通知发送失败';
+    });
+    }
+
+    function toggleComplete(btn) {
+      const tr = btn.closest('tr');
+      const id = tr.dataset.id;
+      const done = !tr.classList.contains('completed');
+      fetch(`/api/orders/${id}/status`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({is_completed: done})
+      }).then(()=>{ if(done) orderComplete(btn); fetchOrders(); });
+    }
+
+    function cancelOrder(btn) {
+      const id = btn.closest('tr').dataset.id;
+      fetch(`/api/orders/${id}/status`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({is_cancelled: true})
+      }).then(()=>fetchOrders());
+    }
+
+    function editOrder(btn) {
+      const tr = btn.closest('tr');
+      const id = tr.dataset.id;
+      const data = JSON.parse(tr.dataset.order || '{}');
+      const name = prompt('Naam', data.customer_name || '');
+      if(name===null) return;
+      const phone = prompt('Telefoon', data.phone || '');
+      if(phone===null) return;
+      const email = prompt('Email', data.email || '');
+      if(email===null) return;
+      const street = prompt('Straat', data.street || '');
+      if(street===null) return;
+      const number = prompt('Huisnummer', data.house_number || '');
+      if(number===null) return;
+      const postcode = prompt('Postcode', data.postcode || '');
+      if(postcode===null) return;
+      const city = prompt('Plaats', data.city || '');
+      if(city===null) return;
+      const pickup = prompt('Afhaaltijd', data.pickup_time || '');
+      if(pickup===null) return;
+      const delivery = prompt('Bezorgtijd', data.delivery_time || '');
+      if(delivery===null) return;
+      fetch(`/api/orders/${id}`, {
+        method:'PUT',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({
+          customer_name:name, phone, email,
+          street, house_number:number, postcode, city,
+          pickup_time:pickup, delivery_time:delivery
+        })
+      }).then(()=>fetchOrders());
     }
   </script>
 </body>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -36,6 +36,9 @@
     padding-right: 20px;
   }
 
+  .completed { background-color: #c8e6c9; }
+  .cancelled { background-color: #e0e0e0; }
+
   .type-bezorging {
     color: red;
     font-weight: bold;
@@ -95,7 +98,7 @@ th:last-child {
     </thead>
     <tbody>
     {% for order in orders %}
-      <tr>
+      <tr data-id="{{ order.id }}" data-order="{{ order|tojson }}" class="{% if order.is_cancelled %}cancelled{% elif order.is_completed %}completed{% endif %}">
         <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
@@ -136,13 +139,18 @@ th:last-child {
         </td>
         <td>{{ order.payment_method }}</td>
         <td>{{ order.order_number or '' }}</td>
-        <td><button onclick="orderComplete(this)"
-          data-number="{{ order.order_number }}"
-          data-name="{{ order.customer_name or '' }}"
-          data-phone="{{ order.phone or '' }}"
-          data-email="{{ order.email or '' }}"
-          data-type="{{ 'bezorg' if is_delivery else 'afhaal' }}">订单完成</button>
-          <span class="notify"></span></td>
+        <td>
+          <button onclick="toggleComplete(this)"
+            data-number="{{ order.order_number }}"
+            data-name="{{ order.customer_name or '' }}"
+            data-phone="{{ order.phone or '' }}"
+            data-email="{{ order.email or '' }}"
+            data-type="{{ 'bezorg' if is_delivery else 'afhaal' }}">
+            {{ 'Undone' if order.is_completed else '订单完成' }}</button>
+          <button onclick="editOrder(this)">编辑</button>
+          <button onclick="cancelOrder(this)">取消</button>
+          <span class="notify"></span>
+        </td>
       </tr>
     {% endfor %}
     </tbody>
@@ -172,5 +180,62 @@ th:last-child {
     }).catch(() => {
       status.textContent = '通知发送失败';
     });
+  }
+
+  function toggleComplete(btn) {
+    const tr = btn.closest('tr');
+    const id = tr.dataset.id;
+    const done = !tr.classList.contains('completed');
+    fetch(`/api/orders/${id}/status`, {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({is_completed: done})
+    }).then(r=>r.json()).then(() => {
+      if(done) orderComplete(btn);
+      fetchOrders();
+    });
+  }
+
+  function cancelOrder(btn) {
+    const id = btn.closest('tr').dataset.id;
+    fetch(`/api/orders/${id}/status`, {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({is_cancelled: true})
+    }).then(()=>fetchOrders());
+  }
+
+  function editOrder(btn) {
+    const tr = btn.closest('tr');
+    const id = tr.dataset.id;
+    const data = JSON.parse(tr.dataset.order || '{}');
+    const name = prompt('Naam', data.customer_name || '');
+    if(name === null) return;
+    const phone = prompt('Telefoon', data.phone || '');
+    if(phone === null) return;
+    const email = prompt('Email', data.email || '');
+    if(email === null) return;
+    const street = prompt('Straat', data.street || '');
+    if(street === null) return;
+    const number = prompt('Huisnummer', data.house_number || '');
+    if(number === null) return;
+    const postcode = prompt('Postcode', data.postcode || '');
+    if(postcode === null) return;
+    const city = prompt('Plaats', data.city || '');
+    if(city === null) return;
+    const pickup = prompt('Afhaaltijd', data.pickup_time || '');
+    if(pickup === null) return;
+    const delivery = prompt('Bezorgtijd', data.delivery_time || '');
+    if(delivery === null) return;
+
+    fetch(`/api/orders/${id}`, {
+      method:'PUT',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        customer_name:name, phone, email,
+        street, house_number:number, postcode, city,
+        pickup_time:pickup, delivery_time:delivery
+      })
+    }).then(()=>fetchOrders());
   }
 </script>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1569,6 +1569,9 @@ function formatCurrency(value){
 
     const tr = document.createElement('tr');
     if (order.id) tr.dataset.id = order.id;
+    tr.dataset.order = JSON.stringify(order);
+    if(order.is_cancelled) tr.classList.add('cancelled');
+    else if(order.is_completed) tr.classList.add('completed');
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     let fooi = parseFloat(order.fooi ?? order.tip);
@@ -1607,12 +1610,14 @@ function formatCurrency(value){
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>
         <td>${order.order_number || '-'}</td>
-        <td><button onclick="orderComplete(this)"
+        <td><button onclick="toggleComplete(this)"
           data-number="${order.order_number}"
           data-name="${order.customer_name || ''}"
           data-phone="${order.phone || ''}"
           data-email="${order.email || ''}"
-          data-type="${isDelivery ? 'bezorg' : 'afhaal'}">订单完成</button>
+          data-type="${isDelivery ? 'bezorg' : 'afhaal'}">${order.is_completed ? 'Undone' : '订单完成'}</button>
+          <button onclick="editOrder(this)">编辑</button>
+          <button onclick="cancelOrder(this)">取消</button>
           <span class="notify"></span></td>`;
       
     tr.dataset.sortKey = getSortKey(order);


### PR DESCRIPTION
## Summary
- persist completion and cancellation status via new columns
- add endpoints for order status updates and editing
- support order editing, completion toggle and cancellation in templates
- mark orders in POS view and admin view with proper state
- allow optional inclusion of cancelled orders in exports

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866ae2f20bc83338dcb66c40adc850b