### PR TITLE
Implement sashimi sold-out controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -510,6 +510,11 @@ with app.app_context():
         "soldout_dragon_roll": "false",
         "soldout_beef_roll": "false",
         "soldout_chicken_roll": "false",
+        "soldout_salmon_sashimi": "false",
+        "soldout_flamed_salmon_sashimi": "false",
+        "soldout_tonijn_sashimi": "false",
+        "soldout_flamed_tonijn_sashimi": "false",
+        "soldout_beef_sashimi": "false",
         "soldout_xbento": "false",
         "soldout_zalm_bowl": "false",
         "soldout_tuna_bowl": "false",
@@ -975,6 +980,11 @@ def dashboard():
         soldout_dragon_roll=get_value('soldout_dragon_roll', 'false'),
         soldout_beef_roll=get_value('soldout_beef_roll', 'false'),
         soldout_chicken_roll=get_value('soldout_chicken_roll', 'false'),
+        soldout_salmon_sashimi=get_value('soldout_salmon_sashimi', 'false'),
+        soldout_flamed_salmon_sashimi=get_value('soldout_flamed_salmon_sashimi', 'false'),
+        soldout_tonijn_sashimi=get_value('soldout_tonijn_sashimi', 'false'),
+        soldout_flamed_tonijn_sashimi=get_value('soldout_flamed_tonijn_sashimi', 'false'),
+        soldout_beef_sashimi=get_value('soldout_beef_sashimi', 'false'),
         soldout_xbento=get_value('soldout_xbento', 'false'),
         soldout_zalm_bowl=get_value('soldout_zalm_bowl', 'false'),
         soldout_tuna_bowl=get_value('soldout_tuna_bowl', 'false'),
@@ -1038,6 +1048,11 @@ def update_setting():
     soldout_dragon_roll_val = data.get('soldout_dragon_roll', 'false')
     soldout_beef_roll_val = data.get('soldout_beef_roll', 'false')
     soldout_chicken_roll_val = data.get('soldout_chicken_roll', 'false')
+    soldout_salmon_sashimi_val = data.get('soldout_salmon_sashimi', 'false')
+    soldout_flamed_salmon_sashimi_val = data.get('soldout_flamed_salmon_sashimi', 'false')
+    soldout_tonijn_sashimi_val = data.get('soldout_tonijn_sashimi', 'false')
+    soldout_flamed_tonijn_sashimi_val = data.get('soldout_flamed_tonijn_sashimi', 'false')
+    soldout_beef_sashimi_val = data.get('soldout_beef_sashimi', 'false')
     soldout_xbento_val = data.get('soldout_xbento', 'false')
     soldout_zalm_bowl_val = data.get('soldout_zalm_bowl', 'false')
     soldout_tuna_bowl_val = data.get('soldout_tuna_bowl', 'false')
@@ -1088,6 +1103,11 @@ def update_setting():
         ('soldout_dragon_roll', soldout_dragon_roll_val),
         ('soldout_beef_roll', soldout_beef_roll_val),
         ('soldout_chicken_roll', soldout_chicken_roll_val),
+        ('soldout_salmon_sashimi', soldout_salmon_sashimi_val),
+        ('soldout_flamed_salmon_sashimi', soldout_flamed_salmon_sashimi_val),
+        ('soldout_tonijn_sashimi', soldout_tonijn_sashimi_val),
+        ('soldout_flamed_tonijn_sashimi', soldout_flamed_tonijn_sashimi_val),
+        ('soldout_beef_sashimi', soldout_beef_sashimi_val),
         ('soldout_xbento', soldout_xbento_val),
         ('soldout_zalm_bowl', soldout_zalm_bowl_val),
         ('soldout_tuna_bowl', soldout_tuna_bowl_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -170,6 +170,33 @@
             <option value="false" {% if soldout_chicken_roll != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_chicken_roll == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+        <br>
+        <h3>Sashimi uitverkocht</h3>
+        <label>Salmon sashimi:</label>
+        <select id="soldout_salmon_sashimi_select">
+            <option value="false" {% if soldout_salmon_sashimi != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_salmon_sashimi == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Flamed salmon sashimi:</label>
+        <select id="soldout_flamed_salmon_sashimi_select">
+            <option value="false" {% if soldout_flamed_salmon_sashimi != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_flamed_salmon_sashimi == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Tonijn sashimi:</label>
+        <select id="soldout_tonijn_sashimi_select">
+            <option value="false" {% if soldout_tonijn_sashimi != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_tonijn_sashimi == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Flamed tonijn sashimi:</label>
+        <select id="soldout_flamed_tonijn_sashimi_select">
+            <option value="false" {% if soldout_flamed_tonijn_sashimi != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_flamed_tonijn_sashimi == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Beef sashimi:</label>
+        <select id="soldout_beef_sashimi_select">
+            <option value="false" {% if soldout_beef_sashimi != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_beef_sashimi == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <br><br>
 
         <h3>Pokebowl uitverkocht</h3>
@@ -494,6 +521,11 @@
             const soldout_dragon_roll = document.getElementById('soldout_dragon_roll_select').value;
             const soldout_beef_roll = document.getElementById('soldout_beef_roll_select').value;
             const soldout_chicken_roll = document.getElementById('soldout_chicken_roll_select').value;
+            const soldout_salmon_sashimi = document.getElementById('soldout_salmon_sashimi_select').value;
+            const soldout_flamed_salmon_sashimi = document.getElementById('soldout_flamed_salmon_sashimi_select').value;
+            const soldout_tonijn_sashimi = document.getElementById('soldout_tonijn_sashimi_select').value;
+            const soldout_flamed_tonijn_sashimi = document.getElementById('soldout_flamed_tonijn_sashimi_select').value;
+            const soldout_beef_sashimi = document.getElementById('soldout_beef_sashimi_select').value;
             const soldout_xbento = document.getElementById('soldout_xbento_select').value;
             const soldout_zalm_bowl = document.getElementById('soldout_zalm_bowl_select').value;
             const soldout_tuna_bowl = document.getElementById('soldout_tuna_bowl_select').value;
@@ -547,6 +579,11 @@
                     soldout_dragon_roll: soldout_dragon_roll,
                     soldout_beef_roll: soldout_beef_roll,
                     soldout_chicken_roll: soldout_chicken_roll,
+                    soldout_salmon_sashimi: soldout_salmon_sashimi,
+                    soldout_flamed_salmon_sashimi: soldout_flamed_salmon_sashimi,
+                    soldout_tonijn_sashimi: soldout_tonijn_sashimi,
+                    soldout_flamed_tonijn_sashimi: soldout_flamed_tonijn_sashimi,
+                    soldout_beef_sashimi: soldout_beef_sashimi,
                     soldout_xbento: soldout_xbento,
                     soldout_zalm_bowl: soldout_zalm_bowl,
                     soldout_tuna_bowl: soldout_tuna_bowl,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2478,6 +2478,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Salmon sashimi</h3>
 <p>€ 9.00</p>
+<p id="soldoutSalmonSashimi" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="salmonSashimiQty">Aantal</label>
 <button class="qty-minus remove-button" data-target="salmonSashimiQty" type="button">-</button>
@@ -2493,6 +2494,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Flamed salmon sashimi</h3>
 <p>€ 10.00</p>
+<p id="soldoutFlamedSalmonSashimi" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="flamedsalmonSashimiQty">Aantal</label>
 <button class="qty-minus remove-button" data-target="flamedsalmonSashimiQty" type="button">-</button>
@@ -2508,6 +2510,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Tonijn sashimi</h3>
 <p>€ 10.00</p>
+<p id="soldoutTonijnSashimi" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="tonijnSashimiQty">Aantal</label>
 <button class="qty-minus remove-button" data-target="tonijnSashimiQty" type="button">-</button>
@@ -2523,6 +2526,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Flamed tonijn sashimi</h3>
 <p>€ 10.50</p>
+<p id="soldoutFlamedTonijnSashimi" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="flamedtonijnSashimiQty">Aantal</label>
 <button class="qty-minus remove-button" data-target="flamedtonijnSashimiQty" type="button">-</button>
@@ -2539,6 +2543,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Beef sashimi</h3>
 <p>€ 10.00</p>
+<p id="soldoutBeefSashimi" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="beefSashimiQty">Aantal</label>
 <button class="qty-minus remove-button" data-target="beefSashimiQty" type="button">-</button>
@@ -2995,6 +3000,11 @@ const soldoutMap = {
   "Dragon Roll Omakase": "soldout_dragon_roll",
   "Beef Roll Omakase": "soldout_beef_roll",
   "Chicken Roll Omakase": "soldout_chicken_roll",
+  "Salmon sashimi": "soldout_salmon_sashimi",
+  "Flamed salmon sashimi": "soldout_flamed_salmon_sashimi",
+  "Tonijn sashimi": "soldout_tonijn_sashimi",
+  "Flamed tonijn sashimi": "soldout_flamed_tonijn_sashimi",
+  "Beef sashimi": "soldout_beef_sashimi",
   "Xbento": "soldout_xbento",
   "Zalm Bowl": "soldout_zalm_bowl",
   "Tuna Bowl": "soldout_tuna_bowl",
@@ -4954,6 +4964,26 @@ function updateStatus(settings) {
     }
   });
 
+  const sashimiConfig = [
+    {name: 'Salmon sashimi', key: 'soldout_salmon_sashimi', qty: 'salmonSashimiQty', msg: 'soldoutSalmonSashimi'},
+    {name: 'Flamed salmon sashimi', key: 'soldout_flamed_salmon_sashimi', qty: 'flamedsalmonSashimiQty', msg: 'soldoutFlamedSalmonSashimi'},
+    {name: 'Tonijn sashimi', key: 'soldout_tonijn_sashimi', qty: 'tonijnSashimiQty', msg: 'soldoutTonijnSashimi'},
+    {name: 'Flamed tonijn sashimi', key: 'soldout_flamed_tonijn_sashimi', qty: 'flamedtonijnSashimiQty', msg: 'soldoutFlamedTonijnSashimi'},
+    {name: 'Beef sashimi', key: 'soldout_beef_sashimi', qty: 'beefSashimiQty', msg: 'soldoutBeefSashimi'}
+  ];
+
+  sashimiConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
+
   const bentoConfig = [
     {name: 'Chicken Bento', key: 'soldout_chicken_bento', qty: 'chickenBentoCount', msg: 'soldoutChickenBento'},
     {name: 'Meatlover Bento', key: 'soldout_meatlover_bento', qty: 'meatloverBentoCount', msg: 'soldoutMeatloverBento'},
@@ -5152,6 +5182,10 @@ function updateStatus(settings) {
   }
   banner.style.display = 'block';
   toggleOrderType();
+  Object.keys(cart).forEach(name => {
+    if (isItemSoldOut(name)) delete cart[name];
+  });
+  updateCart();
 }
 
 


### PR DESCRIPTION
## Summary
- add backend settings for sashimi sold-out states
- expose sashimi toggle controls on dashboard
- render sold-out notices on index and update cart logic

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb9e6ae5883338d6ccb52ef092d71