### PR TITLE
Add ramen soldout toggles

### DIFF
--- a/app.py
+++ b/app.py
@@ -507,6 +507,11 @@ with app.app_context():
         "soldout_veggie_bento": "false",
         "soldout_sushi_bento": "false",
         "soldout_xbento": "false",
+        "soldout_ebi_ramen": "false",
+        "soldout_chicken_ramen": "false",
+        "soldout_beef_ramen": "false",
+        "soldout_ribeye_ramen": "false",
+        "soldout_chasiu_ramen": "false",
     }
     for k, v in defaults.items():
         if not Setting.query.filter_by(key=k).first():
@@ -948,6 +953,11 @@ def dashboard():
         soldout_veggie_bento=get_value('soldout_veggie_bento', 'false'),
         soldout_sushi_bento=get_value('soldout_sushi_bento', 'false'),
         soldout_xbento=get_value('soldout_xbento', 'false'),
+        soldout_ebi_ramen=get_value('soldout_ebi_ramen', 'false'),
+        soldout_chicken_ramen=get_value('soldout_chicken_ramen', 'false'),
+        soldout_beef_ramen=get_value('soldout_beef_ramen', 'false'),
+        soldout_ribeye_ramen=get_value('soldout_ribeye_ramen', 'false'),
+        soldout_chasiu_ramen=get_value('soldout_chasiu_ramen', 'false'),
         sections=sections,
         base_options=bases,
         smaak_options=smaken,
@@ -987,6 +997,11 @@ def update_setting():
     soldout_veggie_bento_val = data.get('soldout_veggie_bento', 'false')
     soldout_sushi_bento_val = data.get('soldout_sushi_bento', 'false')
     soldout_xbento_val = data.get('soldout_xbento', 'false')
+    soldout_ebi_ramen_val = data.get('soldout_ebi_ramen', 'false')
+    soldout_chicken_ramen_val = data.get('soldout_chicken_ramen', 'false')
+    soldout_beef_ramen_val = data.get('soldout_beef_ramen', 'false')
+    soldout_ribeye_ramen_val = data.get('soldout_ribeye_ramen', 'false')
+    soldout_chasiu_ramen_val = data.get('soldout_chasiu_ramen', 'false')
 
     for key, val in [
         ('is_open', is_open_val),
@@ -1013,6 +1028,11 @@ def update_setting():
         ('soldout_veggie_bento', soldout_veggie_bento_val),
         ('soldout_sushi_bento', soldout_sushi_bento_val),
         ('soldout_xbento', soldout_xbento_val),
+        ('soldout_ebi_ramen', soldout_ebi_ramen_val),
+        ('soldout_chicken_ramen', soldout_chicken_ramen_val),
+        ('soldout_beef_ramen', soldout_beef_ramen_val),
+        ('soldout_ribeye_ramen', soldout_ribeye_ramen_val),
+        ('soldout_chasiu_ramen', soldout_chasiu_ramen_val),
     ]:
         s = Setting.query.filter_by(key=key).first()
         if not s:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -149,6 +149,34 @@
         </select>
         <br><br>
 
+        <h3>Ramen uitverkocht</h3>
+        <label>Ebi Furai:</label>
+        <select id="soldout_ebi_ramen_select">
+            <option value="false" {% if soldout_ebi_ramen != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ebi_ramen == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Chicken:</label>
+        <select id="soldout_chicken_ramen_select">
+            <option value="false" {% if soldout_chicken_ramen != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chicken_ramen == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Beef:</label>
+        <select id="soldout_beef_ramen_select">
+            <option value="false" {% if soldout_beef_ramen != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_beef_ramen == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Ribeye:</label>
+        <select id="soldout_ribeye_ramen_select">
+            <option value="false" {% if soldout_ribeye_ramen != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ribeye_ramen == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Chasiu:</label>
+        <select id="soldout_chasiu_ramen_select">
+            <option value="false" {% if soldout_chasiu_ramen != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chasiu_ramen == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select>
+        <br><br>
+
         <button type="submit">保存</button>
     </form>
 
@@ -362,6 +390,11 @@
             const soldout_veggie_bento = document.getElementById('soldout_veggie_bento_select').value;
             const soldout_sushi_bento = document.getElementById('soldout_sushi_bento_select').value;
             const soldout_xbento = document.getElementById('soldout_xbento_select').value;
+            const soldout_ebi_ramen = document.getElementById('soldout_ebi_ramen_select').value;
+            const soldout_chicken_ramen = document.getElementById('soldout_chicken_ramen_select').value;
+            const soldout_beef_ramen = document.getElementById('soldout_beef_ramen_select').value;
+            const soldout_ribeye_ramen = document.getElementById('soldout_ribeye_ramen_select').value;
+            const soldout_chasiu_ramen = document.getElementById('soldout_chasiu_ramen_select').value;
 
             fetch('/dashboard/update', {
                 method: 'POST',
@@ -390,7 +423,12 @@
                     soldout_lamskotelet_bento: soldout_lamskotelet_bento,
                     soldout_veggie_bento: soldout_veggie_bento,
                     soldout_sushi_bento: soldout_sushi_bento,
-                    soldout_xbento: soldout_xbento
+                    soldout_xbento: soldout_xbento,
+                    soldout_ebi_ramen: soldout_ebi_ramen,
+                    soldout_chicken_ramen: soldout_chicken_ramen,
+                    soldout_beef_ramen: soldout_beef_ramen,
+                    soldout_ribeye_ramen: soldout_ribeye_ramen,
+                    soldout_chasiu_ramen: soldout_chasiu_ramen
                 })
             })
             .then(response => response.json())

--- a/templates/index.html
+++ b/templates/index.html
@@ -1950,6 +1950,7 @@ input:focus, select:focus, textarea:focus {
     <div class="menu-content">
       <h3>Ebi Furai</h3>
       <p>€ 18.00</p>
+      <p id="soldoutEbiRamen" class="sold-out-msg hidden">Uitverkocht!</p>
       <div class="bubble-option">
         <select id="ebiBase">
           <option value="">Base</option>
@@ -1984,6 +1985,7 @@ input:focus, select:focus, textarea:focus {
     <div class="menu-content">
       <h3>Chicken</h3>
       <p>€ 18.00</p>
+      <p id="soldoutChickenRamen" class="sold-out-msg hidden">Uitverkocht!</p>
       <div class="bubble-option">
         <select id="chickenBase">
           <option value="">Base</option>
@@ -2018,6 +2020,7 @@ input:focus, select:focus, textarea:focus {
     <div class="menu-content">
       <h3>Beef</h3>
       <p>€ 18.00</p>
+      <p id="soldoutBeefRamen" class="sold-out-msg hidden">Uitverkocht!</p>
       <div class="bubble-option">
         <select id="beefBase">
           <option value="">Base</option>
@@ -2052,6 +2055,7 @@ input:focus, select:focus, textarea:focus {
     <div class="menu-content">
       <h3>Ribeye</h3>
       <p>€ 18.00</p>
+      <p id="soldoutRibeyeRamen" class="sold-out-msg hidden">Uitverkocht!</p>
       <div class="bubble-option">
         <select id="ribeyeBase">
           <option value="">Base</option>
@@ -2086,6 +2090,7 @@ input:focus, select:focus, textarea:focus {
     <div class="menu-content">
       <h3>Chasiu</h3>
       <p>€ 18.00</p>
+      <p id="soldoutChasiuRamen" class="sold-out-msg hidden">Uitverkocht!</p>
       <div class="bubble-option">
         <select id="chasiuBase">
           <option value="">Base</option>
@@ -2957,6 +2962,33 @@ let currentDiscount = 0;
 let bubbleSetControls;
 let xbentoSetControls;
 
+const soldoutMap = {
+  "Chicken Bento": "soldout_chicken_bento",
+  "Meatlover Bento": "soldout_meatlover_bento",
+  "Zalm Lover Bento": "soldout_zalm_lover_bento",
+  "Ebi Lover Bento": "soldout_ebi_lover_bento",
+  "Surf & Turf Bento": "soldout_surf_turf_bento",
+  "Dimsum Bento": "soldout_dimsum_bento",
+  "Lamskotelet Bento": "soldout_lamskotelet_bento",
+  "Veggie Bento": "soldout_veggie_bento",
+  "Bento Sushi Omakase": "soldout_sushi_bento",
+  "Xbento": "soldout_xbento",
+  "Ebi Furai": "soldout_ebi_ramen",
+  "Chicken": "soldout_chicken_ramen",
+  "Beef": "soldout_beef_ramen",
+  "Ribeye": "soldout_ribeye_ramen",
+  "Chasiu": "soldout_chasiu_ramen"
+};
+
+function isItemSoldOut(name){
+  for(const [base,key] of Object.entries(soldoutMap)){
+    if(name.startsWith(base) && currentSettings[key]==="true"){
+      return true;
+    }
+  }
+  return false;
+}
+
 function getOptionPrice(cat, name){
   const opt = (bubbleOptions[cat]||[]).find(o=>o.name===name);
   return opt ? parseFloat(opt.price) : 0;
@@ -3598,6 +3630,7 @@ function createSelect(current, onChange) {
 }
 
 function setQty(name, price, qty, packaging = DEFAULT_PACKAGING_FEE, prefs = null) {
+  if (isItemSoldOut(name)) return;
   if (qty === 0) {
     delete cart[name];
   } else {
@@ -3822,6 +3855,7 @@ let deliveryCloseTime = '23:59';
 let timeInterval = 15;
 let pickupAddress = '';
 let allowedPostcodes = [];
+let currentSettings = {};
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
   el.textContent = msg;
@@ -4837,6 +4871,7 @@ function parseTime(timeStr, startStr){
 }
 
 function updateStatus(settings) {
+  currentSettings = settings;
   const banner = document.getElementById('status-banner');
   const hoursEl = document.getElementById('hours-info');
   const checkoutBtn = document.querySelector('.checkout-btn');
@@ -4876,6 +4911,26 @@ function updateStatus(settings) {
   ];
 
   bentoConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
+
+  const ramenConfig = [
+    {name: 'Ebi Furai', key: 'soldout_ebi_ramen', qty: 'ebiQty', msg: 'soldoutEbiRamen'},
+    {name: 'Chicken', key: 'soldout_chicken_ramen', qty: 'chickenQty', msg: 'soldoutChickenRamen'},
+    {name: 'Beef', key: 'soldout_beef_ramen', qty: 'beefQty', msg: 'soldoutBeefRamen'},
+    {name: 'Ribeye', key: 'soldout_ribeye_ramen', qty: 'ribeyeQty', msg: 'soldoutRibeyeRamen'},
+    {name: 'Chasiu', key: 'soldout_chasiu_ramen', qty: 'chasiuQty', msg: 'soldoutChasiuRamen'}
+  ];
+
+  ramenConfig.forEach(cfg => {
     const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
     if (!itemEl) return;
     const soldout = settings[cfg.key] === 'true';


### PR DESCRIPTION
## Summary
- allow dashboard to set soldout state for each ramen
- store ramen soldout settings in backend
- show soldout banners on ramen menu items
- disable ramen selections when sold out
- prevent adding sold-out items to the cart

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_686ca4b0d5c8833387d34f1ef970a5d1