### PR TITLE
Add admin review management

### DIFF
--- a/templates/admin/review-list.html
+++ b/templates/admin/review-list.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Review Beheer</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; padding: 20px; max-width: 800px; margin:auto; }
+    .review { border:1px solid #ccc; padding:10px; margin-bottom:10px; border-radius:8px; }
+    .reply-box { margin-top:8px; }
+    button { margin-right:8px; }
+  </style>
+</head>
+<body>
+  <h1>Reviews</h1>
+  <div id="reviewsContainer"></div>
+  <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+  <script>
+    async function loadReviews(){
+      const r = await fetch('/api/reviews?page=1&per_page=100');
+      const d = await r.json();
+      const c = document.getElementById('reviewsContainer');
+      c.innerHTML = '';
+      d.reviews.reverse().forEach(rv => {
+        const div = document.createElement('div');
+        div.className = 'review';
+        div.innerHTML = `
+          <strong>${rv.customer_name}</strong>
+          <div>${'★'.repeat(rv.rating||0)}${'☆'.repeat(5-(rv.rating||0))}</div>
+          <p>${rv.content}</p>
+          ${rv.reply ? `<p><em>Antwoord: ${rv.reply}</em></p>` : ''}
+          <div class="reply-box">
+            <input type="text" id="reply-${rv.id}" placeholder="Reply" value="${rv.reply || ''}">
+            <button onclick="sendReply(${rv.id})">Opslaan</button>
+            <button onclick="delReview(${rv.id})">Verwijder</button>
+          </div>
+        `;
+        c.appendChild(div);
+      });
+    }
+    async function sendReply(id){
+      const val = document.getElementById('reply-' + id).value;
+      await fetch(`/api/reviews/${id}/reply`, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({reply:val})});
+    }
+    async function delReview(id){
+      if(!confirm('Weet u zeker dat u deze review wilt verwijderen?')) return;
+      await fetch(`/api/reviews/${id}`, {method:'DELETE'});
+    }
+    const socket = io();
+    socket.on('new_review', loadReviews);
+    socket.on('review_reply', loadReviews);
+    socket.on('delete_review', loadReviews);
+    window.addEventListener('load', loadReviews);
+  </script>
+</body>
+</html>

--- a/templates/review-list.html
+++ b/templates/review-list.html
@@ -165,6 +165,7 @@
   </div>
 </div>
 
+<script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
 <script>
 window.addEventListener('load', loadReviews);
 
@@ -192,6 +193,7 @@ async function loadReviews() {
       <strong>${r.customer_name}</strong><br>
       <div class="review-stars">${renderStars(r.rating)}</div>
       <p>${r.content}</p>
+      ${r.reply ? `<p><em>Antwoord: ${r.reply}</em></p>` : ''}
     `;
     reviewList.appendChild(div);
   });
@@ -242,6 +244,12 @@ function scrollToTop() {
 function goHome() {
   window.location.href = '/';
 }
+
+// SocketIO real-time updates
+const socket = io();
+socket.on('new_review', loadReviews);
+socket.on('review_reply', loadReviews);
+socket.on('delete_review', loadReviews);
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- add `reply` field to Review model and database initialization
- expand reviews API with reply and id info
- add endpoints to reply to and delete reviews
- create admin review management page
- display replies and live updates in public review list

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bfe75d7088333a26df12ffeecc2c6