### PR TITLE
Fix sold-out check for Dessert and Drinks items

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3307,7 +3307,13 @@ const soldoutMap = {
   "Edamame": "soldout_edamame",
   "Kimchi Komkommer": "soldout_kimchi_komkommer",
   "Kimchi Kool": "soldout_kimchi_kool",
-  "Zeewiersalade": "soldout_zeewiersalade"
+  "Zeewiersalade": "soldout_zeewiersalade",
+  "Mochi Mango": "soldout_mochi_mango",
+  "Mochi Aardbei": "soldout_mochi_aardbei",
+  "Mochi Matcha": "soldout_mochi_matcha",
+  "Mochi Pistachio": "soldout_mochi_pistachio",
+  "Cola": "soldout_cola",
+  "Cola Zero": "soldout_cola_zero"
 };
 
 function isItemSoldOut(name){


### PR DESCRIPTION
## Summary
- ensure sold-out dessert and drink items can't be added to cart by mapping them in `isItemSoldOut`

## Testing
- `python -m py_compile app.py wsgi.py add_watermark.py`

------
https://chatgpt.com/codex/tasks/task_e_686ff07ced188333a49ea2514681e707