### PR TITLE
Add sold-out switches for special rolls

### DIFF
--- a/app.py
+++ b/app.py
@@ -506,6 +506,10 @@ with app.app_context():
         "soldout_lamskotelet_bento": "false",
         "soldout_veggie_bento": "false",
         "soldout_sushi_bento": "false",
+        "soldout_salmon_roll": "false",
+        "soldout_dragon_roll": "false",
+        "soldout_beef_roll": "false",
+        "soldout_chicken_roll": "false",
         "soldout_xbento": "false",
         "soldout_zalm_bowl": "false",
         "soldout_tuna_bowl": "false",
@@ -967,6 +971,10 @@ def dashboard():
         soldout_lamskotelet_bento=get_value('soldout_lamskotelet_bento', 'false'),
         soldout_veggie_bento=get_value('soldout_veggie_bento', 'false'),
         soldout_sushi_bento=get_value('soldout_sushi_bento', 'false'),
+        soldout_salmon_roll=get_value('soldout_salmon_roll', 'false'),
+        soldout_dragon_roll=get_value('soldout_dragon_roll', 'false'),
+        soldout_beef_roll=get_value('soldout_beef_roll', 'false'),
+        soldout_chicken_roll=get_value('soldout_chicken_roll', 'false'),
         soldout_xbento=get_value('soldout_xbento', 'false'),
         soldout_zalm_bowl=get_value('soldout_zalm_bowl', 'false'),
         soldout_tuna_bowl=get_value('soldout_tuna_bowl', 'false'),
@@ -1026,6 +1034,10 @@ def update_setting():
     soldout_lamskotelet_bento_val = data.get('soldout_lamskotelet_bento', 'false')
     soldout_veggie_bento_val = data.get('soldout_veggie_bento', 'false')
     soldout_sushi_bento_val = data.get('soldout_sushi_bento', 'false')
+    soldout_salmon_roll_val = data.get('soldout_salmon_roll', 'false')
+    soldout_dragon_roll_val = data.get('soldout_dragon_roll', 'false')
+    soldout_beef_roll_val = data.get('soldout_beef_roll', 'false')
+    soldout_chicken_roll_val = data.get('soldout_chicken_roll', 'false')
     soldout_xbento_val = data.get('soldout_xbento', 'false')
     soldout_zalm_bowl_val = data.get('soldout_zalm_bowl', 'false')
     soldout_tuna_bowl_val = data.get('soldout_tuna_bowl', 'false')
@@ -1072,6 +1084,10 @@ def update_setting():
         ('soldout_lamskotelet_bento', soldout_lamskotelet_bento_val),
         ('soldout_veggie_bento', soldout_veggie_bento_val),
         ('soldout_sushi_bento', soldout_sushi_bento_val),
+        ('soldout_salmon_roll', soldout_salmon_roll_val),
+        ('soldout_dragon_roll', soldout_dragon_roll_val),
+        ('soldout_beef_roll', soldout_beef_roll_val),
+        ('soldout_chicken_roll', soldout_chicken_roll_val),
         ('soldout_xbento', soldout_xbento_val),
         ('soldout_zalm_bowl', soldout_zalm_bowl_val),
         ('soldout_tuna_bowl', soldout_tuna_bowl_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -149,6 +149,29 @@
         </select>
         <br><br>
 
+        <h3>Special Roll uitverkocht</h3>
+        <label>Salmon Roll Omakase:</label>
+        <select id="soldout_salmon_roll_select">
+            <option value="false" {% if soldout_salmon_roll != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_salmon_roll == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Dragon Roll Omakase:</label>
+        <select id="soldout_dragon_roll_select">
+            <option value="false" {% if soldout_dragon_roll != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_dragon_roll == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Beef Roll Omakase:</label>
+        <select id="soldout_beef_roll_select">
+            <option value="false" {% if soldout_beef_roll != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_beef_roll == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Chicken Roll Omakase:</label>
+        <select id="soldout_chicken_roll_select">
+            <option value="false" {% if soldout_chicken_roll != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chicken_roll == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <br><br>
+
         <h3>Pokebowl uitverkocht</h3>
         <label>Zalm Bowl:</label>
         <select id="soldout_zalm_bowl_select">
@@ -467,6 +490,10 @@
             const soldout_lamskotelet_bento = document.getElementById('soldout_lamskotelet_bento_select').value;
             const soldout_veggie_bento = document.getElementById('soldout_veggie_bento_select').value;
             const soldout_sushi_bento = document.getElementById('soldout_sushi_bento_select').value;
+            const soldout_salmon_roll = document.getElementById('soldout_salmon_roll_select').value;
+            const soldout_dragon_roll = document.getElementById('soldout_dragon_roll_select').value;
+            const soldout_beef_roll = document.getElementById('soldout_beef_roll_select').value;
+            const soldout_chicken_roll = document.getElementById('soldout_chicken_roll_select').value;
             const soldout_xbento = document.getElementById('soldout_xbento_select').value;
             const soldout_zalm_bowl = document.getElementById('soldout_zalm_bowl_select').value;
             const soldout_tuna_bowl = document.getElementById('soldout_tuna_bowl_select').value;
@@ -516,6 +543,10 @@
                     soldout_lamskotelet_bento: soldout_lamskotelet_bento,
                     soldout_veggie_bento: soldout_veggie_bento,
                     soldout_sushi_bento: soldout_sushi_bento,
+                    soldout_salmon_roll: soldout_salmon_roll,
+                    soldout_dragon_roll: soldout_dragon_roll,
+                    soldout_beef_roll: soldout_beef_roll,
+                    soldout_chicken_roll: soldout_chicken_roll,
                     soldout_xbento: soldout_xbento,
                     soldout_zalm_bowl: soldout_zalm_bowl,
                     soldout_tuna_bowl: soldout_tuna_bowl,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2406,6 +2406,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Salmon Roll Omakase</h3>
 <p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<p id="soldoutSalmonRoll" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="salmonRollCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="salmonRollCount" type="button">-</button>
@@ -2421,6 +2422,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Dragon Roll Omakase</h3>
 <p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<p id="soldoutDragonRoll" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="dragonRollCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="dragonRollCount" type="button">-</button>
@@ -2437,6 +2439,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Beef Roll Omakase</h3>
 <p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<p id="soldoutBeefRoll" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="beefRollCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="beefRollCount" type="button">-</button>
@@ -2452,6 +2455,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Chicken Roll Omakase</h3>
 <p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<p id="soldoutChickenRoll" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="chickenRollCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="chickenRollCount" type="button">-</button>
@@ -2987,6 +2991,10 @@ const soldoutMap = {
   "Lamskotelet Bento": "soldout_lamskotelet_bento",
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
+  "Salmon Roll Omakase": "soldout_salmon_roll",
+  "Dragon Roll Omakase": "soldout_dragon_roll",
+  "Beef Roll Omakase": "soldout_beef_roll",
+  "Chicken Roll Omakase": "soldout_chicken_roll",
   "Xbento": "soldout_xbento",
   "Zalm Bowl": "soldout_zalm_bowl",
   "Tuna Bowl": "soldout_tuna_bowl",
@@ -4926,6 +4934,25 @@ function updateStatus(settings) {
       if (bubbleSetControls) bubbleSetControls.update();
     }
   }
+
+  const rollConfig = [
+    {name: 'Salmon Roll Omakase', key: 'soldout_salmon_roll', qty: 'salmonRollCount', msg: 'soldoutSalmonRoll'},
+    {name: 'Dragon Roll Omakase', key: 'soldout_dragon_roll', qty: 'dragonRollCount', msg: 'soldoutDragonRoll'},
+    {name: 'Beef Roll Omakase', key: 'soldout_beef_roll', qty: 'beefRollCount', msg: 'soldoutBeefRoll'},
+    {name: 'Chicken Roll Omakase', key: 'soldout_chicken_roll', qty: 'chickenRollCount', msg: 'soldoutChickenRoll'}
+  ];
+
+  rollConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
 
   const bentoConfig = [
     {name: 'Chicken Bento', key: 'soldout_chicken_bento', qty: 'chickenBentoCount', msg: 'soldoutChickenBento'},


### PR DESCRIPTION
## Summary
- persist sold-out flags for each Special Sushi Roll
- expose the roll controls on the dashboard
- disable roll items on the menu when sold out

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cb7e6bc408333a04a2d45636db2d6