### PR TITLE
Add snack sold-out switches

### DIFF
--- a/app.py
+++ b/app.py
@@ -541,6 +541,19 @@ with app.app_context():
         "soldout_beef_ramen": "false",
         "soldout_ribeye_ramen": "false",
         "soldout_chasiu_ramen": "false",
+        "soldout_karaage": "false",
+        "soldout_ebi_fry": "false",
+        "soldout_spicy_crispy_chicken": "false",
+        "soldout_chicken_loempia": "false",
+        "soldout_gyoza": "false",
+        "soldout_inktvis_ringen": "false",
+        "soldout_crispy_rijst": "false",
+        "soldout_yakitori": "false",
+        "soldout_mini_loempia": "false",
+        "soldout_edamame": "false",
+        "soldout_kimchi_komkommer": "false",
+        "soldout_kimchi_kool": "false",
+        "soldout_zeewiersalade": "false",
     }
     for k, v in defaults.items():
         if not Setting.query.filter_by(key=k).first():
@@ -1016,6 +1029,19 @@ def dashboard():
         soldout_beef_ramen=get_value('soldout_beef_ramen', 'false'),
         soldout_ribeye_ramen=get_value('soldout_ribeye_ramen', 'false'),
         soldout_chasiu_ramen=get_value('soldout_chasiu_ramen', 'false'),
+        soldout_karaage=get_value('soldout_karaage', 'false'),
+        soldout_ebi_fry=get_value('soldout_ebi_fry', 'false'),
+        soldout_spicy_crispy_chicken=get_value('soldout_spicy_crispy_chicken', 'false'),
+        soldout_chicken_loempia=get_value('soldout_chicken_loempia', 'false'),
+        soldout_gyoza=get_value('soldout_gyoza', 'false'),
+        soldout_inktvis_ringen=get_value('soldout_inktvis_ringen', 'false'),
+        soldout_crispy_rijst=get_value('soldout_crispy_rijst', 'false'),
+        soldout_yakitori=get_value('soldout_yakitori', 'false'),
+        soldout_mini_loempia=get_value('soldout_mini_loempia', 'false'),
+        soldout_edamame=get_value('soldout_edamame', 'false'),
+        soldout_kimchi_komkommer=get_value('soldout_kimchi_komkommer', 'false'),
+        soldout_kimchi_kool=get_value('soldout_kimchi_kool', 'false'),
+        soldout_zeewiersalade=get_value('soldout_zeewiersalade', 'false'),
         sections=sections,
         base_options=bases,
         smaak_options=smaken,
@@ -1089,6 +1115,19 @@ def update_setting():
     soldout_beef_ramen_val = data.get('soldout_beef_ramen', 'false')
     soldout_ribeye_ramen_val = data.get('soldout_ribeye_ramen', 'false')
     soldout_chasiu_ramen_val = data.get('soldout_chasiu_ramen', 'false')
+    soldout_karaage_val = data.get('soldout_karaage', 'false')
+    soldout_ebi_fry_val = data.get('soldout_ebi_fry', 'false')
+    soldout_spicy_crispy_chicken_val = data.get('soldout_spicy_crispy_chicken', 'false')
+    soldout_chicken_loempia_val = data.get('soldout_chicken_loempia', 'false')
+    soldout_gyoza_val = data.get('soldout_gyoza', 'false')
+    soldout_inktvis_ringen_val = data.get('soldout_inktvis_ringen', 'false')
+    soldout_crispy_rijst_val = data.get('soldout_crispy_rijst', 'false')
+    soldout_yakitori_val = data.get('soldout_yakitori', 'false')
+    soldout_mini_loempia_val = data.get('soldout_mini_loempia', 'false')
+    soldout_edamame_val = data.get('soldout_edamame', 'false')
+    soldout_kimchi_komkommer_val = data.get('soldout_kimchi_komkommer', 'false')
+    soldout_kimchi_kool_val = data.get('soldout_kimchi_kool', 'false')
+    soldout_zeewiersalade_val = data.get('soldout_zeewiersalade', 'false')
 
     for key, val in [
         ('is_open', is_open_val),
@@ -1149,6 +1188,19 @@ def update_setting():
         ('soldout_beef_ramen', soldout_beef_ramen_val),
         ('soldout_ribeye_ramen', soldout_ribeye_ramen_val),
         ('soldout_chasiu_ramen', soldout_chasiu_ramen_val),
+        ('soldout_karaage', soldout_karaage_val),
+        ('soldout_ebi_fry', soldout_ebi_fry_val),
+        ('soldout_spicy_crispy_chicken', soldout_spicy_crispy_chicken_val),
+        ('soldout_chicken_loempia', soldout_chicken_loempia_val),
+        ('soldout_gyoza', soldout_gyoza_val),
+        ('soldout_inktvis_ringen', soldout_inktvis_ringen_val),
+        ('soldout_crispy_rijst', soldout_crispy_rijst_val),
+        ('soldout_yakitori', soldout_yakitori_val),
+        ('soldout_mini_loempia', soldout_mini_loempia_val),
+        ('soldout_edamame', soldout_edamame_val),
+        ('soldout_kimchi_komkommer', soldout_kimchi_komkommer_val),
+        ('soldout_kimchi_kool', soldout_kimchi_kool_val),
+        ('soldout_zeewiersalade', soldout_zeewiersalade_val),
     ]:
         s = Setting.query.filter_by(key=key).first()
         if not s:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -225,6 +225,73 @@
             <option value="false" {% if soldout_chicken_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_chicken_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+
+        <h3>Snack uitverkocht</h3>
+        <label>Karaage:</label>
+        <select id="soldout_karaage_select">
+            <option value="false" {% if soldout_karaage != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_karaage == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Ebi Fry – 4 st:</label>
+        <select id="soldout_ebi_fry_select">
+            <option value="false" {% if soldout_ebi_fry != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ebi_fry == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Spicy Crispy Chicken – 5 st:</label>
+        <select id="soldout_spicy_crispy_chicken_select">
+            <option value="false" {% if soldout_spicy_crispy_chicken != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_spicy_crispy_chicken == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Chicken Loempia – 2 st:</label>
+        <select id="soldout_chicken_loempia_select">
+            <option value="false" {% if soldout_chicken_loempia != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_chicken_loempia == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Gyoza – 5 st:</label>
+        <select id="soldout_gyoza_select">
+            <option value="false" {% if soldout_gyoza != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_gyoza == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Inktvis Ringen – 5 st:</label>
+        <select id="soldout_inktvis_ringen_select">
+            <option value="false" {% if soldout_inktvis_ringen != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_inktvis_ringen == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Crispy Rijst – 4 st:</label>
+        <select id="soldout_crispy_rijst_select">
+            <option value="false" {% if soldout_crispy_rijst != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_crispy_rijst == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Yakitori – 4 st:</label>
+        <select id="soldout_yakitori_select">
+            <option value="false" {% if soldout_yakitori != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_yakitori == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Mini Loempia – 6 st:</label>
+        <select id="soldout_mini_loempia_select">
+            <option value="false" {% if soldout_mini_loempia != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_mini_loempia == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Edamame:</label>
+        <select id="soldout_edamame_select">
+            <option value="false" {% if soldout_edamame != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_edamame == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Kimchi Komkommer:</label>
+        <select id="soldout_kimchi_komkommer_select">
+            <option value="false" {% if soldout_kimchi_komkommer != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_kimchi_komkommer == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Kimchi Kool:</label>
+        <select id="soldout_kimchi_kool_select">
+            <option value="false" {% if soldout_kimchi_kool != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_kimchi_kool == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Zeewiersalade – 100g:</label>
+        <select id="soldout_zeewiersalade_select">
+            <option value="false" {% if soldout_zeewiersalade != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_zeewiersalade == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <br><br>
 
         <h3>Pokebowl uitverkocht</h3>
@@ -580,6 +647,19 @@
             const soldout_beef_ramen = document.getElementById('soldout_beef_ramen_select').value;
             const soldout_ribeye_ramen = document.getElementById('soldout_ribeye_ramen_select').value;
             const soldout_chasiu_ramen = document.getElementById('soldout_chasiu_ramen_select').value;
+            const soldout_karaage = document.getElementById('soldout_karaage_select').value;
+            const soldout_ebi_fry = document.getElementById('soldout_ebi_fry_select').value;
+            const soldout_spicy_crispy_chicken = document.getElementById('soldout_spicy_crispy_chicken_select').value;
+            const soldout_chicken_loempia = document.getElementById('soldout_chicken_loempia_select').value;
+            const soldout_gyoza = document.getElementById('soldout_gyoza_select').value;
+            const soldout_inktvis_ringen = document.getElementById('soldout_inktvis_ringen_select').value;
+            const soldout_crispy_rijst = document.getElementById('soldout_crispy_rijst_select').value;
+            const soldout_yakitori = document.getElementById('soldout_yakitori_select').value;
+            const soldout_mini_loempia = document.getElementById('soldout_mini_loempia_select').value;
+            const soldout_edamame = document.getElementById('soldout_edamame_select').value;
+            const soldout_kimchi_komkommer = document.getElementById('soldout_kimchi_komkommer_select').value;
+            const soldout_kimchi_kool = document.getElementById('soldout_kimchi_kool_select').value;
+            const soldout_zeewiersalade = document.getElementById('soldout_zeewiersalade_select').value;
 
             fetch('/dashboard/update', {
                 method: 'POST',
@@ -642,7 +722,20 @@
                     soldout_chicken_ramen: soldout_chicken_ramen,
                     soldout_beef_ramen: soldout_beef_ramen,
                     soldout_ribeye_ramen: soldout_ribeye_ramen,
-                    soldout_chasiu_ramen: soldout_chasiu_ramen
+                    soldout_chasiu_ramen: soldout_chasiu_ramen,
+                    soldout_karaage: soldout_karaage,
+                    soldout_ebi_fry: soldout_ebi_fry,
+                    soldout_spicy_crispy_chicken: soldout_spicy_crispy_chicken,
+                    soldout_chicken_loempia: soldout_chicken_loempia,
+                    soldout_gyoza: soldout_gyoza,
+                    soldout_inktvis_ringen: soldout_inktvis_ringen,
+                    soldout_crispy_rijst: soldout_crispy_rijst,
+                    soldout_yakitori: soldout_yakitori,
+                    soldout_mini_loempia: soldout_mini_loempia,
+                    soldout_edamame: soldout_edamame,
+                    soldout_kimchi_komkommer: soldout_kimchi_komkommer,
+                    soldout_kimchi_kool: soldout_kimchi_kool,
+                    soldout_zeewiersalade: soldout_zeewiersalade
                 })
             })
             .then(response => response.json())

--- a/templates/index.html
+++ b/templates/index.html
@@ -2658,6 +2658,7 @@ input:focus, select:focus, textarea:focus {
 <div class="menu-content">
 <h3>Karaage (Japanse gefrituurde kip)</h3>
 <p>€ 6.50</p>
+<p id="soldoutKaraage" class="sold-out-msg hidden">Uitverkocht!</p>
 <div class="qty-box">
 <label for="snackCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="snackCount" type="button">-</button>
@@ -2674,6 +2675,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Ebi Fry – 4 st</h3>
     <p>€ 6.20</p>
+    <p id="soldoutEbiFry" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="ebiFryCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="ebiFryCount" type="button">-</button>
@@ -2690,6 +2692,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Spicy Crispy Chicken – 5 st</h3>
     <p>€ 5.50</p>
+    <p id="soldoutSpicyCrispyChicken" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="spicyCrispyChickenCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="spicyCrispyChickenCount" type="button">-</button>
@@ -2706,6 +2709,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Chicken Loempia – 2 st</h3>
     <p>€ 5.00</p>
+    <p id="soldoutChickenLoempia" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="chickenLoempiaCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="chickenLoempiaCount" type="button">-</button>
@@ -2722,6 +2726,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Gyoza – 5 st</h3>
     <p>€ 5.00</p>
+    <p id="soldoutGyoza" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="gyozaCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="gyozaCount" type="button">-</button>
@@ -2738,6 +2743,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Inktvis Ringen – 5 st</h3>
     <p>€ 5.00</p>
+    <p id="soldoutInktvisRingen" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="inktvisRingenCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="inktvisRingenCount" type="button">-</button>
@@ -2754,6 +2760,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Crispy Rijst – 4 st</h3>
     <p>€ 4.00</p>
+    <p id="soldoutCrispyRijst" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="crispyRijstCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="crispyRijstCount" type="button">-</button>
@@ -2770,6 +2777,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Yakitori – 4 st</h3>
     <p>€ 6.00</p>
+    <p id="soldoutYakitori" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="yakitoriCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="yakitoriCount" type="button">-</button>
@@ -2786,6 +2794,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Mini Loempia – 6 st</h3>
     <p>€ 3.50</p>
+    <p id="soldoutMiniLoempia" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="miniLoempiaCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="miniLoempiaCount" type="button">-</button>
@@ -2802,6 +2811,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Edamame</h3>
     <p>€ 4.50</p>
+    <p id="soldoutEdamame" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="edamameCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="edamameCount" type="button">-</button>
@@ -2818,6 +2828,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Kimchi Komkommer</h3>
     <p>€ 4.50</p>
+    <p id="soldoutKimchiKomkommer" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="kimchiKomkommerCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="kimchiKomkommerCount" type="button">-</button>
@@ -2834,6 +2845,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Kimchi Kool</h3>
     <p>€ 5.00</p>
+    <p id="soldoutKimchiKool" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="kimchiKoolCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="kimchiKoolCount" type="button">-</button>
@@ -2850,6 +2862,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-content">
     <h3>Zeewiersalade – 100g</h3>
     <p>€ 5.00</p>
+    <p id="soldoutZeewiersalade" class="sold-out-msg hidden">Uitverkocht!</p>
     <div class="qty-box">
       <label for="zeewiersaladeCount">Aantal</label>
       <button class="qty-minus remove-button" data-target="zeewiersaladeCount" type="button">-</button>
@@ -3035,7 +3048,20 @@ const soldoutMap = {
   "Chicken": "soldout_chicken_ramen",
   "Beef": "soldout_beef_ramen",
   "Ribeye": "soldout_ribeye_ramen",
-  "Chasiu": "soldout_chasiu_ramen"
+  "Chasiu": "soldout_chasiu_ramen",
+  "Karaage": "soldout_karaage",
+  "Ebi Fry": "soldout_ebi_fry",
+  "Spicy Crispy Chicken": "soldout_spicy_crispy_chicken",
+  "Chicken Loempia": "soldout_chicken_loempia",
+  "Gyoza": "soldout_gyoza",
+  "Inktvis Ringen": "soldout_inktvis_ringen",
+  "Crispy Rijst": "soldout_crispy_rijst",
+  "Yakitori": "soldout_yakitori",
+  "Mini Loempia": "soldout_mini_loempia",
+  "Edamame": "soldout_edamame",
+  "Kimchi Komkommer": "soldout_kimchi_komkommer",
+  "Kimchi Kool": "soldout_kimchi_kool",
+  "Zeewiersalade": "soldout_zeewiersalade"
 };
 
 function isItemSoldOut(name){
@@ -5003,6 +5029,34 @@ function updateStatus(settings) {
   ];
 
   crispyRiceConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
+
+  const snackConfig = [
+    {name: 'Karaage', key: 'soldout_karaage', qty: 'snackCount', msg: 'soldoutKaraage'},
+    {name: 'Ebi Fry – 4 st', key: 'soldout_ebi_fry', qty: 'ebiFryCount', msg: 'soldoutEbiFry'},
+    {name: 'Spicy Crispy Chicken – 5 st', key: 'soldout_spicy_crispy_chicken', qty: 'spicyCrispyChickenCount', msg: 'soldoutSpicyCrispyChicken'},
+    {name: 'Chicken Loempia – 2 st', key: 'soldout_chicken_loempia', qty: 'chickenLoempiaCount', msg: 'soldoutChickenLoempia'},
+    {name: 'Gyoza – 5 st', key: 'soldout_gyoza', qty: 'gyozaCount', msg: 'soldoutGyoza'},
+    {name: 'Inktvis Ringen – 5 st', key: 'soldout_inktvis_ringen', qty: 'inktvisRingenCount', msg: 'soldoutInktvisRingen'},
+    {name: 'Crispy Rijst – 4 st', key: 'soldout_crispy_rijst', qty: 'crispyRijstCount', msg: 'soldoutCrispyRijst'},
+    {name: 'Yakitori – 4 st', key: 'soldout_yakitori', qty: 'yakitoriCount', msg: 'soldoutYakitori'},
+    {name: 'Mini Loempia – 6 st', key: 'soldout_mini_loempia', qty: 'miniLoempiaCount', msg: 'soldoutMiniLoempia'},
+    {name: 'Edamame', key: 'soldout_edamame', qty: 'edamameCount', msg: 'soldoutEdamame'},
+    {name: 'Kimchi Komkommer', key: 'soldout_kimchi_komkommer', qty: 'kimchiKomkommerCount', msg: 'soldoutKimchiKomkommer'},
+    {name: 'Kimchi Kool', key: 'soldout_kimchi_kool', qty: 'kimchiKoolCount', msg: 'soldoutKimchiKool'},
+    {name: 'Zeewiersalade – 100g', key: 'soldout_zeewiersalade', qty: 'zeewiersaladeCount', msg: 'soldoutZeewiersalade'}
+  ];
+
+  snackConfig.forEach(cfg => {
     const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
     if (!itemEl) return;
     const soldout = settings[cfg.key] === 'true';


### PR DESCRIPTION
## Summary
- add soldout controls for Snack items in the backend defaults and update handlers
- expose these settings on the dashboard
- create Snack toggle group in dashboard UI and submit values to backend
- add sold-out indicators to snack items on the menu and handle state in JavaScript

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cc1ad22dc8333a0f4f1f524518b2f