### PR TITLE
Enable X-Bowl modal for customer view

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3554,9 +3554,8 @@ function changeXbowlQty(delta) {
   setQty(name, price, val, DEFAULT_PACKAGING_FEE);
   currentXBowlName = name;
   updateXBowlControls();
-  // Match Xbento behaviour: do not open a modal after adding to cart.
-  // A small prompt appears in the product area instead of a popup.
-  // if (delta > 0 && val > 0) showXBowlModal();
+  // Match POS behaviour: show modal after adding to cart
+  if (delta > 0 && val > 0) showXBowlModal();
 }
 
 function createXBowlMainSelect() {


### PR DESCRIPTION
## Summary
- show X-Bowl modal on the customer site when quantity increases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e18ce61f483338642a70e5f80b472