### PR TITLE
Add snack menu items

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2483,6 +2483,198 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </img></div>
+<!-- Ebi Fry -->
+<div class="menu-row menu-item" data-name="Ebi Fry – 4 st" data-packaging="0.2" data-price="6.2">
+  <div class="menu-img">
+    <img alt="Ebi Fry" loading="lazy" src="{{ url_for('static', filename='images/Ebi.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Ebi Fry – 4 st</h3>
+    <p>€ 6.20</p>
+    <div class="qty-box">
+      <label for="ebiFryCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="ebiFryCount" type="button">-</button>
+      <select id="ebiFryCount" name="ebiFryCount"></select>
+      <button class="qty-plus add-button" data-target="ebiFryCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Spicy Crispy Chicken -->
+<div class="menu-row menu-item" data-name="Spicy Crispy Chicken – 5 st" data-packaging="0.2" data-price="5.5">
+  <div class="menu-img">
+    <img alt="Spicy Crispy Chicken" loading="lazy" src="{{ url_for('static', filename='images/chicken-crispy.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Spicy Crispy Chicken – 5 st</h3>
+    <p>€ 5.50</p>
+    <div class="qty-box">
+      <label for="spicyCrispyChickenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="spicyCrispyChickenCount" type="button">-</button>
+      <select id="spicyCrispyChickenCount" name="spicyCrispyChickenCount"></select>
+      <button class="qty-plus add-button" data-target="spicyCrispyChickenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Chicken Loempia -->
+<div class="menu-row menu-item" data-name="Chicken Loempia – 2 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Chicken Loempia" loading="lazy" src="{{ url_for('static', filename='images/st.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Chicken Loempia – 2 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="chickenLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="chickenLoempiaCount" type="button">-</button>
+      <select id="chickenLoempiaCount" name="chickenLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="chickenLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Gyoza -->
+<div class="menu-row menu-item" data-name="Gyoza – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Gyoza" loading="lazy" src="{{ url_for('static', filename='images/dimsum-bento.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Gyoza – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="gyozaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="gyozaCount" type="button">-</button>
+      <select id="gyozaCount" name="gyozaCount"></select>
+      <button class="qty-plus add-button" data-target="gyozaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Inktvis Ringen -->
+<div class="menu-row menu-item" data-name="Inktvis Ringen – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Inktvis Ringen" loading="lazy" src="{{ url_for('static', filename='images/ss.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Inktvis Ringen – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="inktvisRingenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="inktvisRingenCount" type="button">-</button>
+      <select id="inktvisRingenCount" name="inktvisRingenCount"></select>
+      <button class="qty-plus add-button" data-target="inktvisRingenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Crispy Rijst -->
+<div class="menu-row menu-item" data-name="Crispy Rijst – 4 st" data-packaging="0.2" data-price="4">
+  <div class="menu-img">
+    <img alt="Crispy Rijst" loading="lazy" src="{{ url_for('static', filename='images/beef-crispy.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Crispy Rijst – 4 st</h3>
+    <p>€ 4.00</p>
+    <div class="qty-box">
+      <label for="crispyRijstCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="crispyRijstCount" type="button">-</button>
+      <select id="crispyRijstCount" name="crispyRijstCount"></select>
+      <button class="qty-plus add-button" data-target="crispyRijstCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Yakitori -->
+<div class="menu-row menu-item" data-name="Yakitori – 4 st" data-packaging="0.2" data-price="6">
+  <div class="menu-img">
+    <img alt="Yakitori" loading="lazy" src="{{ url_for('static', filename='images/teri鸡.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Yakitori – 4 st</h3>
+    <p>€ 6.00</p>
+    <div class="qty-box">
+      <label for="yakitoriCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="yakitoriCount" type="button">-</button>
+      <select id="yakitoriCount" name="yakitoriCount"></select>
+      <button class="qty-plus add-button" data-target="yakitoriCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Mini Loempia -->
+<div class="menu-row menu-item" data-name="Mini Loempia – 6 st" data-packaging="0.2" data-price="3.5">
+  <div class="menu-img">
+    <img alt="Mini Loempia" loading="lazy" src="{{ url_for('static', filename='images/st.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Mini Loempia – 6 st</h3>
+    <p>€ 3.50</p>
+    <div class="qty-box">
+      <label for="miniLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="miniLoempiaCount" type="button">-</button>
+      <select id="miniLoempiaCount" name="miniLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="miniLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Edamame -->
+<div class="menu-row menu-item" data-name="Edamame" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Edamame" loading="lazy" src="{{ url_for('static', filename='images/zwp.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Edamame</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="edamameCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="edamameCount" type="button">-</button>
+      <select id="edamameCount" name="edamameCount"></select>
+      <button class="qty-plus add-button" data-target="edamameCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Komkommer -->
+<div class="menu-row menu-item" data-name="Kimchi Komkommer" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Kimchi Komkommer" loading="lazy" src="{{ url_for('static', filename='images/nrp.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Komkommer</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="kimchiKomkommerCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKomkommerCount" type="button">-</button>
+      <select id="kimchiKomkommerCount" name="kimchiKomkommerCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKomkommerCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Kool -->
+<div class="menu-row menu-item" data-name="Kimchi Kool" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Kimchi Kool" loading="lazy" src="{{ url_for('static', filename='images/nrp.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Kool</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="kimchiKoolCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKoolCount" type="button">-</button>
+      <select id="kimchiKoolCount" name="kimchiKoolCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKoolCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Zeewiersalade -->
+<div class="menu-row menu-item" data-name="Zeewiersalade – 100g" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Zeewiersalade" loading="lazy" src="{{ url_for('static', filename='images/ss.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Zeewiersalade – 100g</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="zeewiersaladeCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="zeewiersaladeCount" type="button">-</button>
+      <select id="zeewiersaladeCount" name="zeewiersaladeCount"></select>
+      <button class="qty-plus add-button" data-target="zeewiersaladeCount" type="button">+</button>
+    </div>
+  </div>
+</div>
 </div>
 </section>
 <section id="dessert">

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -937,6 +937,198 @@
 </div>
 </div>
 </img></div>
+<!-- Ebi Fry -->
+<div class="menu-row menu-item" data-name="Ebi Fry – 4 st" data-packaging="0.2" data-price="6.2">
+  <div class="menu-img">
+    <img alt="Ebi Fry" loading="lazy" src="{{ url_for('static', filename='images/Ebi.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Ebi Fry – 4 st</h3>
+    <p>€ 6.20</p>
+    <div class="qty-box">
+      <label for="ebiFryCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="ebiFryCount" type="button">-</button>
+      <select id="ebiFryCount" name="ebiFryCount"></select>
+      <button class="qty-plus add-button" data-target="ebiFryCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Spicy Crispy Chicken -->
+<div class="menu-row menu-item" data-name="Spicy Crispy Chicken – 5 st" data-packaging="0.2" data-price="5.5">
+  <div class="menu-img">
+    <img alt="Spicy Crispy Chicken" loading="lazy" src="{{ url_for('static', filename='images/chicken-crispy.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Spicy Crispy Chicken – 5 st</h3>
+    <p>€ 5.50</p>
+    <div class="qty-box">
+      <label for="spicyCrispyChickenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="spicyCrispyChickenCount" type="button">-</button>
+      <select id="spicyCrispyChickenCount" name="spicyCrispyChickenCount"></select>
+      <button class="qty-plus add-button" data-target="spicyCrispyChickenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Chicken Loempia -->
+<div class="menu-row menu-item" data-name="Chicken Loempia – 2 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Chicken Loempia" loading="lazy" src="{{ url_for('static', filename='images/st.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Chicken Loempia – 2 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="chickenLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="chickenLoempiaCount" type="button">-</button>
+      <select id="chickenLoempiaCount" name="chickenLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="chickenLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Gyoza -->
+<div class="menu-row menu-item" data-name="Gyoza – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Gyoza" loading="lazy" src="{{ url_for('static', filename='images/dimsum-bento.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Gyoza – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="gyozaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="gyozaCount" type="button">-</button>
+      <select id="gyozaCount" name="gyozaCount"></select>
+      <button class="qty-plus add-button" data-target="gyozaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Inktvis Ringen -->
+<div class="menu-row menu-item" data-name="Inktvis Ringen – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Inktvis Ringen" loading="lazy" src="{{ url_for('static', filename='images/ss.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Inktvis Ringen – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="inktvisRingenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="inktvisRingenCount" type="button">-</button>
+      <select id="inktvisRingenCount" name="inktvisRingenCount"></select>
+      <button class="qty-plus add-button" data-target="inktvisRingenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Crispy Rijst -->
+<div class="menu-row menu-item" data-name="Crispy Rijst – 4 st" data-packaging="0.2" data-price="4">
+  <div class="menu-img">
+    <img alt="Crispy Rijst" loading="lazy" src="{{ url_for('static', filename='images/beef-crispy.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Crispy Rijst – 4 st</h3>
+    <p>€ 4.00</p>
+    <div class="qty-box">
+      <label for="crispyRijstCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="crispyRijstCount" type="button">-</button>
+      <select id="crispyRijstCount" name="crispyRijstCount"></select>
+      <button class="qty-plus add-button" data-target="crispyRijstCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Yakitori -->
+<div class="menu-row menu-item" data-name="Yakitori – 4 st" data-packaging="0.2" data-price="6">
+  <div class="menu-img">
+    <img alt="Yakitori" loading="lazy" src="{{ url_for('static', filename='images/teri鸡.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Yakitori – 4 st</h3>
+    <p>€ 6.00</p>
+    <div class="qty-box">
+      <label for="yakitoriCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="yakitoriCount" type="button">-</button>
+      <select id="yakitoriCount" name="yakitoriCount"></select>
+      <button class="qty-plus add-button" data-target="yakitoriCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Mini Loempia -->
+<div class="menu-row menu-item" data-name="Mini Loempia – 6 st" data-packaging="0.2" data-price="3.5">
+  <div class="menu-img">
+    <img alt="Mini Loempia" loading="lazy" src="{{ url_for('static', filename='images/st.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Mini Loempia – 6 st</h3>
+    <p>€ 3.50</p>
+    <div class="qty-box">
+      <label for="miniLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="miniLoempiaCount" type="button">-</button>
+      <select id="miniLoempiaCount" name="miniLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="miniLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Edamame -->
+<div class="menu-row menu-item" data-name="Edamame" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Edamame" loading="lazy" src="{{ url_for('static', filename='images/zwp.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Edamame</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="edamameCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="edamameCount" type="button">-</button>
+      <select id="edamameCount" name="edamameCount"></select>
+      <button class="qty-plus add-button" data-target="edamameCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Komkommer -->
+<div class="menu-row menu-item" data-name="Kimchi Komkommer" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Kimchi Komkommer" loading="lazy" src="{{ url_for('static', filename='images/nrp.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Komkommer</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="kimchiKomkommerCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKomkommerCount" type="button">-</button>
+      <select id="kimchiKomkommerCount" name="kimchiKomkommerCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKomkommerCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Kool -->
+<div class="menu-row menu-item" data-name="Kimchi Kool" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Kimchi Kool" loading="lazy" src="{{ url_for('static', filename='images/nrp.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Kool</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="kimchiKoolCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKoolCount" type="button">-</button>
+      <select id="kimchiKoolCount" name="kimchiKoolCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKoolCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Zeewiersalade -->
+<div class="menu-row menu-item" data-name="Zeewiersalade – 100g" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Zeewiersalade" loading="lazy" src="{{ url_for('static', filename='images/ss.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Zeewiersalade – 100g</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="zeewiersaladeCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="zeewiersaladeCount" type="button">-</button>
+      <select id="zeewiersaladeCount" name="zeewiersaladeCount"></select>
+      <button class="qty-plus add-button" data-target="zeewiersaladeCount" type="button">+</button>
+    </div>
+  </div>
+</div>
 </div>
 </section>
 <section id="dessert">


### PR DESCRIPTION
## Summary
- expand snack options in `index.html`
- mirror new snacks in `menu.html` so POS shows them

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68680a6850d8833394c21124829a6f4a