### PR TITLE
Fix mobile X-Bowl layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -478,9 +478,22 @@
   .menu-item[data-name="X-Bowl"] .menu-content { position: static; }
   .menu-item[data-name="X-Bowl"] img { position: static; width: 100%; height: auto; }
   .menu-item[data-name="X-Bowl"] .qty-box { position: static; transform: none; width: 100%; margin-top: 8px; }
-  #xBowlMains, #xBowlToppings { display: flex; overflow-x: auto; gap: 6px; }
-  #xBowlMains>div, #xBowlToppings>div { display: flex; align-items: center; }
-  #xBowlMains button, #xBowlToppings button { width: 1.4rem; height: 1.4rem; font-size: 0.9rem; }
+  #xBowlMains, #xBowlToppings {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  #xBowlMains>div, #xBowlToppings>div {
+    display: flex;
+    align-items: center;
+    flex: 0 0 calc(50% - 3px);
+  }
+  #xBowlMains select, #xBowlToppings select { width: 100%; }
+  #xBowlMains button, #xBowlToppings button {
+    width: 1.4rem;
+    height: 1.4rem;
+    font-size: 0.9rem;
+  }
 }
 
 

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -180,9 +180,22 @@
   .menu-item[data-name="X-Bowl"] .menu-content { position: static; }
   .menu-item[data-name="X-Bowl"] img { position: static; width: 100%; height: auto; }
   .menu-item[data-name="X-Bowl"] .qty-box { position: static; transform: none; width: 100%; margin-top: 8px; }
-  #xBowlMains, #xBowlToppings { display: flex; overflow-x: auto; gap: 6px; }
-  #xBowlMains>div, #xBowlToppings>div { display: flex; align-items: center; }
-  #xBowlMains button, #xBowlToppings button { width: 1.4rem; height: 1.4rem; font-size: 0.9rem; }
+  #xBowlMains, #xBowlToppings {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  #xBowlMains>div, #xBowlToppings>div {
+    display: flex;
+    align-items: center;
+    flex: 0 0 calc(50% - 3px);
+  }
+  #xBowlMains select, #xBowlToppings select { width: 100%; }
+  #xBowlMains button, #xBowlToppings button {
+    width: 1.4rem;
+    height: 1.4rem;
+    font-size: 0.9rem;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- wrap X-Bowl selectors on mobile
- keep selector width full on index and POS pages

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_686dfe6aa5148333ac37426a8a8b5727