### PR TITLE
Add Crispy Rice Sandwich price editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -497,6 +497,12 @@ with app.app_context():
         "time_interval": "15",
         "milktea_soldout": "false",
         "milktea_price": "5",
+        "price_zalm_crispy_rice_sandwich": "7",
+        "price_spicytuna_crispy_rice_sandwich": "7",
+        "price_ebi_crispy_rice_sandwich": "7",
+        "price_beef_crispy_rice_sandwich": "7.5",
+        "price_california_crispy_rice_sandwich": "7.5",
+        "price_chicken_crispy_rice_sandwich": "7",
         "soldout_chicken_bento": "false",
         "soldout_meatlover_bento": "false",
         "soldout_zalm_lover_bento": "false",
@@ -989,6 +995,12 @@ def dashboard():
         time_interval=get_value('time_interval', '15'),
         milktea_soldout=get_value('milktea_soldout', 'false'),
         milktea_price=get_value('milktea_price', '5'),
+        price_zalm_crispy_rice_sandwich=get_value('price_zalm_crispy_rice_sandwich', '7'),
+        price_spicytuna_crispy_rice_sandwich=get_value('price_spicytuna_crispy_rice_sandwich', '7'),
+        price_ebi_crispy_rice_sandwich=get_value('price_ebi_crispy_rice_sandwich', '7'),
+        price_beef_crispy_rice_sandwich=get_value('price_beef_crispy_rice_sandwich', '7.5'),
+        price_california_crispy_rice_sandwich=get_value('price_california_crispy_rice_sandwich', '7.5'),
+        price_chicken_crispy_rice_sandwich=get_value('price_chicken_crispy_rice_sandwich', '7'),
         soldout_chicken_bento=get_value('soldout_chicken_bento', 'false'),
         soldout_meatlover_bento=get_value('soldout_meatlover_bento', 'false'),
         soldout_zalm_lover_bento=get_value('soldout_zalm_lover_bento', 'false'),
@@ -1332,6 +1344,38 @@ def update_milktea_price():
         setting.value = str(price_val)
     db.session.commit()
     socketio.emit('milktea_price_update', {'price': price_val})
+    return jsonify({'success': True})
+
+
+@app.route('/update_crispy_prices', methods=['POST'])
+@login_required
+def update_crispy_prices():
+    data = request.get_json() or {}
+    mapping = {
+        'zalm': 'price_zalm_crispy_rice_sandwich',
+        'spicytuna': 'price_spicytuna_crispy_rice_sandwich',
+        'ebi': 'price_ebi_crispy_rice_sandwich',
+        'beef': 'price_beef_crispy_rice_sandwich',
+        'california': 'price_california_crispy_rice_sandwich',
+        'chicken': 'price_chicken_crispy_rice_sandwich',
+    }
+    updated = {}
+    for k, setting_key in mapping.items():
+        if k in data:
+            try:
+                price_val = float(data[k])
+            except (TypeError, ValueError):
+                continue
+            setting = Setting.query.filter_by(key=setting_key).first()
+            if not setting:
+                setting = Setting(key=setting_key, value=str(price_val))
+                db.session.add(setting)
+            else:
+                setting.value = str(price_val)
+            updated[setting_key] = price_val
+    db.session.commit()
+    if updated:
+        socketio.emit('crispy_price_update', updated)
     return jsonify({'success': True})
 
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -226,6 +226,21 @@
             <option value="true" {% if soldout_chicken_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
 
+        <h3>Crispy Rice Sandwich prijs (€)</h3>
+        <label>Zalm:</label>
+        <input type="number" step="0.01" id="price_zalm_crispy_rice_sandwich_input" value="{{ price_zalm_crispy_rice_sandwich }}"><br>
+        <label>Spicytuna:</label>
+        <input type="number" step="0.01" id="price_spicytuna_crispy_rice_sandwich_input" value="{{ price_spicytuna_crispy_rice_sandwich }}"><br>
+        <label>Ebi:</label>
+        <input type="number" step="0.01" id="price_ebi_crispy_rice_sandwich_input" value="{{ price_ebi_crispy_rice_sandwich }}"><br>
+        <label>Beef:</label>
+        <input type="number" step="0.01" id="price_beef_crispy_rice_sandwich_input" value="{{ price_beef_crispy_rice_sandwich }}"><br>
+        <label>California:</label>
+        <input type="number" step="0.01" id="price_california_crispy_rice_sandwich_input" value="{{ price_california_crispy_rice_sandwich }}"><br>
+        <label>Chicken:</label>
+        <input type="number" step="0.01" id="price_chicken_crispy_rice_sandwich_input" value="{{ price_chicken_crispy_rice_sandwich }}"><br>
+        <button type="button" id="update_crispy_prices_btn">更新价格</button>
+        
         <h3>Snack uitverkocht</h3>
         <label>Karaage:</label>
         <select id="soldout_karaage_select">
@@ -788,6 +803,24 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({price: price})
+            }).then(r => r.json()).then(d => {
+                alert(d.success ? 'Prijs bijgewerkt!' : 'Fout bij bijwerken');
+            }).catch(() => alert('Request failed'));
+        });
+
+        document.getElementById('update_crispy_prices_btn').addEventListener('click', function(){
+            const data = {
+                zalm: parseFloat(document.getElementById('price_zalm_crispy_rice_sandwich_input').value || '0'),
+                spicytuna: parseFloat(document.getElementById('price_spicytuna_crispy_rice_sandwich_input').value || '0'),
+                ebi: parseFloat(document.getElementById('price_ebi_crispy_rice_sandwich_input').value || '0'),
+                beef: parseFloat(document.getElementById('price_beef_crispy_rice_sandwich_input').value || '0'),
+                california: parseFloat(document.getElementById('price_california_crispy_rice_sandwich_input').value || '0'),
+                chicken: parseFloat(document.getElementById('price_chicken_crispy_rice_sandwich_input').value || '0')
+            };
+            fetch('/update_crispy_prices', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
             }).then(r => r.json()).then(d => {
                 alert(d.success ? 'Prijs bijgewerkt!' : 'Fout bij bijwerken');
             }).catch(() => alert('Request failed'));

--- a/templates/index.html
+++ b/templates/index.html
@@ -3141,6 +3141,26 @@ function updateXbentoDisplay(){
   }
 }
 
+function applyCrispyPrices(prices){
+  const map={
+    'Zalm crispy rice sandwich': parseFloat(prices.price_zalm_crispy_rice_sandwich),
+    'Spicytuna crispy rice sandwich': parseFloat(prices.price_spicytuna_crispy_rice_sandwich),
+    'Ebi crispy rice sandwich': parseFloat(prices.price_ebi_crispy_rice_sandwich),
+    'Beef crispy rice sandwich': parseFloat(prices.price_beef_crispy_rice_sandwich),
+    'California crispy rice sandwich': parseFloat(prices.price_california_crispy_rice_sandwich),
+    'Chicken crispy rice sandwich': parseFloat(prices.price_chicken_crispy_rice_sandwich)
+  };
+  Object.entries(map).forEach(([name,price])=>{
+    if(isNaN(price)) return;
+    const el=document.querySelector(`.menu-item[data-name="${name}"]`);
+    if(el){
+      el.dataset.price=price;
+      const pe=el.querySelector('p');
+      if(pe) pe.textContent=`€ ${price.toFixed(2)}`;
+    }
+  });
+}
+
 function saveCart() {
   sessionStorage.setItem('novaCart', JSON.stringify(cart));
 }
@@ -4979,6 +4999,7 @@ function parseTime(timeStr, startStr){
 
 function updateStatus(settings) {
   currentSettings = settings;
+  applyCrispyPrices(settings);
   const banner = document.getElementById('status-banner');
   const hoursEl = document.getElementById('hours-info');
   const checkoutBtn = document.querySelector('.checkout-btn');
@@ -5351,6 +5372,9 @@ socket.on('xbento_options_update', data => {
   populateXbentoSelectors();
   updateXbentoDisplay();
   updateXbentoCartPrices();
+});
+socket.on('crispy_price_update', data => {
+  applyCrispyPrices(data);
 });
 const overlay = document.getElementById('closed-overlay');
 if(overlay){

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -755,6 +755,26 @@ function updateXbentoDisplay(){
   }
 }
 
+function applyCrispyPrices(prices){
+  const map={
+    'Zalm crispy rice sandwich': parseFloat(prices.price_zalm_crispy_rice_sandwich),
+    'Spicytuna crispy rice sandwich': parseFloat(prices.price_spicytuna_crispy_rice_sandwich),
+    'Ebi crispy rice sandwich': parseFloat(prices.price_ebi_crispy_rice_sandwich),
+    'Beef crispy rice sandwich': parseFloat(prices.price_beef_crispy_rice_sandwich),
+    'California crispy rice sandwich': parseFloat(prices.price_california_crispy_rice_sandwich),
+    'Chicken crispy rice sandwich': parseFloat(prices.price_chicken_crispy_rice_sandwich)
+  };
+  Object.entries(map).forEach(([name,price])=>{
+    if(isNaN(price)) return;
+    const el=document.querySelector(`.menu-item[data-name="${name}"]`);
+    if(el){
+      el.dataset.price=price;
+      const pe=el.querySelector('p');
+      if(pe) pe.textContent=`€${price.toFixed(2)}`;
+    }
+  });
+}
+
 function changeBubbleQty(delta){
   const sel=document.getElementById('bubbleTeaQty');
   let val=parseInt(sel.value||0);
@@ -1515,7 +1535,10 @@ function formatCurrency(value){
     if(r.ok){ const d=await r.json(); applyMenuPrices(d); }
   }
   loadMenu();
-  fetch('/api/settings').then(r=>r.json()).then(s=>{ if(s.milktea_price){ milkTeaPrice=parseFloat(s.milktea_price); updateMilkTeaDisplay(); }});
+  fetch('/api/settings').then(r=>r.json()).then(s=>{
+    if(s.milktea_price){ milkTeaPrice=parseFloat(s.milktea_price); updateMilkTeaDisplay(); }
+    applyCrispyPrices(s);
+  });
   fetchBubbleOptions();
   fetchXbentoOptions();
   socket.on('menu_update', applyMenuPrices);
@@ -1534,6 +1557,9 @@ function formatCurrency(value){
     populateXbentoSelectors();
     updateXbentoDisplay();
     updateXbentoCartPrices();
+  });
+  socket.on('crispy_price_update', data => {
+    applyCrispyPrices(data);
   });
 
   let pollTimer;


### PR DESCRIPTION
## Summary
- allow editing crispy rice sandwich prices in dashboard
- store prices in settings and broadcast via websocket
- update index and POS pages when prices change

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cc8a7cea88333b906515216b9261e