### PR TITLE
Sync customer X‑Bowl with POS version

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1487,6 +1487,38 @@ input:focus, select:focus, textarea:focus {
   }
 }
 
+  .xbowl-summary {
+    background: rgba(255,255,255,0.7);
+    backdrop-filter: blur(6px);
+    border-radius: 8px;
+    padding: 4px 8px;
+    margin: 2px 0;
+    font-size: 0.8rem;
+  }
+
+@media (max-width: 767px) {
+  .menu-item[data-name="X-Bowl"] { aspect-ratio: auto; height: auto; }
+  .menu-item[data-name="X-Bowl"] .menu-content { position: static; }
+  .menu-item[data-name="X-Bowl"] img { position: static; width: 100%; height: auto; }
+  .menu-item[data-name="X-Bowl"] .qty-box { position: static; transform: none; width: 100%; margin-top: 8px; }
+  #xBowlMains, #xBowlToppings {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  #xBowlMains>div, #xBowlToppings>div {
+    display: flex;
+    align-items: center;
+    flex: 0 0 calc(50% - 3px);
+  }
+  #xBowlMains select, #xBowlToppings select { width: 100%; }
+  #xBowlMains button, #xBowlToppings button {
+    width: 1.4rem;
+    height: 1.4rem;
+    font-size: 0.9rem;
+  }
+}
+
 
 
 
@@ -2419,11 +2451,12 @@ input:focus, select:focus, textarea:focus {
 
     <div class="menu-row menu-item" data-name="X-Bowl" data-price="0" data-packaging="0.2">
       <div class="menu-img">
-        <img src="{{ url_for('static', filename='images/Xbowl.png') }}" alt="X-Bowl">
+          <img src="{{ url_for('static', filename='images/Xbowl.png') }}" alt="X-Bowl">
       </div>
       <div class="menu-content">
-        <h3>X-Bowl</h3>
-        <p id="soldoutXBowl" class="sold-out-msg hidden">Uitverkocht!</p>
+        <h3>X-Bowl (Vrije samenstelling)</h3>
+        <p id="xBowlSummary" class="xbowl-summary"></p>
+        <p id="xBowlPrice" class="xbowl-summary">Prijs afhankelijk van keuzes</p>
         <div class="bubble-option">
           <select id="xBowlBase">
             <option value="">Basis</option>
@@ -3117,6 +3150,7 @@ const xbowlMains = [
 ];
 const xbowlToppings = ['Komkommer','Avocado','Sojabonen','Mais','Zeewiersalade','Masago','Inari','Tamago'];
 const XBOWL_TOPPING_PRICE = 1.5;
+let currentXBowlName = "";
 let currentPackaging = 0;
 let currentSubtotal = 0;
 let finalTotal = 0;
@@ -3514,6 +3548,17 @@ function updateXBowlDisplay() {
     item.dataset.price = price;
     const p = document.getElementById('xBowlPrice');
     if (p) p.textContent = price ? `€ ${price.toFixed(2)}` : 'Prijs afhankelijk van keuzes';
+    const info = document.getElementById('xBowlSummary');
+    if (info) {
+      const mainNames = mains.map(o => o.value).join(', ');
+      const topNames = toppings.join(', ');
+      const parts = [];
+      if (baseOpt && baseOpt.value) parts.push(baseOpt.value);
+      if (mainNames) parts.push(mainNames);
+      if (topNames) parts.push(topNames);
+      const text = parts.join(' | ');
+      info.textContent = text ? `${text} - € ${price.toFixed(2)}` : '';
+    }
   }
 }
 
@@ -3541,8 +3586,13 @@ function changeXbowlQty(delta) {
   qtySel.value = val;
   updateXBowlDisplay();
   const price = parseFloat(document.querySelector('.menu-item[data-name="X-Bowl"]').dataset.price || 0);
+  if (currentXBowlName && currentXBowlName !== name && cart[currentXBowlName]) {
+    delete cart[currentXBowlName];
+  }
   setQty(name, price, val, DEFAULT_PACKAGING_FEE);
+  currentXBowlName = name;
   updateXBowlControls();
+  if (delta > 0 && val > 0) showXBowlModal();
 }
 
 function createXBowlMainSelect() {
@@ -5620,6 +5670,26 @@ document.addEventListener('click', e => {
     e.preventDefault();
   }
 }, true);
+</script>
+
+<div id="xBowlAddedModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.4); align-items:center; justify-content:center; z-index:1000;">
+  <div style="background:white; padding:20px; border-radius:12px; text-align:center;">
+    <p>Toegevoegd! Nieuwe maken?</p>
+    <div style="display:flex; gap:10px; justify-content:center; margin-top:10px;">
+      <button id="xBowlAgain">Ja, graag</button>
+      <button id="xBowlClose">Nee, bedankt</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  const xbowlModal = document.getElementById('xBowlAddedModal');
+  const againBtn = document.getElementById('xBowlAgain');
+  const closeXBowlBtn = document.getElementById('xBowlClose');
+  function showXBowlModal(){ if(xbowlModal) xbowlModal.style.display = 'flex'; }
+  function hideXBowlModal(){ if(xbowlModal) xbowlModal.style.display = 'none'; }
+  if(againBtn){ againBtn.addEventListener('click', () => { clearXBowlSet(); hideXBowlModal(); }); }
+  if(closeXBowlBtn){ closeXBowlBtn.addEventListener('click', hideXBowlModal); }
 </script>
 
 <div id="reviewsModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); align-items:center; justify-content:center; z-index:1000;">


### PR DESCRIPTION
## Summary
- rebuild the X-Bowl section on the public menu to match the POS layout and behaviour
- style X-Bowl elements consistently with the POS page
- support XBowl modal workflow and summary logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e3dbb4b0883338ede05992b211b6c