### PR TITLE
Add Dessert sold-out toggles

### DIFF
--- a/app.py
+++ b/app.py
@@ -554,6 +554,10 @@ with app.app_context():
         "soldout_kimchi_komkommer": "false",
         "soldout_kimchi_kool": "false",
         "soldout_zeewiersalade": "false",
+        "soldout_mochi_mango": "false",
+        "soldout_mochi_aardbei": "false",
+        "soldout_mochi_matcha": "false",
+        "soldout_mochi_pistachio": "false",
     }
     for k, v in defaults.items():
         if not Setting.query.filter_by(key=k).first():
@@ -1042,6 +1046,10 @@ def dashboard():
         soldout_kimchi_komkommer=get_value('soldout_kimchi_komkommer', 'false'),
         soldout_kimchi_kool=get_value('soldout_kimchi_kool', 'false'),
         soldout_zeewiersalade=get_value('soldout_zeewiersalade', 'false'),
+        soldout_mochi_mango=get_value('soldout_mochi_mango', 'false'),
+        soldout_mochi_aardbei=get_value('soldout_mochi_aardbei', 'false'),
+        soldout_mochi_matcha=get_value('soldout_mochi_matcha', 'false'),
+        soldout_mochi_pistachio=get_value('soldout_mochi_pistachio', 'false'),
         sections=sections,
         base_options=bases,
         smaak_options=smaken,
@@ -1128,6 +1136,10 @@ def update_setting():
     soldout_kimchi_komkommer_val = data.get('soldout_kimchi_komkommer', 'false')
     soldout_kimchi_kool_val = data.get('soldout_kimchi_kool', 'false')
     soldout_zeewiersalade_val = data.get('soldout_zeewiersalade', 'false')
+    soldout_mochi_mango_val = data.get('soldout_mochi_mango', 'false')
+    soldout_mochi_aardbei_val = data.get('soldout_mochi_aardbei', 'false')
+    soldout_mochi_matcha_val = data.get('soldout_mochi_matcha', 'false')
+    soldout_mochi_pistachio_val = data.get('soldout_mochi_pistachio', 'false')
 
     for key, val in [
         ('is_open', is_open_val),
@@ -1201,6 +1213,10 @@ def update_setting():
         ('soldout_kimchi_komkommer', soldout_kimchi_komkommer_val),
         ('soldout_kimchi_kool', soldout_kimchi_kool_val),
         ('soldout_zeewiersalade', soldout_zeewiersalade_val),
+        ('soldout_mochi_mango', soldout_mochi_mango_val),
+        ('soldout_mochi_aardbei', soldout_mochi_aardbei_val),
+        ('soldout_mochi_matcha', soldout_mochi_matcha_val),
+        ('soldout_mochi_pistachio', soldout_mochi_pistachio_val),
     ]:
         s = Setting.query.filter_by(key=key).first()
         if not s:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -292,6 +292,28 @@
             <option value="false" {% if soldout_zeewiersalade != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_zeewiersalade == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+
+        <h3>Dessert uitverkocht</h3>
+        <label>Mochi Mango:</label>
+        <select id="soldout_mochi_mango_select">
+            <option value="false" {% if soldout_mochi_mango != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_mochi_mango == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Mochi Aardbei:</label>
+        <select id="soldout_mochi_aardbei_select">
+            <option value="false" {% if soldout_mochi_aardbei != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_mochi_aardbei == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Mochi Matcha:</label>
+        <select id="soldout_mochi_matcha_select">
+            <option value="false" {% if soldout_mochi_matcha != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_mochi_matcha == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Mochi Pistachio:</label>
+        <select id="soldout_mochi_pistachio_select">
+            <option value="false" {% if soldout_mochi_pistachio != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_mochi_pistachio == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <br><br>
 
         <h3>Pokebowl uitverkocht</h3>
@@ -658,8 +680,12 @@
             const soldout_mini_loempia = document.getElementById('soldout_mini_loempia_select').value;
             const soldout_edamame = document.getElementById('soldout_edamame_select').value;
             const soldout_kimchi_komkommer = document.getElementById('soldout_kimchi_komkommer_select').value;
-            const soldout_kimchi_kool = document.getElementById('soldout_kimchi_kool_select').value;
-            const soldout_zeewiersalade = document.getElementById('soldout_zeewiersalade_select').value;
+              const soldout_kimchi_kool = document.getElementById('soldout_kimchi_kool_select').value;
+              const soldout_zeewiersalade = document.getElementById('soldout_zeewiersalade_select').value;
+              const soldout_mochi_mango = document.getElementById('soldout_mochi_mango_select').value;
+              const soldout_mochi_aardbei = document.getElementById('soldout_mochi_aardbei_select').value;
+              const soldout_mochi_matcha = document.getElementById('soldout_mochi_matcha_select').value;
+              const soldout_mochi_pistachio = document.getElementById('soldout_mochi_pistachio_select').value;
 
             fetch('/dashboard/update', {
                 method: 'POST',
@@ -734,9 +760,13 @@
                     soldout_mini_loempia: soldout_mini_loempia,
                     soldout_edamame: soldout_edamame,
                     soldout_kimchi_komkommer: soldout_kimchi_komkommer,
-                    soldout_kimchi_kool: soldout_kimchi_kool,
-                    soldout_zeewiersalade: soldout_zeewiersalade
-                })
+                      soldout_kimchi_kool: soldout_kimchi_kool,
+                      soldout_zeewiersalade: soldout_zeewiersalade,
+                      soldout_mochi_mango: soldout_mochi_mango,
+                      soldout_mochi_aardbei: soldout_mochi_aardbei,
+                      soldout_mochi_matcha: soldout_mochi_matcha,
+                      soldout_mochi_pistachio: soldout_mochi_pistachio
+                  })
             })
             .then(response => response.json())
             .then(data => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2881,9 +2881,10 @@ input:focus, select:focus, textarea:focus {
 <img alt="Mochi Mango" loading="lazy" src="{{ url_for('static', filename='images/mochi-mango.png') }}">
 </img></div>
 <div class="menu-content">
-<h3>Mochi – Mango</h3>
-<p>€ 4.00</p>
-<div class="qty-box">
+  <h3>Mochi – Mango</h3>
+  <p>€ 4.00</p>
+  <p id="soldoutMochiMango" class="sold-out-msg hidden">Uitverkocht!</p>
+  <div class="qty-box">
 <label for="mochiMangoCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="mochiMangoCount" type="button">-</button>
 <select id="mochiMangoCount" name="mochiMangoCount"></select>
@@ -2897,9 +2898,10 @@ input:focus, select:focus, textarea:focus {
 <img alt="Mochi Aardbei" loading="lazy" src="{{ url_for('static', filename='images/mochi-aardbei.png') }}">
 </img></div>
 <div class="menu-content">
-<h3>Mochi – Aardbei</h3>
-<p>€ 4.00</p>
-<div class="qty-box">
+  <h3>Mochi – Aardbei</h3>
+  <p>€ 4.00</p>
+  <p id="soldoutMochiAardbei" class="sold-out-msg hidden">Uitverkocht!</p>
+  <div class="qty-box">
 <label for="mochiAardbeiCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="mochiAardbeiCount" type="button">-</button>
 <select id="mochiAardbeiCount" name="mochiAardbeiCount"></select>
@@ -2913,9 +2915,10 @@ input:focus, select:focus, textarea:focus {
 <img alt="Mochi Matcha" loading="lazy" src="{{ url_for('static', filename='images/mochi-matcha.png') }}">
 </img></div>
 <div class="menu-content">
-<h3>Mochi – Matcha</h3>
-<p>€ 4.00</p>
-<div class="qty-box">
+  <h3>Mochi – Matcha</h3>
+  <p>€ 4.00</p>
+  <p id="soldoutMochiMatcha" class="sold-out-msg hidden">Uitverkocht!</p>
+  <div class="qty-box">
 <label for="mochiMatchaCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="mochiMatchaCount" type="button">-</button>
 <select id="mochiMatchaCount" name="mochiMatchaCount"></select>
@@ -2929,9 +2932,10 @@ input:focus, select:focus, textarea:focus {
 <img alt="Mochi Pistachio" loading="lazy" src="{{ url_for('static', filename='images/mochi-pistachio.png') }}">
 </img></div>
 <div class="menu-content">
-<h3>Mochi – Pistachio</h3>
-<p>€ 4.00</p>
-<div class="qty-box">
+  <h3>Mochi – Pistachio</h3>
+  <p>€ 4.00</p>
+  <p id="soldoutMochiPistachio" class="sold-out-msg hidden">Uitverkocht!</p>
+  <div class="qty-box">
 <label for="mochiPistachioCount">Aantal</label>
 <button class="qty-minus remove-button" data-target="mochiPistachioCount" type="button">-</button>
 <select id="mochiPistachioCount" name="mochiPistachioCount"></select>
@@ -5057,6 +5061,25 @@ function updateStatus(settings) {
   ];
 
   snackConfig.forEach(cfg => {
+    const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
+    if (!itemEl) return;
+    const soldout = settings[cfg.key] === 'true';
+    const msgEl = document.getElementById(cfg.msg);
+    if (msgEl) msgEl.classList.toggle('hidden', !soldout);
+    itemEl.querySelectorAll('select, button').forEach(el => { el.disabled = soldout; });
+    if (soldout && document.getElementById(cfg.qty)) {
+      document.getElementById(cfg.qty).value = 0;
+    }
+  });
+
+  const dessertConfig = [
+    {name: 'Mochi Mango', key: 'soldout_mochi_mango', qty: 'mochiMangoCount', msg: 'soldoutMochiMango'},
+    {name: 'Mochi Aardbei', key: 'soldout_mochi_aardbei', qty: 'mochiAardbeiCount', msg: 'soldoutMochiAardbei'},
+    {name: 'Mochi Matcha', key: 'soldout_mochi_matcha', qty: 'mochiMatchaCount', msg: 'soldoutMochiMatcha'},
+    {name: 'Mochi Pistachio', key: 'soldout_mochi_pistachio', qty: 'mochiPistachioCount', msg: 'soldoutMochiPistachio'}
+  ];
+
+  dessertConfig.forEach(cfg => {
     const itemEl = document.querySelector(`[data-name="${cfg.name}"]`);
     if (!itemEl) return;
     const soldout = settings[cfg.key] === 'true';


### PR DESCRIPTION
## Summary
- allow marking dessert items as sold out
- show sold out state on index
- send new settings via dashboard

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_686cc5714d848333b74a8e1e46d4f93e