### PR TITLE
Fix X‑Bowl add logic

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3554,7 +3554,9 @@ function changeXbowlQty(delta) {
   setQty(name, price, val, DEFAULT_PACKAGING_FEE);
   currentXBowlName = name;
   updateXBowlControls();
-  if (delta > 0 && val > 0) showXBowlModal();
+  // Match Xbento behaviour: do not open a modal after adding to cart.
+  // A small prompt appears in the product area instead of a popup.
+  // if (delta > 0 && val > 0) showXBowlModal();
 }
 
 function createXBowlMainSelect() {


### PR DESCRIPTION
## Summary
- stop opening modal after clicking X‑Bowl `+`

## Testing
- `python -m py_compile app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_686e140b2c088333814ab5b663bd5a40