### PR TITLE
Add bento sold-out controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -495,6 +495,18 @@ with app.app_context():
         "delivery_start": "11:00",
         "delivery_end": "21:00",
         "time_interval": "15",
+        "milktea_soldout": "false",
+        "milktea_price": "5",
+        "soldout_chicken_bento": "false",
+        "soldout_meatlover_bento": "false",
+        "soldout_zalm_lover_bento": "false",
+        "soldout_ebi_lover_bento": "false",
+        "soldout_surf_turf_bento": "false",
+        "soldout_dimsum_bento": "false",
+        "soldout_lamskotelet_bento": "false",
+        "soldout_veggie_bento": "false",
+        "soldout_sushi_bento": "false",
+        "soldout_xbento": "false",
     }
     for k, v in defaults.items():
         if not Setting.query.filter_by(key=k).first():
@@ -926,6 +938,16 @@ def dashboard():
         time_interval=get_value('time_interval', '15'),
         milktea_soldout=get_value('milktea_soldout', 'false'),
         milktea_price=get_value('milktea_price', '5'),
+        soldout_chicken_bento=get_value('soldout_chicken_bento', 'false'),
+        soldout_meatlover_bento=get_value('soldout_meatlover_bento', 'false'),
+        soldout_zalm_lover_bento=get_value('soldout_zalm_lover_bento', 'false'),
+        soldout_ebi_lover_bento=get_value('soldout_ebi_lover_bento', 'false'),
+        soldout_surf_turf_bento=get_value('soldout_surf_turf_bento', 'false'),
+        soldout_dimsum_bento=get_value('soldout_dimsum_bento', 'false'),
+        soldout_lamskotelet_bento=get_value('soldout_lamskotelet_bento', 'false'),
+        soldout_veggie_bento=get_value('soldout_veggie_bento', 'false'),
+        soldout_sushi_bento=get_value('soldout_sushi_bento', 'false'),
+        soldout_xbento=get_value('soldout_xbento', 'false'),
         sections=sections,
         base_options=bases,
         smaak_options=smaken,
@@ -955,6 +977,16 @@ def update_setting():
     delivery_postcodes_val = data.get('delivery_postcodes', '')
     time_interval_val = data.get('time_interval', '15')
     milktea_soldout_val = data.get('milktea_soldout', 'false')
+    soldout_chicken_bento_val = data.get('soldout_chicken_bento', 'false')
+    soldout_meatlover_bento_val = data.get('soldout_meatlover_bento', 'false')
+    soldout_zalm_lover_bento_val = data.get('soldout_zalm_lover_bento', 'false')
+    soldout_ebi_lover_bento_val = data.get('soldout_ebi_lover_bento', 'false')
+    soldout_surf_turf_bento_val = data.get('soldout_surf_turf_bento', 'false')
+    soldout_dimsum_bento_val = data.get('soldout_dimsum_bento', 'false')
+    soldout_lamskotelet_bento_val = data.get('soldout_lamskotelet_bento', 'false')
+    soldout_veggie_bento_val = data.get('soldout_veggie_bento', 'false')
+    soldout_sushi_bento_val = data.get('soldout_sushi_bento', 'false')
+    soldout_xbento_val = data.get('soldout_xbento', 'false')
 
     for key, val in [
         ('is_open', is_open_val),
@@ -971,6 +1003,16 @@ def update_setting():
         ('delivery_postcodes', delivery_postcodes_val),
         ('time_interval', time_interval_val),
         ('milktea_soldout', milktea_soldout_val),
+        ('soldout_chicken_bento', soldout_chicken_bento_val),
+        ('soldout_meatlover_bento', soldout_meatlover_bento_val),
+        ('soldout_zalm_lover_bento', soldout_zalm_lover_bento_val),
+        ('soldout_ebi_lover_bento', soldout_ebi_lover_bento_val),
+        ('soldout_surf_turf_bento', soldout_surf_turf_bento_val),
+        ('soldout_dimsum_bento', soldout_dimsum_bento_val),
+        ('soldout_lamskotelet_bento', soldout_lamskotelet_bento_val),
+        ('soldout_veggie_bento', soldout_veggie_bento_val),
+        ('soldout_sushi_bento', soldout_sushi_bento_val),
+        ('soldout_xbento', soldout_xbento_val),
     ]:
         s = Setting.query.filter_by(key=key).first()
         if not s:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -96,6 +96,59 @@
         </select>
         <br><br>
 
+        <h3>Bento uitverkocht</h3>
+        <label>Chicken Bento:</label>
+        <select id="soldout_chicken_bento_select">
+            <option value="false" {% if soldout_chicken_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chicken_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Meatlover Bento:</label>
+        <select id="soldout_meatlover_bento_select">
+            <option value="false" {% if soldout_meatlover_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_meatlover_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Zalm Lover Bento:</label>
+        <select id="soldout_zalm_lover_bento_select">
+            <option value="false" {% if soldout_zalm_lover_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_zalm_lover_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Ebi Lover Bento:</label>
+        <select id="soldout_ebi_lover_bento_select">
+            <option value="false" {% if soldout_ebi_lover_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ebi_lover_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Surf & Turf Bento:</label>
+        <select id="soldout_surf_turf_bento_select">
+            <option value="false" {% if soldout_surf_turf_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_surf_turf_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Dimsum Bento:</label>
+        <select id="soldout_dimsum_bento_select">
+            <option value="false" {% if soldout_dimsum_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_dimsum_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Lamskotelet Bento:</label>
+        <select id="soldout_lamskotelet_bento_select">
+            <option value="false" {% if soldout_lamskotelet_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_lamskotelet_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Veggie Bento:</label>
+        <select id="soldout_veggie_bento_select">
+            <option value="false" {% if soldout_veggie_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_veggie_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Sushi Omakase Bento:</label>
+        <select id="soldout_sushi_bento_select">
+            <option value="false" {% if soldout_sushi_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_sushi_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Xbento:</label>
+        <select id="soldout_xbento_select">
+            <option value="false" {% if soldout_xbento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_xbento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select>
+        <br><br>
+
         <button type="submit">保存</button>
     </form>
 
@@ -299,6 +352,16 @@
                   .join(',');
             const time_interval = document.getElementById('interval_select').value;
             const milktea_soldout = document.getElementById('milktea_soldout_select').value;
+            const soldout_chicken_bento = document.getElementById('soldout_chicken_bento_select').value;
+            const soldout_meatlover_bento = document.getElementById('soldout_meatlover_bento_select').value;
+            const soldout_zalm_lover_bento = document.getElementById('soldout_zalm_lover_bento_select').value;
+            const soldout_ebi_lover_bento = document.getElementById('soldout_ebi_lover_bento_select').value;
+            const soldout_surf_turf_bento = document.getElementById('soldout_surf_turf_bento_select').value;
+            const soldout_dimsum_bento = document.getElementById('soldout_dimsum_bento_select').value;
+            const soldout_lamskotelet_bento = document.getElementById('soldout_lamskotelet_bento_select').value;
+            const soldout_veggie_bento = document.getElementById('soldout_veggie_bento_select').value;
+            const soldout_sushi_bento = document.getElementById('soldout_sushi_bento_select').value;
+            const soldout_xbento = document.getElementById('soldout_xbento_select').value;
 
             fetch('/dashboard/update', {
                 method: 'POST',
@@ -317,7 +380,17 @@
                     delivery_end: delivery_end,
                     delivery_postcodes: delivery_postcodes,
                     time_interval: time_interval,
-                    milktea_soldout: milktea_soldout
+                    milktea_soldout: milktea_soldout,
+                    soldout_chicken_bento: soldout_chicken_bento,
+                    soldout_meatlover_bento: soldout_meatlover_bento,
+                    soldout_zalm_lover_bento: soldout_zalm_lover_bento,
+                    soldout_ebi_lover_bento: soldout_ebi_lover_bento,
+                    soldout_surf_turf_bento: soldout_surf_turf_bento,
+                    soldout_dimsum_bento: soldout_dimsum_bento,
+                    soldout_lamskotelet_bento: soldout_lamskotelet_bento,
+                    soldout_veggie_bento: soldout_veggie_bento,
+                    soldout_sushi_bento: soldout_sushi_bento,
+                    soldout_xbento: soldout_xbento
                 })
             })
             .then(response => response.json())

--- a/templates/index.html
+++ b/templates/index.html
@@ -1747,6 +1747,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Chicken Bento</h3>
 <p>€ 22.00</p>
+<p id="soldoutChickenBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="chickenBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="chickenBentoCount" type="button">-</button>
@@ -1764,6 +1765,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Meatlover Bento</h3>
 <p>€ 25.00</p>
+<p id="soldoutMeatloverBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="meatloverBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="meatloverBentoCount" type="button">-</button>
@@ -1780,6 +1782,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Zalm Lover Bento</h3>
 <p>€ 23.00</p>
+<p id="soldoutZalmLoverBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="zalmLoverBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="zalmLoverBentoCount" type="button">-</button>
@@ -1796,6 +1799,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Ebi Lover Bento</h3>
 <p>€ 23.00</p>
+<p id="soldoutEbiLoverBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="ebiLoverBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="ebiLoverBentoCount" type="button">-</button>
@@ -1812,6 +1816,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Surf &amp; Turf Bento</h3>
 <p>€ 25.00</p>
+<p id="soldoutSurfTurfBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="surfTurfBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="surfTurfBentoCount" type="button">-</button>
@@ -1828,6 +1833,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Dimsum Bento</h3>
 <p>€ 15.00</p>
+<p id="soldoutDimsumBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="dimsumBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="dimsumBentoCount" type="button">-</button>
@@ -1844,6 +1850,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Lamskotelet Bento</h3>
 <p>€ 28.00</p>
+<p id="soldoutLamskoteletBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="lamsBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="lamsBentoCount" type="button">-</button>
@@ -1860,6 +1867,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Veggie Bento</h3>
 <p>€ 20.00</p>
+<p id="soldoutVeggieBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="veggieBentoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="veggieBentoCount" type="button">-</button>
@@ -1875,6 +1883,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Bento Sushi Omakase</h3>
 <p>€ 22.00</p>
+<p id="soldoutSushiBento" class="sold-out-msg hidden">Uitverkocht!</p>
 <p class="menu-description">±16st Verrassing van de chef!</p>
 <div class="qty-box">
 <label for="sushiBentoCount">Aantal</label>
@@ -1894,6 +1903,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Xbento (stel zelf samen)</h3>
 <p>Vanaf € 25.00</p>
+<p id="soldoutXbento" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="bubble-option">
 <select id="xBentoMain">
 <option value="">Hoofdgerecht</option>
@@ -4851,6 +4861,31 @@ function updateStatus(settings) {
       if (bubbleSetControls) bubbleSetControls.update();
     }
   }
+
+  const bentoConfig = [
+    {name: 'Chicken Bento', key: 'soldout_chicken_bento', qty: 'chickenBentoCount', msg: 'soldoutChickenBento'},
+    {name: 'Meatlover Bento', key: 'soldout_meatlover_bento', qty: 'meatloverBentoCount', msg: 'soldoutMeatloverBento'},
+    {name: 'Zalm Lover Bento', key: 'soldout_zalm_lover_bento', qty: 'zalmLoverBentoCount', msg: 'soldoutZalmLoverBento'},
+    {name: 'Ebi Lover Bento', key: 'soldout_ebi_lover_bento', qty: 'ebiLoverBentoCount', msg: 'soldoutEbiLoverBento'},
+    {name: 'Surf & Turf Bento', key: 'soldout_surf_turf_bento', qty: 'surfTurfBentoCount', msg: 'soldoutSurfTurfBento'},
+    {name: 'Dimsum Bento', key: 'soldout_dimsum_bento', qty: 'dimsumBentoCount', msg: 'soldoutDimsumBento'},
+    {name: 'Lamskotelet Bento', key: 'soldout_lamskotelet_bento', qty: 'lamsBentoCount', msg: 'soldoutLamskoteletBento'},
+    {name: 'Veggie Bento', key: 'soldout_veggie_bento', qty: 'veggieBentoCount', msg: 'soldoutVeggieBento'},
+    {name: 'Bento Sushi Omakase', key: 'soldout_sushi_bento', qty: 'sushiBentoCount', msg: 'soldoutSushiBento'},
+    {name: 'Xbento', key: 'soldout_xbento', qty: 'xBentoQty', msg: 'soldoutXbento'}
+  ];
+
+  bentoConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
 
   if (settings.milktea_price) {
     milkTeaPrice = parseFloat(settings.milktea_price);


### PR DESCRIPTION
## Summary
- allow marking each bento item as sold out from dashboard
- sync bento sold-out status to index via Socket.IO
- show 'Uitverkocht!' message and disable ordering when a bento is sold out

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ca078fb6c83338cb31df44718073f