### PR TITLE
Enable sold‑out toggles for crispy rice sandwiches

### DIFF
--- a/app.py
+++ b/app.py
@@ -515,6 +515,11 @@ with app.app_context():
         "soldout_tonijn_sashimi": "false",
         "soldout_flamed_tonijn_sashimi": "false",
         "soldout_beef_sashimi": "false",
+        "soldout_zalm_crispy_rice_sandwich": "false",
+        "soldout_ebi_crispy_rice_sandwich": "false",
+        "soldout_beef_crispy_rice_sandwich": "false",
+        "soldout_california_crispy_rice_sandwich": "false",
+        "soldout_chicken_crispy_rice_sandwich": "false",
         "soldout_xbento": "false",
         "soldout_zalm_bowl": "false",
         "soldout_tuna_bowl": "false",
@@ -985,6 +990,11 @@ def dashboard():
         soldout_tonijn_sashimi=get_value('soldout_tonijn_sashimi', 'false'),
         soldout_flamed_tonijn_sashimi=get_value('soldout_flamed_tonijn_sashimi', 'false'),
         soldout_beef_sashimi=get_value('soldout_beef_sashimi', 'false'),
+        soldout_zalm_crispy_rice_sandwich=get_value('soldout_zalm_crispy_rice_sandwich', 'false'),
+        soldout_ebi_crispy_rice_sandwich=get_value('soldout_ebi_crispy_rice_sandwich', 'false'),
+        soldout_beef_crispy_rice_sandwich=get_value('soldout_beef_crispy_rice_sandwich', 'false'),
+        soldout_california_crispy_rice_sandwich=get_value('soldout_california_crispy_rice_sandwich', 'false'),
+        soldout_chicken_crispy_rice_sandwich=get_value('soldout_chicken_crispy_rice_sandwich', 'false'),
         soldout_xbento=get_value('soldout_xbento', 'false'),
         soldout_zalm_bowl=get_value('soldout_zalm_bowl', 'false'),
         soldout_tuna_bowl=get_value('soldout_tuna_bowl', 'false'),
@@ -1053,6 +1063,11 @@ def update_setting():
     soldout_tonijn_sashimi_val = data.get('soldout_tonijn_sashimi', 'false')
     soldout_flamed_tonijn_sashimi_val = data.get('soldout_flamed_tonijn_sashimi', 'false')
     soldout_beef_sashimi_val = data.get('soldout_beef_sashimi', 'false')
+    soldout_zalm_crispy_rice_sandwich_val = data.get('soldout_zalm_crispy_rice_sandwich', 'false')
+    soldout_ebi_crispy_rice_sandwich_val = data.get('soldout_ebi_crispy_rice_sandwich', 'false')
+    soldout_beef_crispy_rice_sandwich_val = data.get('soldout_beef_crispy_rice_sandwich', 'false')
+    soldout_california_crispy_rice_sandwich_val = data.get('soldout_california_crispy_rice_sandwich', 'false')
+    soldout_chicken_crispy_rice_sandwich_val = data.get('soldout_chicken_crispy_rice_sandwich', 'false')
     soldout_xbento_val = data.get('soldout_xbento', 'false')
     soldout_zalm_bowl_val = data.get('soldout_zalm_bowl', 'false')
     soldout_tuna_bowl_val = data.get('soldout_tuna_bowl', 'false')
@@ -1108,6 +1123,11 @@ def update_setting():
         ('soldout_tonijn_sashimi', soldout_tonijn_sashimi_val),
         ('soldout_flamed_tonijn_sashimi', soldout_flamed_tonijn_sashimi_val),
         ('soldout_beef_sashimi', soldout_beef_sashimi_val),
+        ('soldout_zalm_crispy_rice_sandwich', soldout_zalm_crispy_rice_sandwich_val),
+        ('soldout_ebi_crispy_rice_sandwich', soldout_ebi_crispy_rice_sandwich_val),
+        ('soldout_beef_crispy_rice_sandwich', soldout_beef_crispy_rice_sandwich_val),
+        ('soldout_california_crispy_rice_sandwich', soldout_california_crispy_rice_sandwich_val),
+        ('soldout_chicken_crispy_rice_sandwich', soldout_chicken_crispy_rice_sandwich_val),
         ('soldout_xbento', soldout_xbento_val),
         ('soldout_zalm_bowl', soldout_zalm_bowl_val),
         ('soldout_tuna_bowl', soldout_tuna_bowl_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -199,6 +199,34 @@
         </select><br>
         <br><br>
 
+        <h3>Crispy Rice Sandwich uitverkocht</h3>
+        <label>Zalm crispy rice sandwich:</label>
+        <select id="soldout_zalm_crispy_rice_sandwich_select">
+            <option value="false" {% if soldout_zalm_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_zalm_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Ebi crispy rice sandwich:</label>
+        <select id="soldout_ebi_crispy_rice_sandwich_select">
+            <option value="false" {% if soldout_ebi_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ebi_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Beef crispy rice sandwich:</label>
+        <select id="soldout_beef_crispy_rice_sandwich_select">
+            <option value="false" {% if soldout_beef_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_beef_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>California crispy rice sandwich:</label>
+        <select id="soldout_california_crispy_rice_sandwich_select">
+            <option value="false" {% if soldout_california_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_california_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Chicken crispy rice sandwich:</label>
+        <select id="soldout_chicken_crispy_rice_sandwich_select">
+            <option value="false" {% if soldout_chicken_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chicken_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <br><br>
+
         <h3>Pokebowl uitverkocht</h3>
         <label>Zalm Bowl:</label>
         <select id="soldout_zalm_bowl_select">
@@ -526,6 +554,11 @@
             const soldout_tonijn_sashimi = document.getElementById('soldout_tonijn_sashimi_select').value;
             const soldout_flamed_tonijn_sashimi = document.getElementById('soldout_flamed_tonijn_sashimi_select').value;
             const soldout_beef_sashimi = document.getElementById('soldout_beef_sashimi_select').value;
+            const soldout_zalm_crispy_rice_sandwich = document.getElementById('soldout_zalm_crispy_rice_sandwich_select').value;
+            const soldout_ebi_crispy_rice_sandwich = document.getElementById('soldout_ebi_crispy_rice_sandwich_select').value;
+            const soldout_beef_crispy_rice_sandwich = document.getElementById('soldout_beef_crispy_rice_sandwich_select').value;
+            const soldout_california_crispy_rice_sandwich = document.getElementById('soldout_california_crispy_rice_sandwich_select').value;
+            const soldout_chicken_crispy_rice_sandwich = document.getElementById('soldout_chicken_crispy_rice_sandwich_select').value;
             const soldout_xbento = document.getElementById('soldout_xbento_select').value;
             const soldout_zalm_bowl = document.getElementById('soldout_zalm_bowl_select').value;
             const soldout_tuna_bowl = document.getElementById('soldout_tuna_bowl_select').value;
@@ -582,9 +615,14 @@
                     soldout_salmon_sashimi: soldout_salmon_sashimi,
                     soldout_flamed_salmon_sashimi: soldout_flamed_salmon_sashimi,
                     soldout_tonijn_sashimi: soldout_tonijn_sashimi,
-                    soldout_flamed_tonijn_sashimi: soldout_flamed_tonijn_sashimi,
-                    soldout_beef_sashimi: soldout_beef_sashimi,
-                    soldout_xbento: soldout_xbento,
+                      soldout_flamed_tonijn_sashimi: soldout_flamed_tonijn_sashimi,
+                      soldout_beef_sashimi: soldout_beef_sashimi,
+                      soldout_zalm_crispy_rice_sandwich: soldout_zalm_crispy_rice_sandwich,
+                      soldout_ebi_crispy_rice_sandwich: soldout_ebi_crispy_rice_sandwich,
+                      soldout_beef_crispy_rice_sandwich: soldout_beef_crispy_rice_sandwich,
+                      soldout_california_crispy_rice_sandwich: soldout_california_crispy_rice_sandwich,
+                      soldout_chicken_crispy_rice_sandwich: soldout_chicken_crispy_rice_sandwich,
+                      soldout_xbento: soldout_xbento,
                     soldout_zalm_bowl: soldout_zalm_bowl,
                     soldout_tuna_bowl: soldout_tuna_bowl,
                     soldout_ebi_fry_bowl: soldout_ebi_fry_bowl,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2568,6 +2568,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Zalm crispy rice sandwich</h3>
 <p>€ 7.00</p>
+<p id="soldoutZalmCrispyRiceSandwich" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="zalm-crispy-rice-sandwich">Aantal</label>
 <button class="qty-minus remove-button" data-target="zalm-crispy-rice-sandwich" type="button">-</button>
@@ -2585,6 +2586,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Ebi crispy rice sandwich</h3>
 <p>€ 7.00</p>
+<p id="soldoutEbiCrispyRiceSandwich" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="ebiCrispyRiceSandwich">Aantal</label>
 <button class="qty-minus remove-button" data-target="ebiCrispyRiceSandwich" type="button">-</button>
@@ -2601,6 +2603,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Beef crispy rice sandwich</h3>
 <p>€ 7.50</p>
+<p id="soldoutBeefCrispyRiceSandwich" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="beefCrispyRiceSandwich">Aantal</label>
 <button class="qty-minus remove-button" data-target="beefCrispyRiceSandwich" type="button">-</button>
@@ -2617,6 +2620,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>California crispy rice sandwich</h3>
 <p>€ 7.50</p>
+<p id="soldoutCaliforniaCrispyRiceSandwich" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="californiaCrispyRiceSandwich">Aantal</label>
 <button class="qty-minus remove-button" data-target="californiaCrispyRiceSandwich" type="button">-</button>
@@ -2633,6 +2637,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Chicken crispy rice sandwich</h3>
 <p>€ 7.00</p>
+<p id="soldoutChickenCrispyRiceSandwich" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="chickenCrispyRiceSandwich">Aantal</label>
 <button class="qty-minus remove-button" data-target="chickenCrispyRiceSandwich" type="button">-</button>
@@ -3005,6 +3010,11 @@ const soldoutMap = {
   "Tonijn sashimi": "soldout_tonijn_sashimi",
   "Flamed tonijn sashimi": "soldout_flamed_tonijn_sashimi",
   "Beef sashimi": "soldout_beef_sashimi",
+  "Zalm crispy rice sandwich": "soldout_zalm_crispy_rice_sandwich",
+  "Ebi crispy rice sandwich": "soldout_ebi_crispy_rice_sandwich",
+  "Beef crispy rice sandwich": "soldout_beef_crispy_rice_sandwich",
+  "California crispy rice sandwich": "soldout_california_crispy_rice_sandwich",
+  "Chicken crispy rice sandwich": "soldout_chicken_crispy_rice_sandwich",
   "Xbento": "soldout_xbento",
   "Zalm Bowl": "soldout_zalm_bowl",
   "Tuna Bowl": "soldout_tuna_bowl",
@@ -4973,6 +4983,26 @@ function updateStatus(settings) {
   ];
 
   sashimiConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
+
+  const crispyRiceConfig = [
+    {name: 'Zalm crispy rice sandwich', key: 'soldout_zalm_crispy_rice_sandwich', qty: 'zalm-crispy-rice-sandwich', msg: 'soldoutZalmCrispyRiceSandwich'},
+    {name: 'Ebi crispy rice sandwich', key: 'soldout_ebi_crispy_rice_sandwich', qty: 'ebiCrispyRiceSandwich', msg: 'soldoutEbiCrispyRiceSandwich'},
+    {name: 'Beef crispy rice sandwich', key: 'soldout_beef_crispy_rice_sandwich', qty: 'beefCrispyRiceSandwich', msg: 'soldoutBeefCrispyRiceSandwich'},
+    {name: 'California crispy rice sandwich', key: 'soldout_california_crispy_rice_sandwich', qty: 'californiaCrispyRiceSandwich', msg: 'soldoutCaliforniaCrispyRiceSandwich'},
+    {name: 'Chicken crispy rice sandwich', key: 'soldout_chicken_crispy_rice_sandwich', qty: 'chickenCrispyRiceSandwich', msg: 'soldoutChickenCrispyRiceSandwich'}
+  ];
+
+  crispyRiceConfig.forEach(cfg => {
     const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
     if (!itemEl) return;
     const soldout = settings[cfg.key] === 'true';


### PR DESCRIPTION
## Summary
- add new sold-out switches for each crispy rice sandwich in dashboard
- persist crispy rice sandwich sold-out state server-side
- show sold-out message and disable controls on the index page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cbe57118083339ef892dffc240ab2