### PR TITLE
Add sold-out toggles for Pokebowl items

### DIFF
--- a/app.py
+++ b/app.py
@@ -507,6 +507,21 @@ with app.app_context():
         "soldout_veggie_bento": "false",
         "soldout_sushi_bento": "false",
         "soldout_xbento": "false",
+        "soldout_zalm_bowl": "false",
+        "soldout_tuna_bowl": "false",
+        "soldout_ebi_fry_bowl": "false",
+        "soldout_chicken_karaage_bowl": "false",
+        "soldout_spicy_chicken_bowl": "false",
+        "soldout_teriyaki_chicken_bowl": "false",
+        "soldout_teriyaki_beef_bowl": "false",
+        "soldout_california_bowl": "false",
+        "soldout_vega_bowl": "false",
+        "soldout_meatlover_bowl": "false",
+        "soldout_rainbow_bowl": "false",
+        "soldout_spicy_tuna_bowl": "false",
+        "soldout_flamed_zalm_bowl": "false",
+        "soldout_flamed_tuna_bowl": "false",
+        "soldout_x_bowl": "false",
         "soldout_ebi_ramen": "false",
         "soldout_chicken_ramen": "false",
         "soldout_beef_ramen": "false",
@@ -953,6 +968,21 @@ def dashboard():
         soldout_veggie_bento=get_value('soldout_veggie_bento', 'false'),
         soldout_sushi_bento=get_value('soldout_sushi_bento', 'false'),
         soldout_xbento=get_value('soldout_xbento', 'false'),
+        soldout_zalm_bowl=get_value('soldout_zalm_bowl', 'false'),
+        soldout_tuna_bowl=get_value('soldout_tuna_bowl', 'false'),
+        soldout_ebi_fry_bowl=get_value('soldout_ebi_fry_bowl', 'false'),
+        soldout_chicken_karaage_bowl=get_value('soldout_chicken_karaage_bowl', 'false'),
+        soldout_spicy_chicken_bowl=get_value('soldout_spicy_chicken_bowl', 'false'),
+        soldout_teriyaki_chicken_bowl=get_value('soldout_teriyaki_chicken_bowl', 'false'),
+        soldout_teriyaki_beef_bowl=get_value('soldout_teriyaki_beef_bowl', 'false'),
+        soldout_california_bowl=get_value('soldout_california_bowl', 'false'),
+        soldout_vega_bowl=get_value('soldout_vega_bowl', 'false'),
+        soldout_meatlover_bowl=get_value('soldout_meatlover_bowl', 'false'),
+        soldout_rainbow_bowl=get_value('soldout_rainbow_bowl', 'false'),
+        soldout_spicy_tuna_bowl=get_value('soldout_spicy_tuna_bowl', 'false'),
+        soldout_flamed_zalm_bowl=get_value('soldout_flamed_zalm_bowl', 'false'),
+        soldout_flamed_tuna_bowl=get_value('soldout_flamed_tuna_bowl', 'false'),
+        soldout_x_bowl=get_value('soldout_x_bowl', 'false'),
         soldout_ebi_ramen=get_value('soldout_ebi_ramen', 'false'),
         soldout_chicken_ramen=get_value('soldout_chicken_ramen', 'false'),
         soldout_beef_ramen=get_value('soldout_beef_ramen', 'false'),
@@ -997,6 +1027,21 @@ def update_setting():
     soldout_veggie_bento_val = data.get('soldout_veggie_bento', 'false')
     soldout_sushi_bento_val = data.get('soldout_sushi_bento', 'false')
     soldout_xbento_val = data.get('soldout_xbento', 'false')
+    soldout_zalm_bowl_val = data.get('soldout_zalm_bowl', 'false')
+    soldout_tuna_bowl_val = data.get('soldout_tuna_bowl', 'false')
+    soldout_ebi_fry_bowl_val = data.get('soldout_ebi_fry_bowl', 'false')
+    soldout_chicken_karaage_bowl_val = data.get('soldout_chicken_karaage_bowl', 'false')
+    soldout_spicy_chicken_bowl_val = data.get('soldout_spicy_chicken_bowl', 'false')
+    soldout_teriyaki_chicken_bowl_val = data.get('soldout_teriyaki_chicken_bowl', 'false')
+    soldout_teriyaki_beef_bowl_val = data.get('soldout_teriyaki_beef_bowl', 'false')
+    soldout_california_bowl_val = data.get('soldout_california_bowl', 'false')
+    soldout_vega_bowl_val = data.get('soldout_vega_bowl', 'false')
+    soldout_meatlover_bowl_val = data.get('soldout_meatlover_bowl', 'false')
+    soldout_rainbow_bowl_val = data.get('soldout_rainbow_bowl', 'false')
+    soldout_spicy_tuna_bowl_val = data.get('soldout_spicy_tuna_bowl', 'false')
+    soldout_flamed_zalm_bowl_val = data.get('soldout_flamed_zalm_bowl', 'false')
+    soldout_flamed_tuna_bowl_val = data.get('soldout_flamed_tuna_bowl', 'false')
+    soldout_x_bowl_val = data.get('soldout_x_bowl', 'false')
     soldout_ebi_ramen_val = data.get('soldout_ebi_ramen', 'false')
     soldout_chicken_ramen_val = data.get('soldout_chicken_ramen', 'false')
     soldout_beef_ramen_val = data.get('soldout_beef_ramen', 'false')
@@ -1028,6 +1073,21 @@ def update_setting():
         ('soldout_veggie_bento', soldout_veggie_bento_val),
         ('soldout_sushi_bento', soldout_sushi_bento_val),
         ('soldout_xbento', soldout_xbento_val),
+        ('soldout_zalm_bowl', soldout_zalm_bowl_val),
+        ('soldout_tuna_bowl', soldout_tuna_bowl_val),
+        ('soldout_ebi_fry_bowl', soldout_ebi_fry_bowl_val),
+        ('soldout_chicken_karaage_bowl', soldout_chicken_karaage_bowl_val),
+        ('soldout_spicy_chicken_bowl', soldout_spicy_chicken_bowl_val),
+        ('soldout_teriyaki_chicken_bowl', soldout_teriyaki_chicken_bowl_val),
+        ('soldout_teriyaki_beef_bowl', soldout_teriyaki_beef_bowl_val),
+        ('soldout_california_bowl', soldout_california_bowl_val),
+        ('soldout_vega_bowl', soldout_vega_bowl_val),
+        ('soldout_meatlover_bowl', soldout_meatlover_bowl_val),
+        ('soldout_rainbow_bowl', soldout_rainbow_bowl_val),
+        ('soldout_spicy_tuna_bowl', soldout_spicy_tuna_bowl_val),
+        ('soldout_flamed_zalm_bowl', soldout_flamed_zalm_bowl_val),
+        ('soldout_flamed_tuna_bowl', soldout_flamed_tuna_bowl_val),
+        ('soldout_x_bowl', soldout_x_bowl_val),
         ('soldout_ebi_ramen', soldout_ebi_ramen_val),
         ('soldout_chicken_ramen', soldout_chicken_ramen_val),
         ('soldout_beef_ramen', soldout_beef_ramen_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -149,6 +149,84 @@
         </select>
         <br><br>
 
+        <h3>Pokebowl uitverkocht</h3>
+        <label>Zalm Bowl:</label>
+        <select id="soldout_zalm_bowl_select">
+            <option value="false" {% if soldout_zalm_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_zalm_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Tuna Bowl:</label>
+        <select id="soldout_tuna_bowl_select">
+            <option value="false" {% if soldout_tuna_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_tuna_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Ebi Fry Bowl:</label>
+        <select id="soldout_ebi_fry_bowl_select">
+            <option value="false" {% if soldout_ebi_fry_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ebi_fry_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Chicken Karaage Bowl:</label>
+        <select id="soldout_chicken_karaage_bowl_select">
+            <option value="false" {% if soldout_chicken_karaage_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chicken_karaage_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Spicy Chicken Bowl:</label>
+        <select id="soldout_spicy_chicken_bowl_select">
+            <option value="false" {% if soldout_spicy_chicken_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_spicy_chicken_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Teriyaki Chicken Bowl:</label>
+        <select id="soldout_teriyaki_chicken_bowl_select">
+            <option value="false" {% if soldout_teriyaki_chicken_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_teriyaki_chicken_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Teriyaki Beef Bowl:</label>
+        <select id="soldout_teriyaki_beef_bowl_select">
+            <option value="false" {% if soldout_teriyaki_beef_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_teriyaki_beef_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>California Bowl:</label>
+        <select id="soldout_california_bowl_select">
+            <option value="false" {% if soldout_california_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_california_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Vega Bowl:</label>
+        <select id="soldout_vega_bowl_select">
+            <option value="false" {% if soldout_vega_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_vega_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Meatlover Bowl:</label>
+        <select id="soldout_meatlover_bowl_select">
+            <option value="false" {% if soldout_meatlover_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_meatlover_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Rainbow Bowl:</label>
+        <select id="soldout_rainbow_bowl_select">
+            <option value="false" {% if soldout_rainbow_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_rainbow_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Spicy Tuna Bowl:</label>
+        <select id="soldout_spicy_tuna_bowl_select">
+            <option value="false" {% if soldout_spicy_tuna_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_spicy_tuna_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Flamed Zalm Bowl:</label>
+        <select id="soldout_flamed_zalm_bowl_select">
+            <option value="false" {% if soldout_flamed_zalm_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_flamed_zalm_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Flamed Tuna Bowl:</label>
+        <select id="soldout_flamed_tuna_bowl_select">
+            <option value="false" {% if soldout_flamed_tuna_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_flamed_tuna_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>X-Bowl:</label>
+        <select id="soldout_x_bowl_select">
+            <option value="false" {% if soldout_x_bowl != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_x_bowl == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select>
+        <br><br>
+
         <h3>Ramen uitverkocht</h3>
         <label>Ebi Furai:</label>
         <select id="soldout_ebi_ramen_select">
@@ -390,6 +468,21 @@
             const soldout_veggie_bento = document.getElementById('soldout_veggie_bento_select').value;
             const soldout_sushi_bento = document.getElementById('soldout_sushi_bento_select').value;
             const soldout_xbento = document.getElementById('soldout_xbento_select').value;
+            const soldout_zalm_bowl = document.getElementById('soldout_zalm_bowl_select').value;
+            const soldout_tuna_bowl = document.getElementById('soldout_tuna_bowl_select').value;
+            const soldout_ebi_fry_bowl = document.getElementById('soldout_ebi_fry_bowl_select').value;
+            const soldout_chicken_karaage_bowl = document.getElementById('soldout_chicken_karaage_bowl_select').value;
+            const soldout_spicy_chicken_bowl = document.getElementById('soldout_spicy_chicken_bowl_select').value;
+            const soldout_teriyaki_chicken_bowl = document.getElementById('soldout_teriyaki_chicken_bowl_select').value;
+            const soldout_teriyaki_beef_bowl = document.getElementById('soldout_teriyaki_beef_bowl_select').value;
+            const soldout_california_bowl = document.getElementById('soldout_california_bowl_select').value;
+            const soldout_vega_bowl = document.getElementById('soldout_vega_bowl_select').value;
+            const soldout_meatlover_bowl = document.getElementById('soldout_meatlover_bowl_select').value;
+            const soldout_rainbow_bowl = document.getElementById('soldout_rainbow_bowl_select').value;
+            const soldout_spicy_tuna_bowl = document.getElementById('soldout_spicy_tuna_bowl_select').value;
+            const soldout_flamed_zalm_bowl = document.getElementById('soldout_flamed_zalm_bowl_select').value;
+            const soldout_flamed_tuna_bowl = document.getElementById('soldout_flamed_tuna_bowl_select').value;
+            const soldout_x_bowl = document.getElementById('soldout_x_bowl_select').value;
             const soldout_ebi_ramen = document.getElementById('soldout_ebi_ramen_select').value;
             const soldout_chicken_ramen = document.getElementById('soldout_chicken_ramen_select').value;
             const soldout_beef_ramen = document.getElementById('soldout_beef_ramen_select').value;
@@ -424,6 +517,21 @@
                     soldout_veggie_bento: soldout_veggie_bento,
                     soldout_sushi_bento: soldout_sushi_bento,
                     soldout_xbento: soldout_xbento,
+                    soldout_zalm_bowl: soldout_zalm_bowl,
+                    soldout_tuna_bowl: soldout_tuna_bowl,
+                    soldout_ebi_fry_bowl: soldout_ebi_fry_bowl,
+                    soldout_chicken_karaage_bowl: soldout_chicken_karaage_bowl,
+                    soldout_spicy_chicken_bowl: soldout_spicy_chicken_bowl,
+                    soldout_teriyaki_chicken_bowl: soldout_teriyaki_chicken_bowl,
+                    soldout_teriyaki_beef_bowl: soldout_teriyaki_beef_bowl,
+                    soldout_california_bowl: soldout_california_bowl,
+                    soldout_vega_bowl: soldout_vega_bowl,
+                    soldout_meatlover_bowl: soldout_meatlover_bowl,
+                    soldout_rainbow_bowl: soldout_rainbow_bowl,
+                    soldout_spicy_tuna_bowl: soldout_spicy_tuna_bowl,
+                    soldout_flamed_zalm_bowl: soldout_flamed_zalm_bowl,
+                    soldout_flamed_tuna_bowl: soldout_flamed_tuna_bowl,
+                    soldout_x_bowl: soldout_x_bowl,
                     soldout_ebi_ramen: soldout_ebi_ramen,
                     soldout_chicken_ramen: soldout_chicken_ramen,
                     soldout_beef_ramen: soldout_beef_ramen,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2129,6 +2129,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Zalm Bowl</h3>
         <p>€ 15.00</p>
+        <p id="soldoutZalmBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="zalmBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="zalmBowlQty" type="button">-</button>
@@ -2144,6 +2145,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Tuna Bowl</h3>
         <p>€ 15.00</p>
+        <p id="soldoutTunaBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="tunaBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="tunaBowlQty" type="button">-</button>
@@ -2160,6 +2162,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Ebi Fry Bowl</h3>
         <p>€ 15.50</p>
+        <p id="soldoutEbiFryBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="ebiFryBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="ebiFryBowlQty" type="button">-</button>
@@ -2176,6 +2179,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Chicken Karaage Bowl</h3>
         <p>€ 15.50</p>
+        <p id="soldoutChickenKaraageBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="chickenKaraageBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="chickenKaraageBowlQty" type="button">-</button>
@@ -2192,6 +2196,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Spicy Chicken Bowl</h3>
         <p>€ 15.50</p>
+        <p id="soldoutSpicyChickenBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="spicyChickenBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="spicyChickenBowlQty" type="button">-</button>
@@ -2208,6 +2213,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Teriyaki Chicken Bowl</h3>
         <p>€ 15.50</p>
+        <p id="soldoutTeriyakiChickenBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="teriyakiChickenBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="teriyakiChickenBowlQty" type="button">-</button>
@@ -2224,6 +2230,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Teriyaki Beef Bowl</h3>
         <p>€ 15.50</p>
+        <p id="soldoutTeriyakiBeefBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="teriyakiBeefBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="teriyakiBeefBowlQty" type="button">-</button>
@@ -2240,6 +2247,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>California Bowl</h3>
         <p>€ 14.00</p>
+        <p id="soldoutCaliforniaBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="californiaBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="californiaBowlQty" type="button">-</button>
@@ -2256,6 +2264,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Vega Bowl (Vegetarisch)</h3>
         <p>€ 13.00</p>
+        <p id="soldoutVegaBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="vegaBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="vegaBowlQty" type="button">-</button>
@@ -2272,6 +2281,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Meatlover Bowl</h3>
         <p>€ 17.00</p>
+        <p id="soldoutMeatloverBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="meatloverBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="meatloverBowlQty" type="button">-</button>
@@ -2288,6 +2298,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Rainbow Bowl</h3>
         <p>€ 17.00</p>
+        <p id="soldoutRainbowBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="rainbowBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="rainbowBowlQty" type="button">-</button>
@@ -2304,6 +2315,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Spicy Tuna Bowl</h3>
         <p>€ 15.50</p>
+        <p id="soldoutSpicyTunaBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="spicyTunaBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="spicyTunaBowlQty" type="button">-</button>
@@ -2320,6 +2332,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Flamed Zalm Bowl</h3>
         <p>€ 16.00</p>
+        <p id="soldoutFlamedZalmBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="flamedZalmBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="flamedZalmBowlQty" type="button">-</button>
@@ -2336,6 +2349,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>Flamed Tuna Bowl</h3>
         <p>€ 16.00</p>
+        <p id="soldoutFlamedTunaBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="qty-box">
           <label for="flamedTunaBowlQty">Aantal</label>
           <button class="qty-minus remove-button" data-target="flamedTunaBowlQty" type="button">-</button>
@@ -2352,6 +2366,7 @@ input:focus, select:focus, textarea:focus {
       <div class="menu-content">
         <h3>X-Bowl (Vrije samenstelling)</h3>
         <p>Prijs afhankelijk van keuzes</p>
+        <p id="soldoutXBowl" class="sold-out-msg hidden">Uitverkocht!</p>
         <div class="bubble-option">
           <select id="xBowlBase">
             <option value="">Basis</option>
@@ -2973,6 +2988,21 @@ const soldoutMap = {
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
   "Xbento": "soldout_xbento",
+  "Zalm Bowl": "soldout_zalm_bowl",
+  "Tuna Bowl": "soldout_tuna_bowl",
+  "Ebi Fry Bowl": "soldout_ebi_fry_bowl",
+  "Chicken Karaage Bowl": "soldout_chicken_karaage_bowl",
+  "Spicy Chicken Bowl": "soldout_spicy_chicken_bowl",
+  "Teriyaki Chicken Bowl": "soldout_teriyaki_chicken_bowl",
+  "Teriyaki Beef Bowl": "soldout_teriyaki_beef_bowl",
+  "California Bowl": "soldout_california_bowl",
+  "Vega Bowl": "soldout_vega_bowl",
+  "Meatlover Bowl": "soldout_meatlover_bowl",
+  "Rainbow Bowl": "soldout_rainbow_bowl",
+  "Spicy Tuna Bowl": "soldout_spicy_tuna_bowl",
+  "Flamed Zalm Bowl": "soldout_flamed_zalm_bowl",
+  "Flamed Tuna Bowl": "soldout_flamed_tuna_bowl",
+  "X-Bowl": "soldout_x_bowl",
   "Ebi Furai": "soldout_ebi_ramen",
   "Chicken": "soldout_chicken_ramen",
   "Beef": "soldout_beef_ramen",
@@ -4911,6 +4941,36 @@ function updateStatus(settings) {
   ];
 
   bentoConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
+
+  const pokebowlConfig = [
+    {name: 'Zalm Bowl', key: 'soldout_zalm_bowl', qty: 'zalmBowlQty', msg: 'soldoutZalmBowl'},
+    {name: 'Tuna Bowl', key: 'soldout_tuna_bowl', qty: 'tunaBowlQty', msg: 'soldoutTunaBowl'},
+    {name: 'Ebi Fry Bowl', key: 'soldout_ebi_fry_bowl', qty: 'ebiFryBowlQty', msg: 'soldoutEbiFryBowl'},
+    {name: 'Chicken Karaage Bowl', key: 'soldout_chicken_karaage_bowl', qty: 'chickenKaraageBowlQty', msg: 'soldoutChickenKaraageBowl'},
+    {name: 'Spicy Chicken Bowl', key: 'soldout_spicy_chicken_bowl', qty: 'spicyChickenBowlQty', msg: 'soldoutSpicyChickenBowl'},
+    {name: 'Teriyaki Chicken Bowl', key: 'soldout_teriyaki_chicken_bowl', qty: 'teriyakiChickenBowlQty', msg: 'soldoutTeriyakiChickenBowl'},
+    {name: 'Teriyaki Beef Bowl', key: 'soldout_teriyaki_beef_bowl', qty: 'teriyakiBeefBowlQty', msg: 'soldoutTeriyakiBeefBowl'},
+    {name: 'California Bowl', key: 'soldout_california_bowl', qty: 'californiaBowlQty', msg: 'soldoutCaliforniaBowl'},
+    {name: 'Vega Bowl', key: 'soldout_vega_bowl', qty: 'vegaBowlQty', msg: 'soldoutVegaBowl'},
+    {name: 'Meatlover Bowl', key: 'soldout_meatlover_bowl', qty: 'meatloverBowlQty', msg: 'soldoutMeatloverBowl'},
+    {name: 'Rainbow Bowl', key: 'soldout_rainbow_bowl', qty: 'rainbowBowlQty', msg: 'soldoutRainbowBowl'},
+    {name: 'Spicy Tuna Bowl', key: 'soldout_spicy_tuna_bowl', qty: 'spicyTunaBowlQty', msg: 'soldoutSpicyTunaBowl'},
+    {name: 'Flamed Zalm Bowl', key: 'soldout_flamed_zalm_bowl', qty: 'flamedZalmBowlQty', msg: 'soldoutFlamedZalmBowl'},
+    {name: 'Flamed Tuna Bowl', key: 'soldout_flamed_tuna_bowl', qty: 'flamedTunaBowlQty', msg: 'soldoutFlamedTunaBowl'},
+    {name: 'X-Bowl', key: 'soldout_x_bowl', qty: 'xBowlQty', msg: 'soldoutXBowl'}
+  ];
+
+  pokebowlConfig.forEach(cfg => {
     const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
     if (!itemEl) return;
     const soldout = settings[cfg.key] === 'true';


### PR DESCRIPTION
## Summary
- extend backend settings with soldout flags for every Pokebowl item
- expose new flags in Dashboard and handle them on update
- render sold-out controls for Pokebowl items in Dashboard UI
- display sold-out messages for Pokebowl items on index page
- disable quantity controls and prevent adding to cart when sold out

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cb16895d883338153763c12326abd