### PR TITLE
Fix X-Bowl clearing removing cart item

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3688,6 +3688,7 @@ function clearXBowlSet(){
   ensureXBowlTopping();
   updateXBowlDisplay();
   updateXBowlControls();
+  currentXBowlName = '';
 }
 
 

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -936,6 +936,7 @@ function clearXBowlSet(){
   ensureXBowlTopping();
   updateXBowlDisplay();
   updateXBowlControls();
+  currentXBowlName="";
 }
 
 function applyCrispyPrices(prices){


### PR DESCRIPTION
## Summary
- keep previously added X-Bowls when starting a new set by resetting `currentXBowlName`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686e7741cbe08333b91109eb129c6cb0