### PR TITLE
Add sold-out warning popup

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4242,7 +4242,10 @@ function createSelect(current, onChange) {
 }
 
 function setQty(name, price, qty, packaging = DEFAULT_PACKAGING_FEE, prefs = null) {
-  if (isItemSoldOut(name)) return;
+  if (isItemSoldOut(name)) {
+    showFeedback('Uitverkocht!', true);
+    return;
+  }
   price = parseFloat(price);
   if (isNaN(price)) price = 0;
   qty = parseInt(qty, 10);


### PR DESCRIPTION
## Summary
- notify customers if they attempt to add a sold-out item

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6870a88575d48333a029938aed1ff828