### PR TITLE
Sync new menu items with dashboard and POS

### DIFF
--- a/app.py
+++ b/app.py
@@ -522,6 +522,7 @@ with app.app_context():
         "soldout_flamed_tonijn_sashimi": "false",
         "soldout_beef_sashimi": "false",
         "soldout_zalm_crispy_rice_sandwich": "false",
+        "soldout_spicytuna_crispy_rice_sandwich": "false",
         "soldout_ebi_crispy_rice_sandwich": "false",
         "soldout_beef_crispy_rice_sandwich": "false",
         "soldout_california_crispy_rice_sandwich": "false",
@@ -553,7 +554,7 @@ with app.app_context():
         "soldout_chicken_loempia": "false",
         "soldout_gyoza": "false",
         "soldout_inktvis_ringen": "false",
-        "soldout_crispy_rijst": "false",
+        "soldout_sesambal": "false",
         "soldout_yakitori": "false",
         "soldout_mini_loempia": "false",
         "soldout_edamame": "false",
@@ -1020,6 +1021,7 @@ def dashboard():
         soldout_flamed_tonijn_sashimi=get_value('soldout_flamed_tonijn_sashimi', 'false'),
         soldout_beef_sashimi=get_value('soldout_beef_sashimi', 'false'),
         soldout_zalm_crispy_rice_sandwich=get_value('soldout_zalm_crispy_rice_sandwich', 'false'),
+        soldout_spicytuna_crispy_rice_sandwich=get_value('soldout_spicytuna_crispy_rice_sandwich', 'false'),
         soldout_ebi_crispy_rice_sandwich=get_value('soldout_ebi_crispy_rice_sandwich', 'false'),
         soldout_beef_crispy_rice_sandwich=get_value('soldout_beef_crispy_rice_sandwich', 'false'),
         soldout_california_crispy_rice_sandwich=get_value('soldout_california_crispy_rice_sandwich', 'false'),
@@ -1051,7 +1053,7 @@ def dashboard():
         soldout_chicken_loempia=get_value('soldout_chicken_loempia', 'false'),
         soldout_gyoza=get_value('soldout_gyoza', 'false'),
         soldout_inktvis_ringen=get_value('soldout_inktvis_ringen', 'false'),
-        soldout_crispy_rijst=get_value('soldout_crispy_rijst', 'false'),
+        soldout_sesambal=get_value('soldout_sesambal', 'false'),
         soldout_yakitori=get_value('soldout_yakitori', 'false'),
         soldout_mini_loempia=get_value('soldout_mini_loempia', 'false'),
         soldout_edamame=get_value('soldout_edamame', 'false'),
@@ -1110,6 +1112,7 @@ def update_setting():
     soldout_flamed_tonijn_sashimi_val = data.get('soldout_flamed_tonijn_sashimi', 'false')
     soldout_beef_sashimi_val = data.get('soldout_beef_sashimi', 'false')
     soldout_zalm_crispy_rice_sandwich_val = data.get('soldout_zalm_crispy_rice_sandwich', 'false')
+    soldout_spicytuna_crispy_rice_sandwich_val = data.get('soldout_spicytuna_crispy_rice_sandwich', 'false')
     soldout_ebi_crispy_rice_sandwich_val = data.get('soldout_ebi_crispy_rice_sandwich', 'false')
     soldout_beef_crispy_rice_sandwich_val = data.get('soldout_beef_crispy_rice_sandwich', 'false')
     soldout_california_crispy_rice_sandwich_val = data.get('soldout_california_crispy_rice_sandwich', 'false')
@@ -1141,7 +1144,7 @@ def update_setting():
     soldout_chicken_loempia_val = data.get('soldout_chicken_loempia', 'false')
     soldout_gyoza_val = data.get('soldout_gyoza', 'false')
     soldout_inktvis_ringen_val = data.get('soldout_inktvis_ringen', 'false')
-    soldout_crispy_rijst_val = data.get('soldout_crispy_rijst', 'false')
+    soldout_sesambal_val = data.get('soldout_sesambal', 'false')
     soldout_yakitori_val = data.get('soldout_yakitori', 'false')
     soldout_mini_loempia_val = data.get('soldout_mini_loempia', 'false')
     soldout_edamame_val = data.get('soldout_edamame', 'false')
@@ -1187,6 +1190,7 @@ def update_setting():
         ('soldout_flamed_tonijn_sashimi', soldout_flamed_tonijn_sashimi_val),
         ('soldout_beef_sashimi', soldout_beef_sashimi_val),
         ('soldout_zalm_crispy_rice_sandwich', soldout_zalm_crispy_rice_sandwich_val),
+        ('soldout_spicytuna_crispy_rice_sandwich', soldout_spicytuna_crispy_rice_sandwich_val),
         ('soldout_ebi_crispy_rice_sandwich', soldout_ebi_crispy_rice_sandwich_val),
         ('soldout_beef_crispy_rice_sandwich', soldout_beef_crispy_rice_sandwich_val),
         ('soldout_california_crispy_rice_sandwich', soldout_california_crispy_rice_sandwich_val),
@@ -1218,7 +1222,7 @@ def update_setting():
         ('soldout_chicken_loempia', soldout_chicken_loempia_val),
         ('soldout_gyoza', soldout_gyoza_val),
         ('soldout_inktvis_ringen', soldout_inktvis_ringen_val),
-        ('soldout_crispy_rijst', soldout_crispy_rijst_val),
+        ('soldout_sesambal', soldout_sesambal_val),
         ('soldout_yakitori', soldout_yakitori_val),
         ('soldout_mini_loempia', soldout_mini_loempia_val),
         ('soldout_edamame', soldout_edamame_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -205,6 +205,11 @@
             <option value="false" {% if soldout_zalm_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_zalm_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+        <label>Spicytuna crispy rice sandwich:</label>
+        <select id="soldout_spicytuna_crispy_rice_sandwich_select">
+            <option value="false" {% if soldout_spicytuna_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_spicytuna_crispy_rice_sandwich == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <label>Ebi crispy rice sandwich:</label>
         <select id="soldout_ebi_crispy_rice_sandwich_select">
             <option value="false" {% if soldout_ebi_crispy_rice_sandwich != 'true' %}selected{% endif %}>Open</option>
@@ -272,10 +277,10 @@
             <option value="false" {% if soldout_inktvis_ringen != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_inktvis_ringen == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
-        <label>Crispy Rijst – 4 st:</label>
-        <select id="soldout_crispy_rijst_select">
-            <option value="false" {% if soldout_crispy_rijst != 'true' %}selected{% endif %}>Open</option>
-            <option value="true" {% if soldout_crispy_rijst == 'true' %}selected{% endif %}>Uitverkocht</option>
+        <label>Sesambal – 5 st:</label>
+        <select id="soldout_sesambal_select">
+            <option value="false" {% if soldout_sesambal != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_sesambal == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
         <label>Yakitori – 4 st:</label>
         <select id="soldout_yakitori_select">
@@ -659,6 +664,7 @@
             const soldout_flamed_tonijn_sashimi = document.getElementById('soldout_flamed_tonijn_sashimi_select').value;
             const soldout_beef_sashimi = document.getElementById('soldout_beef_sashimi_select').value;
             const soldout_zalm_crispy_rice_sandwich = document.getElementById('soldout_zalm_crispy_rice_sandwich_select').value;
+            const soldout_spicytuna_crispy_rice_sandwich = document.getElementById('soldout_spicytuna_crispy_rice_sandwich_select').value;
             const soldout_ebi_crispy_rice_sandwich = document.getElementById('soldout_ebi_crispy_rice_sandwich_select').value;
             const soldout_beef_crispy_rice_sandwich = document.getElementById('soldout_beef_crispy_rice_sandwich_select').value;
             const soldout_california_crispy_rice_sandwich = document.getElementById('soldout_california_crispy_rice_sandwich_select').value;
@@ -690,7 +696,7 @@
             const soldout_chicken_loempia = document.getElementById('soldout_chicken_loempia_select').value;
             const soldout_gyoza = document.getElementById('soldout_gyoza_select').value;
             const soldout_inktvis_ringen = document.getElementById('soldout_inktvis_ringen_select').value;
-            const soldout_crispy_rijst = document.getElementById('soldout_crispy_rijst_select').value;
+            const soldout_sesambal = document.getElementById('soldout_sesambal_select').value;
             const soldout_yakitori = document.getElementById('soldout_yakitori_select').value;
             const soldout_mini_loempia = document.getElementById('soldout_mini_loempia_select').value;
             const soldout_edamame = document.getElementById('soldout_edamame_select').value;
@@ -739,6 +745,7 @@
                       soldout_flamed_tonijn_sashimi: soldout_flamed_tonijn_sashimi,
                       soldout_beef_sashimi: soldout_beef_sashimi,
                       soldout_zalm_crispy_rice_sandwich: soldout_zalm_crispy_rice_sandwich,
+                      soldout_spicytuna_crispy_rice_sandwich: soldout_spicytuna_crispy_rice_sandwich,
                       soldout_ebi_crispy_rice_sandwich: soldout_ebi_crispy_rice_sandwich,
                       soldout_beef_crispy_rice_sandwich: soldout_beef_crispy_rice_sandwich,
                       soldout_california_crispy_rice_sandwich: soldout_california_crispy_rice_sandwich,
@@ -770,7 +777,7 @@
                     soldout_chicken_loempia: soldout_chicken_loempia,
                     soldout_gyoza: soldout_gyoza,
                     soldout_inktvis_ringen: soldout_inktvis_ringen,
-                    soldout_crispy_rijst: soldout_crispy_rijst,
+                    soldout_sesambal: soldout_sesambal,
                     soldout_yakitori: soldout_yakitori,
                     soldout_mini_loempia: soldout_mini_loempia,
                     soldout_edamame: soldout_edamame,

--- a/templates/index.html
+++ b/templates/index.html
@@ -3136,7 +3136,7 @@ const soldoutMap = {
   "Chicken Loempia": "soldout_chicken_loempia",
   "Gyoza": "soldout_gyoza",
   "Inktvis Ringen": "soldout_inktvis_ringen",
-  "Crispy Rijst": "soldout_crispy_rijst",
+  "Sesambal – 5 st": "soldout_sesambal",
   "Yakitori": "soldout_yakitori",
   "Mini Loempia": "soldout_mini_loempia",
   "Edamame": "soldout_edamame",

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -851,6 +851,22 @@
 </div>
 </div>
 </div>
+<!-- Spicytuna -->
+<div class="menu-row menu-item" data-name="Spicytuna crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Spicytuna crispy rice sandwich" src="{{ url_for('static', filename='images/zalm.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Spicytuna crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="spicytuna-crispy-rice-sandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="spicytuna-crispy-rice-sandwich" type="button">-</button>
+<select id="spicytuna-crispy-rice-sandwich" name="Spicytuna crispy rice sandwich"></select>
+<button class="qty-plus add-button" data-target="spicytuna-crispy-rice-sandwich" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Ebi -->
 <!-- Ebi Crispy Rice Sandwich -->
 <div class="menu-row menu-item" data-name="Ebi crispy rice sandwich" data-packaging="0.2" data-price="7">
@@ -1016,19 +1032,19 @@
     </div>
   </div>
 </div>
-<!-- Crispy Rijst -->
-<div class="menu-row menu-item" data-name="Crispy Rijst – 4 st" data-packaging="0.2" data-price="4">
+<!-- Sesambal -->
+<div class="menu-row menu-item" data-name="Sesambal – 5 st" data-packaging="0.2" data-price="5">
   <div class="menu-img">
-    <img alt="Crispy Rijst" loading="lazy" src="{{ url_for('static', filename='images/beef-crispy.png') }}">
+    <img alt="Sasambal" loading="lazy" src="{{ url_for('static', filename='images/SEM.webp') }}">
     </img></div>
   <div class="menu-content">
-    <h3>Crispy Rijst – 4 st</h3>
+    <h3>Sesambal – 5 st</h3>
     <p>€ 4.00</p>
     <div class="qty-box">
-      <label for="crispyRijstCount">Aantal</label>
-      <button class="qty-minus remove-button" data-target="crispyRijstCount" type="button">-</button>
-      <select id="crispyRijstCount" name="crispyRijstCount"></select>
-      <button class="qty-plus add-button" data-target="crispyRijstCount" type="button">+</button>
+      <label for="sesambalCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="sesambalCount" type="button">-</button>
+      <select id="sesambalCount" name="sesambalCount"></select>
+      <button class="qty-plus add-button" data-target="sesambalCount" type="button">+</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add Spicytuna crispy rice sandwich to the shared menu
- rename Crispy Rijst to Sesambal in the menu and mapping
- update dashboard controls to handle new items
- add new sold-out settings to backend

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686d27690da0833397c6e95df9fa77b7