### PR TITLE
Add mobile-only Info section after Drinks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3213,9 +3213,13 @@ input:focus, select:focus, textarea:focus {
       <select id="colaZeroCount" name="colaZeroCount"></select>
       <button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
     </div>
-  </div>
 </div>
 </div>
+</div>
+</section>
+<section id="info" class="mobile-only">
+  <h2>Info</h2>
+  <p>We zijn nog niet open en bevinden ons in de testfase. Nieuwe ontwikkelingen worden tijdig gecommuniceerd.</p>
 </section>
 <!-- iPhone 主屏幕提示 -->
 <section id="wapp" class="menu-tip-section">


### PR DESCRIPTION
## Summary
- add Info section for mobile users on index page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d6bbe0048333bcdb2ee1014b8208