### PR TITLE
Add separate opening hours checks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3666,6 +3666,7 @@ let businessHours = '';
 let closedMessage = '';
 let pickupAvailable = true;
 let deliveryAvailable = true;
+let currentSettings = null;
 let pickupOpenTime = '12:00';
 let pickupCloseTime = '23:59';
 let deliveryOpenTime = '12:00';
@@ -3889,7 +3890,7 @@ function checkout() {
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
-  fetch('https://flask-order-api.onrender.com/submit_order', {
+  fetch('/submit_order', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -4080,6 +4081,9 @@ function checkout() {
     }
     updatePriceBreakdown(currentSubtotal, currentPackaging);
     storeOpen = afhalen.checked ? pickupAvailable : deliveryAvailable;
+    if(currentSettings){
+      updateStatus(currentSettings);
+    }
   }
 
   // 初始化执行一次
@@ -4657,6 +4661,7 @@ function parseTime(timeStr, startStr){
 }
 
 function updateStatus(settings){
+  currentSettings = settings;
   const banner = document.getElementById('status-banner');
   const hoursEl = document.getElementById('hours-info');
   const checkoutBtn = document.querySelector('.checkout-btn');
@@ -4698,6 +4703,16 @@ function updateStatus(settings){
   deliveryAvailable = websiteOn && dayOpen && settings.delivery_enabled !== 'false';
   const pickupWithinHours = inRange(settings.pickup_start, settings.pickup_end);
   const deliveryWithinHours = inRange(settings.delivery_start, settings.delivery_end);
+
+  const pickupOpenNow = pickupAvailable && pickupWithinHours;
+  const deliveryOpenNow = deliveryAvailable && deliveryWithinHours;
+
+  let notice = '';
+  if(pickupOpenNow && !deliveryOpenNow){
+    notice = 'Bezorg is nu gesloten. U kunt afhalen!';
+  }else if(deliveryOpenNow && !pickupOpenNow){
+    notice = 'Afhaal is nu gesloten. U kunt laten bezorgen!';
+  }
 
   let message = '';
   if(allClosed){
@@ -4747,6 +4762,10 @@ function updateStatus(settings){
         }
       }
     }
+  }
+
+  if(storeOpen && notice){
+    message = notice;
   }
 
   closedMessage = message;


### PR DESCRIPTION
## Summary
- enforce order type opening hours on server
- update checkout JS with independent pickup/delivery time checks
- refresh status message when toggling order type
- send orders to local `/submit_order` endpoint

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_686a43e9dee483338500e6bb9ec2efe0