### PR TITLE
Add menu snippet to Electron pos

### DIFF
--- a/electron-app/menu.html
+++ b/electron-app/menu.html
@@ -1,0 +1,1316 @@
+
+<section id="bubble">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Bubble Tea
+</h2>
+<div class="menu-row menu-item" data-name="Bubble Tea" data-packaging="0.2" data-price="5">
+<div class="menu-img">
+<img alt="Bubble Tea" src="{{ url_for('static', filename='images/bubble-tea-main.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Bubble Tea</h3>
+<p>€ 5.00</p>
+<div class="bubble-option">
+<select id="bubbleType">
+<option value="">Base</option>
+<option value="Green Tea">Green Tea</option>
+<option value="Milk Tea">Milk Tea</option>
+<option value="Milkshake">Milkshake</option>
+</select>
+</div>
+<div class="bubble-option">
+<select id="bubbleFlavor">
+<option value="">Smaak</option>
+<option value="Mango">Mango</option>
+<option value="Appel">Appel</option>
+<option value="Matcha">Matcha</option>
+<option value="Brown Sugar">Brown Sugar</option>
+</select>
+</div>
+<div class="bubble-option">
+  <select id="bubbleTopping">
+<option value="">Topping</option>
+<option value="Appel Popping">Appel Popping</option>
+<option value="Perzik Popping">Perzik Popping</option>
+  <option value="Tapioca">Tapioca</option>
+  </select>
+</div>
+        <div class="new-set-wrap hidden" id="bubbleNewWrap">
+          <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+          <button type="button" class="new-set-button" id="bubbleNew">druk op</button>
+        </div>
+<div class="qty-box">
+  <label for="bubbleTeaQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="bubbleTeaQty" type="button">-</button>
+<select id="bubbleTeaQty"></select>
+<button class="qty-plus add-button" data-target="bubbleTeaQty" type="button">+</button>
+</div>
+</div>
+<section id="bento">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Bento box
+</h2>
+<!-- Chicken Bento -->
+<div class="menu-row menu-item" data-name="Chicken Bento" data-packaging="0.2" data-price="22">
+<div class="menu-img">
+<img alt="Chicken Bento" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Chicken Bento</h3>
+<p>€ 22.00</p>
+<div class="qty-box">
+<label for="chickenBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="chickenBentoCount" type="button">-</button>
+<select id="chickenBentoCount" name="chickenBentoCount"></select>
+<button class="qty-plus add-button" data-target="chickenBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Meatlover Bento -->
+<!-- Meatlover Bento -->
+<div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Meatlover Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Meatlover Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="meatloverBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="meatloverBentoCount" type="button">-</button>
+<select id="meatloverBentoCount" name="meatloverBentoCount"></select>
+<button class="qty-plus add-button" data-target="meatloverBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Zalm Lover Bento -->
+<div class="menu-row menu-item" data-name="Zalm Lover Bento" data-packaging="0.2" data-price="23">
+<div class="menu-img">
+<img alt="Zalm Lover Bento" src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Zalm Lover Bento</h3>
+<p>€ 23.00</p>
+<div class="qty-box">
+<label for="zalmLoverBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="zalmLoverBentoCount" type="button">-</button>
+<select id="zalmLoverBentoCount" name="zalmLoverBentoCount"></select>
+<button class="qty-plus add-button" data-target="zalmLoverBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Ebi Lover Bento -->
+<div class="menu-row menu-item" data-name="Ebi Lover Bento" data-packaging="0.2" data-price="23">
+<div class="menu-img">
+<img alt="Ebi Lover Bento" src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ebi Lover Bento</h3>
+<p>€ 23.00</p>
+<div class="qty-box">
+<label for="ebiLoverBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="ebiLoverBentoCount" type="button">-</button>
+<select id="ebiLoverBentoCount" name="ebiLoverBentoCount"></select>
+<button class="qty-plus add-button" data-target="ebiLoverBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Surf & Turf Bento -->
+<div class="menu-row menu-item" data-name="Surf &amp; Turf Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Surf &amp; Turf Bento" src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Surf &amp; Turf Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="surfTurfBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="surfTurfBentoCount" type="button">-</button>
+<select id="surfTurfBentoCount" name="surfTurfBentoCount"></select>
+<button class="qty-plus add-button" data-target="surfTurfBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Dimsum Bento -->
+<div class="menu-row menu-item" data-name="Dimsum Bento" data-packaging="0.2" data-price="15">
+<div class="menu-img">
+<img alt="Dimsum Bento" src="{{ url_for('static', filename='images/dimsum-bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Dimsum Bento</h3>
+<p>€ 15.00</p>
+<div class="qty-box">
+<label for="dimsumBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="dimsumBentoCount" type="button">-</button>
+<select id="dimsumBentoCount" name="dimsumBentoCount"></select>
+<button class="qty-plus add-button" data-target="dimsumBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Lamskotelet Bento -->
+<div class="menu-row menu-item" data-name="Lamskotelet Bento" data-packaging="0.2" data-price="28">
+<div class="menu-img">
+<img alt="Lamskotelet Bento" src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Lamskotelet Bento</h3>
+<p>€ 28.00</p>
+<div class="qty-box">
+<label for="lamsBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="lamsBentoCount" type="button">-</button>
+<select id="lamsBentoCount" name="lamsBentoCount"></select>
+<button class="qty-plus add-button" data-target="lamsBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Veggie Bento -->
+<div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
+<div class="menu-img">
+<img alt="Veggie Bento" src="{{ url_for('static', filename='images/veggie-bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Veggie Bento</h3>
+<p>€ 20.00</p>
+<div class="qty-box">
+<label for="veggieBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="veggieBentoCount" type="button">-</button>
+<select id="veggieBentoCount" name="veggieBentoCount"></select>
+<button class="qty-plus add-button" data-target="veggieBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Bento Sushi Omakase" data-packaging="0.2" data-price="22">
+<div class="menu-img">
+<img alt="Bento Sushi Omakase" src="{{ url_for('static', filename='images/sushi-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Bento Sushi Omakase</h3>
+<p>€ 22.00</p>
+<p class="menu-description">±16st Verrassing van de chef!</p>
+<div class="qty-box">
+<label for="sushiBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="sushiBentoCount" type="button">-</button>
+<select id="sushiBentoCount" name="sushiBentoCount"></select>
+<button class="qty-plus add-button" data-target="sushiBentoCount" type="button">+</button>
+</div>
+<div id="omakasePrefs"></div>
+</div>
+</div>
+<!-- Xbento - Stel je eigen bento samen -->
+<!-- Xbento - Stel je eigen bento samen -->
+<div class="menu-row menu-item" data-name="Xbento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Xbento" src="{{ url_for('static', filename='images/xbento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Xbento (stel zelf samen)</h3>
+<p>Vanaf € 25.00</p>
+<div class="bubble-option">
+<select id="xBentoMain">
+<option value="">Hoofdgerecht</option>
+</select>
+</div>
+<div class="bubble-option">
+<select id="xBentoSide">
+<option value="">Bijgerecht</option>
+</select>
+</div>
+<div class="bubble-option">
+  <select id="xBentoRice">
+<option value="">Rijstsoort</option>
+  </select>
+</div>
+<div class="bubble-option">
+  <select id="xBentoVeg">
+    <option value="">Groente</option>
+  </select>
+</div>
+    <div class="new-set-wrap hidden" id="xBentoNewWrap">
+      <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+      <button type="button" class="new-set-button" id="xBentoNew">druk op</button>
+    </div>
+<div class="qty-box">
+  <label for="xBentoQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="xBentoQty" type="button">-</button>
+<select class="qty-select" id="xBentoQty" name="xBentoQty"></select>
+<button class="qty-plus add-button" data-target="xBentoQty" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="drinks">
+<div class="menu-group">
+<div class="menu-row menu-item" data-name="Cola" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaCount" type="button">-</button>
+<select id="colaCount" name="colaCount"></select>
+<button class="qty-plus add-button" data-target="colaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola Zero" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola Zero</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaZeroCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaZeroCount" type="button">-</button>
+<select id="colaZeroCount" name="colaZeroCount"></select>
+<button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="drinks">
+<div class="menu-group">
+<div class="menu-row menu-item" data-name="Cola" data-packaging="0.2" data-price="2.5">
+<div class="menu-img">
+<img alt="Cola" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola</h3>
+<p>€ 2.50</p>
+<div class="qty-box">
+<label for="colaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaCount" type="button">-</button>
+<select id="colaCount" name="colaCount"></select>
+<button class="qty-plus add-button" data-target="colaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.2" data-price="2.5">
+<div class="menu-img">
+<img alt="Cola Zero" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola Zero</h3>
+<p>€ 2.50</p>
+<div class="qty-box">
+<label for="colaZeroCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaZeroCount" type="button">-</button>
+<select id="colaZeroCount" name="colaZeroCount"></select>
+<button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Pokebowl Section -->
+<section id="Ramen">
+<h2>Ramen</h2>
+<div class="menu-section">
+  <!-- Ebi Furai Ramen -->
+  <div class="menu-row menu-item" data-code="ebi" data-name="Ebi Furai" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Ebi Furai Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Ebi Furai</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="ebiBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="ebiSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="ebiNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="ebiNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="ebiQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="ebiQty" type="button">-</button>
+        <select id="ebiQty"></select>
+        <button class="qty-plus add-button" data-target="ebiQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Chicken Ramen -->
+  <div class="menu-row menu-item" data-code="chicken" data-name="Chicken" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Chicken Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Chicken</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="chickenBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="chickenSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="chickenNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="chickenNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="chickenQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="chickenQty" type="button">-</button>
+        <select id="chickenQty"></select>
+        <button class="qty-plus add-button" data-target="chickenQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Beef Ramen -->
+  <div class="menu-row menu-item" data-code="beef" data-name="Beef" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Beef Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Beef</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="beefBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="beefSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="beefNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="beefNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="beefQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="beefQty" type="button">-</button>
+        <select id="beefQty"></select>
+        <button class="qty-plus add-button" data-target="beefQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Ribeye Ramen -->
+  <div class="menu-row menu-item" data-code="ribeye" data-name="Ribeye" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Ribeye Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Ribeye</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="ribeyeBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="ribeyeSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="ribeyeNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="ribeyeNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="ribeyeQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="ribeyeQty" type="button">-</button>
+        <select id="ribeyeQty"></select>
+        <button class="qty-plus add-button" data-target="ribeyeQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Chasiu Ramen -->
+  <div class="menu-row menu-item" data-code="chasiu" data-name="Chasiu" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Chasiu Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Chasiu</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="chasiuBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="chasiuSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="chasiuNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="chasiuNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="chasiuQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="chasiuQty" type="button">-</button>
+        <select id="chasiuQty"></select>
+        <button class="qty-plus add-button" data-target="chasiuQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+<section id="Pokebowl">
+  <h2>Pokebowl</h2>
+  <div class="menu-section">
+    <div class="menu-row menu-item" data-name="Zalm Bowl" data-price="15" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/zwp.png') }}" alt="Zalm Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Zalm Bowl</h3>
+        <p>€ 15.00</p>
+        <div class="qty-box">
+          <label for="zalmBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="zalmBowlQty" type="button">-</button>
+          <select id="zalmBowlQty" name="zalmBowlQty"></select>
+          <button class="qty-plus add-button" data-target="zalmBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+    <div class="menu-row menu-item" data-name="Tuna Bowl" data-price="15" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/tup.png') }}" alt="Tuna Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Tuna Bowl</h3>
+        <p>€ 15.00</p>
+        <div class="qty-box">
+          <label for="tunaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="tunaBowlQty" type="button">-</button>
+          <select id="tunaBowlQty" name="tunaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="tunaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Ebi Fry Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/虾boel.png') }}" alt="Ebi Fry Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Ebi Fry Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="ebiFryBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="ebiFryBowlQty" type="button">-</button>
+          <select id="ebiFryBowlQty" name="ebiFryBowlQty"></select>
+          <button class="qty-plus add-button" data-target="ebiFryBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Chicken Karaage Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/chicken-kar.jpg') }}" alt="Chicken Karaage Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Chicken Karaage Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="chickenKaraageBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="chickenKaraageBowlQty" type="button">-</button>
+          <select id="chickenKaraageBowlQty" name="chickenKaraageBowlQty"></select>
+          <button class="qty-plus add-button" data-target="chickenKaraageBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Spicy Chicken Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/chicken-kar.jpg') }}" alt="Spicy Chicken Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Spicy Chicken Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="spicyChickenBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="spicyChickenBowlQty" type="button">-</button>
+          <select id="spicyChickenBowlQty" name="spicyChickenBowlQty"></select>
+          <button class="qty-plus add-button" data-target="spicyChickenBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Teriyaki Chicken Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/teriyaki-chicken-bowl.jpg') }}" alt="Teriyaki Chicken Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Teriyaki Chicken Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="teriyakiChickenBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="teriyakiChickenBowlQty" type="button">-</button>
+          <select id="teriyakiChickenBowlQty" name="teriyakiChickenBowlQty"></select>
+          <button class="qty-plus add-button" data-target="teriyakiChickenBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Teriyaki Beef Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/nrp.png') }}" alt="Teriyaki Beef Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Teriyaki Beef Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="teriyakiBeefBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="teriyakiBeefBowlQty" type="button">-</button>
+          <select id="teriyakiBeefBowlQty" name="teriyakiBeefBowlQty"></select>
+          <button class="qty-plus add-button" data-target="teriyakiBeefBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="California Bowl" data-price="14" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/calibowl.png') }}" alt="California Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>California Bowl</h3>
+        <p>€ 14.00</p>
+        <div class="qty-box">
+          <label for="californiaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="californiaBowlQty" type="button">-</button>
+          <select id="californiaBowlQty" name="californiaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="californiaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Vega Bowl" data-price="13" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/vega-bowl.jpg') }}" alt="Vega Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Vega Bowl (Vegetarisch)</h3>
+        <p>€ 13.00</p>
+        <div class="qty-box">
+          <label for="vegaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="vegaBowlQty" type="button">-</button>
+          <select id="vegaBowlQty" name="vegaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="vegaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Meatlover Bowl" data-price="17" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/meatlover-bowl.jpg') }}" alt="Meatlover Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Meatlover Bowl</h3>
+        <p>€ 17.00</p>
+        <div class="qty-box">
+          <label for="meatloverBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="meatloverBowlQty" type="button">-</button>
+          <select id="meatloverBowlQty" name="meatloverBowlQty"></select>
+          <button class="qty-plus add-button" data-target="meatloverBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Rainbow Bowl" data-price="17" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/rainbowl.png') }}" alt="Rainbow Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Rainbow Bowl</h3>
+        <p>€ 17.00</p>
+        <div class="qty-box">
+          <label for="rainbowBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="rainbowBowlQty" type="button">-</button>
+          <select id="rainbowBowlQty" name="rainbowBowlQty"></select>
+          <button class="qty-plus add-button" data-target="rainbowBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Spicy Tuna Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/spicy-tuna-bowl.jpg') }}" alt="Spicy Tuna Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Spicy Tuna Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="spicyTunaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="spicyTunaBowlQty" type="button">-</button>
+          <select id="spicyTunaBowlQty" name="spicyTunaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="spicyTunaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Flamed Zalm Bowl" data-price="16" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/flamed-salmon-bowl.jpg') }}" alt="Flamed Zalm Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Flamed Zalm Bowl</h3>
+        <p>€ 16.00</p>
+        <div class="qty-box">
+          <label for="flamedZalmBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="flamedZalmBowlQty" type="button">-</button>
+          <select id="flamedZalmBowlQty" name="flamedZalmBowlQty"></select>
+          <button class="qty-plus add-button" data-target="flamedZalmBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Flamed Tuna Bowl" data-price="16" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/flamed-tuna-bowl.png') }}" alt="Flamed Tuna Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Flamed Tuna Bowl</h3>
+        <p>€ 16.00</p>
+        <div class="qty-box">
+          <label for="flamedTunaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="flamedTunaBowlQty" type="button">-</button>
+          <select id="flamedTunaBowlQty" name="flamedTunaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="flamedTunaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="X-Bowl" data-price="0" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/Xbowl.png') }}" alt="X-Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>X-Bowl (Vrije samenstelling)</h3>
+        <p id="xBowlSummary" class="xbowl-summary"></p>
+        <p id="xBowlPrice" class="xbowl-summary">Prijs afhankelijk van keuzes</p>
+        <div class="bubble-option">
+          <select id="xBowlBase">
+            <option value="">Basis</option>
+            <option value="Sushi rijst" data-price="4">Sushi rijst</option>
+            <option value="IJsbergsla" data-price="5">IJsbergsla</option>
+            <option value="Tempura crispy rijst" data-price="6">Tempura crispy rijst</option>
+          </select>
+        </div>
+        <div id="xBowlMains"></div>
+        <div id="xBowlToppings"></div>
+        <div class="new-set-wrap hidden" id="xBowlNewWrap">
+          <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+          <button type="button" class="new-set-button" id="xBowlNew">druk op</button>
+        </div>
+        <div class="qty-box">
+          <label for="xBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="xBowlQty" type="button">-</button>
+          <select id="xBowlQty" class="qty-select" name="xBowlQty"></select>
+          <button class="qty-plus add-button" data-target="xBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+<section id="sushi">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Special Sushi Rolls
+</h2>
+<div class="menu-row menu-item" data-name="Salmon Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Green Dragon Roll" src="{{ url_for('static', filename='images/green-dragon-roll.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Salmon Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="salmonRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="salmonRollCount" type="button">-</button>
+<select id="salmonRollCount" name="salmonRollCount"></select>
+<button class="qty-plus add-button" data-target="salmonRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Dragon Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Angry Dragon Roll" src="{{ url_for('static', filename='images/angry-dragon.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Dragon Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="dragonRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="dragonRollCount" type="button">-</button>
+<select id="dragonRollCount" name="dragonRollCount"></select>
+<button class="qty-plus add-button" data-target="dragonRollCount" type="button">+</button>
+</div>
+<div id="dragonPrefs"></div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Beef Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Beef Roll Omakase" src="{{ url_for('static', filename='images/牛圈.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Beef Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="beefRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="beefRollCount" type="button">-</button>
+<select id="beefRollCount" name="beefRollCount"></select>
+<button class="qty-plus add-button" data-target="beefRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Chicken Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Chicken Roll Omakase" src="{{ url_for('static', filename='images/几卷.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Chicken Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="chickenRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="chickenRollCount" type="button">-</button>
+<select id="chickenRollCount" name="chickenRollCount"></select>
+<button class="qty-plus add-button" data-target="chickenRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div></section>
+<section id="sashimi">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+      Sashimi per 6 stuks
+    </h2>
+
+<div class="menu-row menu-item" data-name="Salmon sashimi" data-packaging="0.2" data-price="9">
+<div class="menu-img">
+<img alt="Salmon sashimi" src="{{ url_for('static', filename='images/ss.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Salmon sashimi</h3>
+<p>€ 9.00</p>
+<div class="qty-box">
+<label for="salmonSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="salmonSashimiQty" type="button">-</button>
+<select id="salmonSashimiQty" name="salmonSashimiQty"></select>
+<button class="qty-plus add-button" data-target="salmonSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+ <div class="menu-row menu-item" data-name="Flamed salmon sashimi" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Flamed salmon sashimi" src="{{ url_for('static', filename='images/fz.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Flamed salmon sashimi</h3>
+<p>€ 10.00</p>
+<div class="qty-box">
+<label for="flamedsalmonSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="flamedsalmonSashimiQty" type="button">-</button>
+<select id="flamedsalmonSashimiQty" name="flamedsalmonSashimiQty"></select>
+<button class="qty-plus add-button" data-target="flamedsalmonSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Tonijn sashimi" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Tonijn sashimi" src="{{ url_for('static', filename='images/st.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tonijn sashimi</h3>
+<p>€ 10.00</p>
+<div class="qty-box">
+<label for="tonijnSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="tonijnSashimiQty" type="button">-</button>
+<select id="tonijnSashimiQty" name="tonijnSashimiQty"></select>
+<button class="qty-plus add-button" data-target="tonijnSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Salmon sashimi" data-packaging="0.2" data-price="10.5">
+<div class="menu-img">
+<img alt="Salmon sashimi" src="{{ url_for('static', filename='images/ft.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Flamed tonijn sashimi</h3>
+<p>€ 10.50</p>
+<div class="qty-box">
+<label for="flamedtonijnSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="flamedtonijnSashimiQty" type="button">-</button>
+<select id="flamedtonijnSashimiQty" name="flamedtonijnSashimiQty"></select>
+<button class="qty-plus add-button" data-target="flamedtonijnSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+
+<div class="menu-row menu-item" data-name="Beef sashimi" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Beef sashimi" src="{{ url_for('static', filename='images/suy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Beef sashimi</h3>
+<p>€ 10.00</p>
+<div class="qty-box">
+<label for="beefSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="beefSashimiQty" type="button">-</button>
+<select id="beefSashimiQty" name="beefSashimiQty"></select>
+<button class="qty-plus add-button" data-target="beefSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+
+</div>
+</section>
+<section id="Crispy-rice-sandwich">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+      Crispy rice sandwich
+    </h2>
+<!-- Zalm -->
+<div class="menu-row menu-item" data-name="Zalm crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Zalm crispy rice sandwich" src="{{ url_for('static', filename='images/zalm.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Zalm crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="zalm-crispy-rice-sandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="zalm-crispy-rice-sandwich" type="button">-</button>
+<select id="zalm-crispy-rice-sandwich" name="Zalm crispy rice sandwich"></select>
+<button class="qty-plus add-button" data-target="zalm-crispy-rice-sandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Spicytuna -->
+<div class="menu-row menu-item" data-name="Spicytuna crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Spicytuna crispy rice sandwich" src="{{ url_for('static', filename='images/zalm.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Spicytuna crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="spicytuna-crispy-rice-sandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="spicytuna-crispy-rice-sandwich" type="button">-</button>
+<select id="spicytuna-crispy-rice-sandwich" name="Spicytuna crispy rice sandwich"></select>
+<button class="qty-plus add-button" data-target="spicytuna-crispy-rice-sandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Ebi -->
+<!-- Ebi Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Ebi crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Ebi Crispy Rice Sandwich" src="{{ url_for('static', filename='images/Ebi.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ebi crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="ebiCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="ebiCrispyRiceSandwich" type="button">-</button>
+<select id="ebiCrispyRiceSandwich" name="ebiCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="ebiCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Beef Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Beef crispy rice sandwich" data-packaging="0.2" data-price="7.5">
+<div class="menu-img">
+<img alt="Beef Crispy Rice Sandwich" src="{{ url_for('static', filename='images/beef-crispy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Beef crispy rice sandwich</h3>
+<p>€ 7.50</p>
+<div class="qty-box">
+<label for="beefCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="beefCrispyRiceSandwich" type="button">-</button>
+<select id="beefCrispyRiceSandwich" name="beefCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="beefCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- California Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="California crispy rice sandwich" data-packaging="0.2" data-price="7.5">
+<div class="menu-img">
+<img alt="California Crispy Rice Sandwich" src="{{ url_for('static', filename='images/california-crispy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>California crispy rice sandwich</h3>
+<p>€ 7.50</p>
+<div class="qty-box">
+<label for="californiaCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="californiaCrispyRiceSandwich" type="button">-</button>
+<select id="californiaCrispyRiceSandwich" name="californiaCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="californiaCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Chicken Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Chicken crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Chicken Crispy Rice Sandwich" src="{{ url_for('static', filename='images/chicken-crispy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Chicken crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="chickenCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="chickenCrispyRiceSandwich" type="button">-</button>
+<select id="chickenCrispyRiceSandwich" name="chickenCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="chickenCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="snack">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Snack
+</h2>
+<div class="menu-row menu-item" data-name="Karaage" data-packaging="0.2" data-price="6.5">
+<img alt="Karaage" class="menu-img" loading="lazy" src="{{ url_for('static', filename='images/karaage.png') }}">
+<div class="menu-content">
+<h3>Karaage (Japanse gefrituurde kip)</h3>
+<p>€ 6.50</p>
+<div class="qty-box">
+<label for="snackCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="snackCount" type="button">-</button>
+<select id="snackCount" name="snackCount"></select>
+<button class="qty-plus add-button" data-target="snackCount" type="button">+</button>
+</div>
+</div>
+</img></div>
+<!-- Ebi Fry -->
+<div class="menu-row menu-item" data-name="Ebi Fry – 4 st" data-packaging="0.2" data-price="6.2">
+  <div class="menu-img">
+    <img alt="Ebi Fry" loading="lazy" src="{{ url_for('static', filename='images/EB.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Ebi Fry – 4 st</h3>
+    <p>€ 6.20</p>
+    <div class="qty-box">
+      <label for="ebiFryCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="ebiFryCount" type="button">-</button>
+      <select id="ebiFryCount" name="ebiFryCount"></select>
+      <button class="qty-plus add-button" data-target="ebiFryCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Spicy Crispy Chicken -->
+<div class="menu-row menu-item" data-name="Spicy Crispy Chicken – 5 st" data-packaging="0.2" data-price="5.5">
+  <div class="menu-img">
+    <img alt="Spicy Crispy Chicken" loading="lazy" src="{{ url_for('static', filename='images/karaage.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Spicy Crispy Chicken – 5 st</h3>
+    <p>€ 5.50</p>
+    <div class="qty-box">
+      <label for="spicyCrispyChickenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="spicyCrispyChickenCount" type="button">-</button>
+      <select id="spicyCrispyChickenCount" name="spicyCrispyChickenCount"></select>
+      <button class="qty-plus add-button" data-target="spicyCrispyChickenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Chicken Loempia -->
+<div class="menu-row menu-item" data-name="Chicken Loempia – 2 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Chicken Loempia" loading="lazy" src="{{ url_for('static', filename='images/KIPL.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Chicken Loempia – 2 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="chickenLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="chickenLoempiaCount" type="button">-</button>
+      <select id="chickenLoempiaCount" name="chickenLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="chickenLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Gyoza -->
+<div class="menu-row menu-item" data-name="Gyoza – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Gyoza" loading="lazy" src="{{ url_for('static', filename='images/GYO.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Gyoza – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="gyozaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="gyozaCount" type="button">-</button>
+      <select id="gyozaCount" name="gyozaCount"></select>
+      <button class="qty-plus add-button" data-target="gyozaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Inktvis Ringen -->
+<div class="menu-row menu-item" data-name="Inktvis Ringen – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Inktvis Ringen" loading="lazy" src="{{ url_for('static', filename='images/INKT.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Inktvis Ringen – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="inktvisRingenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="inktvisRingenCount" type="button">-</button>
+      <select id="inktvisRingenCount" name="inktvisRingenCount"></select>
+      <button class="qty-plus add-button" data-target="inktvisRingenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Sesambal -->
+<div class="menu-row menu-item" data-name="Sesambal – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Sasambal" loading="lazy" src="{{ url_for('static', filename='images/SEM.webp') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Sesambal – 5 st</h3>
+    <p>€ 4.00</p>
+    <div class="qty-box">
+      <label for="sesambalCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="sesambalCount" type="button">-</button>
+      <select id="sesambalCount" name="sesambalCount"></select>
+      <button class="qty-plus add-button" data-target="sesambalCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Yakitori -->
+<div class="menu-row menu-item" data-name="Yakitori – 4 st" data-packaging="0.2" data-price="6">
+  <div class="menu-img">
+    <img alt="Yakitori" loading="lazy" src="{{ url_for('static', filename='images/YAK.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Yakitori – 4 st</h3>
+    <p>€ 6.00</p>
+    <div class="qty-box">
+      <label for="yakitoriCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="yakitoriCount" type="button">-</button>
+      <select id="yakitoriCount" name="yakitoriCount"></select>
+      <button class="qty-plus add-button" data-target="yakitoriCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Mini Loempia -->
+<div class="menu-row menu-item" data-name="Mini Loempia – 6 st" data-packaging="0.2" data-price="3.5">
+  <div class="menu-img">
+    <img alt="Mini Loempia" loading="lazy" src="{{ url_for('static', filename='images/LOM.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Mini Loempia – 6 st</h3>
+    <p>€ 3.50</p>
+    <div class="qty-box">
+      <label for="miniLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="miniLoempiaCount" type="button">-</button>
+      <select id="miniLoempiaCount" name="miniLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="miniLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Edamame -->
+<div class="menu-row menu-item" data-name="Edamame" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Edamame" loading="lazy" src="{{ url_for('static', filename='images/EDA.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Edamame</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="edamameCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="edamameCount" type="button">-</button>
+      <select id="edamameCount" name="edamameCount"></select>
+      <button class="qty-plus add-button" data-target="edamameCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Komkommer -->
+<div class="menu-row menu-item" data-name="Kimchi Komkommer" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Kimchi Komkommer" loading="lazy" src="{{ url_for('static', filename='images/KKK.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Komkommer</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="kimchiKomkommerCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKomkommerCount" type="button">-</button>
+      <select id="kimchiKomkommerCount" name="kimchiKomkommerCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKomkommerCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Kool -->
+<div class="menu-row menu-item" data-name="Kimchi Kool" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Kimchi Kool" loading="lazy" src="{{ url_for('static', filename='images/KIM.webp') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Kool</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="kimchiKoolCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKoolCount" type="button">-</button>
+      <select id="kimchiKoolCount" name="kimchiKoolCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKoolCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Zeewiersalade -->
+<div class="menu-row menu-item" data-name="Zeewiersalade – 100g" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Zeewiersalade" loading="lazy" src="{{ url_for('static', filename='images/ZEW.webp') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Zeewiersalade – 100g</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="zeewiersaladeCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="zeewiersaladeCount" type="button">-</button>
+      <select id="zeewiersaladeCount" name="zeewiersaladeCount"></select>
+      <button class="qty-plus add-button" data-target="zeewiersaladeCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+</div>
+</section>
+<section id="dessert">
+<div class="menu-group">
+<!-- Mango -->
+<div class="menu-row menu-item" data-name="Mochi Mango" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Mango" loading="lazy" src="{{ url_for('static', filename='images/mochi-mango.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Mango</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiMangoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiMangoCount" type="button">-</button>
+<select id="mochiMangoCount" name="mochiMangoCount"></select>
+<button class="qty-plus add-button" data-target="mochiMangoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Aardbei -->
+<div class="menu-row menu-item" data-name="Mochi Aardbei" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Aardbei" loading="lazy" src="{{ url_for('static', filename='images/mochi-aardbei.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Aardbei</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiAardbeiCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiAardbeiCount" type="button">-</button>
+<select id="mochiAardbeiCount" name="mochiAardbeiCount"></select>
+<button class="qty-plus add-button" data-target="mochiAardbeiCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Matcha -->
+<div class="menu-row menu-item" data-name="Mochi Matcha" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Matcha" loading="lazy" src="{{ url_for('static', filename='images/mochi-matcha.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Matcha</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiMatchaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiMatchaCount" type="button">-</button>
+<select id="mochiMatchaCount" name="mochiMatchaCount"></select>
+<button class="qty-plus add-button" data-target="mochiMatchaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Pistachio -->
+<div class="menu-row menu-item" data-name="Mochi Pistachio" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Pistachio" loading="lazy" src="{{ url_for('static', filename='images/mochi-pistachio.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Pistachio</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiPistachioCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiPistachioCount" type="button">-</button>
+<select id="mochiPistachioCount" name="mochiPistachioCount"></select>
+<button class="qty-plus add-button" data-target="mochiPistachioCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="drinks">
+<div class="menu-group">
+<div class="menu-row menu-item" data-name="Cola" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaCount" type="button">-</button>
+<select id="colaCount" name="colaCount"></select>
+<button class="qty-plus add-button" data-target="colaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola Zero" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola Zero</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaZeroCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaZeroCount" type="button">-</button>
+<select id="colaZeroCount" name="colaZeroCount"></select>
+<button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>

--- a/electron-app/pos.html
+++ b/electron-app/pos.html
@@ -851,7 +851,1323 @@ th:last-child {
   </div>
   <div class="center-area">
     <div class="product-list">
-      {% include 'menu.html' %}
+<!-- Menu inserted directly for Electron build -->
+
+<section id="bubble">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Bubble Tea
+</h2>
+<div class="menu-row menu-item" data-name="Bubble Tea" data-packaging="0.2" data-price="5">
+<div class="menu-img">
+<img alt="Bubble Tea" src="{{ url_for('static', filename='images/bubble-tea-main.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Bubble Tea</h3>
+<p>€ 5.00</p>
+<div class="bubble-option">
+<select id="bubbleType">
+<option value="">Base</option>
+<option value="Green Tea">Green Tea</option>
+<option value="Milk Tea">Milk Tea</option>
+<option value="Milkshake">Milkshake</option>
+</select>
+</div>
+<div class="bubble-option">
+<select id="bubbleFlavor">
+<option value="">Smaak</option>
+<option value="Mango">Mango</option>
+<option value="Appel">Appel</option>
+<option value="Matcha">Matcha</option>
+<option value="Brown Sugar">Brown Sugar</option>
+</select>
+</div>
+<div class="bubble-option">
+  <select id="bubbleTopping">
+<option value="">Topping</option>
+<option value="Appel Popping">Appel Popping</option>
+<option value="Perzik Popping">Perzik Popping</option>
+  <option value="Tapioca">Tapioca</option>
+  </select>
+</div>
+        <div class="new-set-wrap hidden" id="bubbleNewWrap">
+          <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+          <button type="button" class="new-set-button" id="bubbleNew">druk op</button>
+        </div>
+<div class="qty-box">
+  <label for="bubbleTeaQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="bubbleTeaQty" type="button">-</button>
+<select id="bubbleTeaQty"></select>
+<button class="qty-plus add-button" data-target="bubbleTeaQty" type="button">+</button>
+</div>
+</div>
+<section id="bento">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Bento box
+</h2>
+<!-- Chicken Bento -->
+<div class="menu-row menu-item" data-name="Chicken Bento" data-packaging="0.2" data-price="22">
+<div class="menu-img">
+<img alt="Chicken Bento" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Chicken Bento</h3>
+<p>€ 22.00</p>
+<div class="qty-box">
+<label for="chickenBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="chickenBentoCount" type="button">-</button>
+<select id="chickenBentoCount" name="chickenBentoCount"></select>
+<button class="qty-plus add-button" data-target="chickenBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Meatlover Bento -->
+<!-- Meatlover Bento -->
+<div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Meatlover Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Meatlover Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="meatloverBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="meatloverBentoCount" type="button">-</button>
+<select id="meatloverBentoCount" name="meatloverBentoCount"></select>
+<button class="qty-plus add-button" data-target="meatloverBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Zalm Lover Bento -->
+<div class="menu-row menu-item" data-name="Zalm Lover Bento" data-packaging="0.2" data-price="23">
+<div class="menu-img">
+<img alt="Zalm Lover Bento" src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Zalm Lover Bento</h3>
+<p>€ 23.00</p>
+<div class="qty-box">
+<label for="zalmLoverBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="zalmLoverBentoCount" type="button">-</button>
+<select id="zalmLoverBentoCount" name="zalmLoverBentoCount"></select>
+<button class="qty-plus add-button" data-target="zalmLoverBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Ebi Lover Bento -->
+<div class="menu-row menu-item" data-name="Ebi Lover Bento" data-packaging="0.2" data-price="23">
+<div class="menu-img">
+<img alt="Ebi Lover Bento" src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ebi Lover Bento</h3>
+<p>€ 23.00</p>
+<div class="qty-box">
+<label for="ebiLoverBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="ebiLoverBentoCount" type="button">-</button>
+<select id="ebiLoverBentoCount" name="ebiLoverBentoCount"></select>
+<button class="qty-plus add-button" data-target="ebiLoverBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Surf & Turf Bento -->
+<div class="menu-row menu-item" data-name="Surf &amp; Turf Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Surf &amp; Turf Bento" src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Surf &amp; Turf Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="surfTurfBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="surfTurfBentoCount" type="button">-</button>
+<select id="surfTurfBentoCount" name="surfTurfBentoCount"></select>
+<button class="qty-plus add-button" data-target="surfTurfBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Dimsum Bento -->
+<div class="menu-row menu-item" data-name="Dimsum Bento" data-packaging="0.2" data-price="15">
+<div class="menu-img">
+<img alt="Dimsum Bento" src="{{ url_for('static', filename='images/dimsum-bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Dimsum Bento</h3>
+<p>€ 15.00</p>
+<div class="qty-box">
+<label for="dimsumBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="dimsumBentoCount" type="button">-</button>
+<select id="dimsumBentoCount" name="dimsumBentoCount"></select>
+<button class="qty-plus add-button" data-target="dimsumBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Lamskotelet Bento -->
+<div class="menu-row menu-item" data-name="Lamskotelet Bento" data-packaging="0.2" data-price="28">
+<div class="menu-img">
+<img alt="Lamskotelet Bento" src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Lamskotelet Bento</h3>
+<p>€ 28.00</p>
+<div class="qty-box">
+<label for="lamsBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="lamsBentoCount" type="button">-</button>
+<select id="lamsBentoCount" name="lamsBentoCount"></select>
+<button class="qty-plus add-button" data-target="lamsBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Veggie Bento -->
+<div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
+<div class="menu-img">
+<img alt="Veggie Bento" src="{{ url_for('static', filename='images/veggie-bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Veggie Bento</h3>
+<p>€ 20.00</p>
+<div class="qty-box">
+<label for="veggieBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="veggieBentoCount" type="button">-</button>
+<select id="veggieBentoCount" name="veggieBentoCount"></select>
+<button class="qty-plus add-button" data-target="veggieBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Bento Sushi Omakase" data-packaging="0.2" data-price="22">
+<div class="menu-img">
+<img alt="Bento Sushi Omakase" src="{{ url_for('static', filename='images/sushi-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Bento Sushi Omakase</h3>
+<p>€ 22.00</p>
+<p class="menu-description">±16st Verrassing van de chef!</p>
+<div class="qty-box">
+<label for="sushiBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="sushiBentoCount" type="button">-</button>
+<select id="sushiBentoCount" name="sushiBentoCount"></select>
+<button class="qty-plus add-button" data-target="sushiBentoCount" type="button">+</button>
+</div>
+<div id="omakasePrefs"></div>
+</div>
+</div>
+<!-- Xbento - Stel je eigen bento samen -->
+<!-- Xbento - Stel je eigen bento samen -->
+<div class="menu-row menu-item" data-name="Xbento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Xbento" src="{{ url_for('static', filename='images/xbento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Xbento (stel zelf samen)</h3>
+<p>Vanaf € 25.00</p>
+<div class="bubble-option">
+<select id="xBentoMain">
+<option value="">Hoofdgerecht</option>
+</select>
+</div>
+<div class="bubble-option">
+<select id="xBentoSide">
+<option value="">Bijgerecht</option>
+</select>
+</div>
+<div class="bubble-option">
+  <select id="xBentoRice">
+<option value="">Rijstsoort</option>
+  </select>
+</div>
+<div class="bubble-option">
+  <select id="xBentoVeg">
+    <option value="">Groente</option>
+  </select>
+</div>
+    <div class="new-set-wrap hidden" id="xBentoNewWrap">
+      <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+      <button type="button" class="new-set-button" id="xBentoNew">druk op</button>
+    </div>
+<div class="qty-box">
+  <label for="xBentoQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="xBentoQty" type="button">-</button>
+<select class="qty-select" id="xBentoQty" name="xBentoQty"></select>
+<button class="qty-plus add-button" data-target="xBentoQty" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="drinks">
+<div class="menu-group">
+<div class="menu-row menu-item" data-name="Cola" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaCount" type="button">-</button>
+<select id="colaCount" name="colaCount"></select>
+<button class="qty-plus add-button" data-target="colaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola Zero" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola Zero</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaZeroCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaZeroCount" type="button">-</button>
+<select id="colaZeroCount" name="colaZeroCount"></select>
+<button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="drinks">
+<div class="menu-group">
+<div class="menu-row menu-item" data-name="Cola" data-packaging="0.2" data-price="2.5">
+<div class="menu-img">
+<img alt="Cola" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola</h3>
+<p>€ 2.50</p>
+<div class="qty-box">
+<label for="colaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaCount" type="button">-</button>
+<select id="colaCount" name="colaCount"></select>
+<button class="qty-plus add-button" data-target="colaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.2" data-price="2.5">
+<div class="menu-img">
+<img alt="Cola Zero" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola Zero</h3>
+<p>€ 2.50</p>
+<div class="qty-box">
+<label for="colaZeroCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaZeroCount" type="button">-</button>
+<select id="colaZeroCount" name="colaZeroCount"></select>
+<button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Pokebowl Section -->
+<section id="Ramen">
+<h2>Ramen</h2>
+<div class="menu-section">
+  <!-- Ebi Furai Ramen -->
+  <div class="menu-row menu-item" data-code="ebi" data-name="Ebi Furai" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Ebi Furai Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Ebi Furai</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="ebiBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="ebiSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="ebiNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="ebiNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="ebiQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="ebiQty" type="button">-</button>
+        <select id="ebiQty"></select>
+        <button class="qty-plus add-button" data-target="ebiQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Chicken Ramen -->
+  <div class="menu-row menu-item" data-code="chicken" data-name="Chicken" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Chicken Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Chicken</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="chickenBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="chickenSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="chickenNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="chickenNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="chickenQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="chickenQty" type="button">-</button>
+        <select id="chickenQty"></select>
+        <button class="qty-plus add-button" data-target="chickenQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Beef Ramen -->
+  <div class="menu-row menu-item" data-code="beef" data-name="Beef" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Beef Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Beef</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="beefBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="beefSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="beefNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="beefNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="beefQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="beefQty" type="button">-</button>
+        <select id="beefQty"></select>
+        <button class="qty-plus add-button" data-target="beefQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Ribeye Ramen -->
+  <div class="menu-row menu-item" data-code="ribeye" data-name="Ribeye" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Ribeye Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Ribeye</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="ribeyeBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="ribeyeSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="ribeyeNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="ribeyeNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="ribeyeQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="ribeyeQty" type="button">-</button>
+        <select id="ribeyeQty"></select>
+        <button class="qty-plus add-button" data-target="ribeyeQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+  <!-- Chasiu Ramen -->
+  <div class="menu-row menu-item" data-code="chasiu" data-name="Chasiu" data-packaging="0.2" data-price="18">
+    <div class="menu-img">
+      <img alt="Chasiu Ramen" src="{{ url_for('static', filename='images/tonkotsu-ramen.png') }}"/>
+    </div>
+    <div class="menu-content">
+      <h3>Chasiu</h3>
+      <p>€ 18.00</p>
+      <div class="bubble-option">
+        <select id="chasiuBase">
+          <option value="">Base</option>
+          <option value="Ramen">Ramen</option>
+          <option value="Udon">Udon</option>
+        </select>
+      </div>
+      <div class="bubble-option">
+        <select id="chasiuSmaak">
+          <option value="">Smaak</option>
+          <option value="Miso">Miso</option>
+          <option value="Soyu">Soyu</option>
+        </select>
+      </div>
+      <div class="new-set-wrap hidden" id="chasiuNewWrap">
+        <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+        <button type="button" class="new-set-button" id="chasiuNew">druk op</button>
+      </div>
+      <div class="qty-box">
+        <label for="chasiuQty">Aantal</label>
+        <button class="qty-minus remove-button" data-target="chasiuQty" type="button">-</button>
+        <select id="chasiuQty"></select>
+        <button class="qty-plus add-button" data-target="chasiuQty" type="button">+</button>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+<section id="Pokebowl">
+  <h2>Pokebowl</h2>
+  <div class="menu-section">
+    <div class="menu-row menu-item" data-name="Zalm Bowl" data-price="15" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/zwp.png') }}" alt="Zalm Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Zalm Bowl</h3>
+        <p>€ 15.00</p>
+        <div class="qty-box">
+          <label for="zalmBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="zalmBowlQty" type="button">-</button>
+          <select id="zalmBowlQty" name="zalmBowlQty"></select>
+          <button class="qty-plus add-button" data-target="zalmBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+    <div class="menu-row menu-item" data-name="Tuna Bowl" data-price="15" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/tup.png') }}" alt="Tuna Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Tuna Bowl</h3>
+        <p>€ 15.00</p>
+        <div class="qty-box">
+          <label for="tunaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="tunaBowlQty" type="button">-</button>
+          <select id="tunaBowlQty" name="tunaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="tunaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Ebi Fry Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/虾boel.png') }}" alt="Ebi Fry Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Ebi Fry Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="ebiFryBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="ebiFryBowlQty" type="button">-</button>
+          <select id="ebiFryBowlQty" name="ebiFryBowlQty"></select>
+          <button class="qty-plus add-button" data-target="ebiFryBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Chicken Karaage Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/chicken-kar.jpg') }}" alt="Chicken Karaage Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Chicken Karaage Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="chickenKaraageBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="chickenKaraageBowlQty" type="button">-</button>
+          <select id="chickenKaraageBowlQty" name="chickenKaraageBowlQty"></select>
+          <button class="qty-plus add-button" data-target="chickenKaraageBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Spicy Chicken Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/chicken-kar.jpg') }}" alt="Spicy Chicken Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Spicy Chicken Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="spicyChickenBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="spicyChickenBowlQty" type="button">-</button>
+          <select id="spicyChickenBowlQty" name="spicyChickenBowlQty"></select>
+          <button class="qty-plus add-button" data-target="spicyChickenBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Teriyaki Chicken Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/teriyaki-chicken-bowl.jpg') }}" alt="Teriyaki Chicken Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Teriyaki Chicken Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="teriyakiChickenBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="teriyakiChickenBowlQty" type="button">-</button>
+          <select id="teriyakiChickenBowlQty" name="teriyakiChickenBowlQty"></select>
+          <button class="qty-plus add-button" data-target="teriyakiChickenBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Teriyaki Beef Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/nrp.png') }}" alt="Teriyaki Beef Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Teriyaki Beef Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="teriyakiBeefBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="teriyakiBeefBowlQty" type="button">-</button>
+          <select id="teriyakiBeefBowlQty" name="teriyakiBeefBowlQty"></select>
+          <button class="qty-plus add-button" data-target="teriyakiBeefBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="California Bowl" data-price="14" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/calibowl.png') }}" alt="California Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>California Bowl</h3>
+        <p>€ 14.00</p>
+        <div class="qty-box">
+          <label for="californiaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="californiaBowlQty" type="button">-</button>
+          <select id="californiaBowlQty" name="californiaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="californiaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Vega Bowl" data-price="13" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/vega-bowl.jpg') }}" alt="Vega Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Vega Bowl (Vegetarisch)</h3>
+        <p>€ 13.00</p>
+        <div class="qty-box">
+          <label for="vegaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="vegaBowlQty" type="button">-</button>
+          <select id="vegaBowlQty" name="vegaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="vegaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Meatlover Bowl" data-price="17" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/meatlover-bowl.jpg') }}" alt="Meatlover Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Meatlover Bowl</h3>
+        <p>€ 17.00</p>
+        <div class="qty-box">
+          <label for="meatloverBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="meatloverBowlQty" type="button">-</button>
+          <select id="meatloverBowlQty" name="meatloverBowlQty"></select>
+          <button class="qty-plus add-button" data-target="meatloverBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Rainbow Bowl" data-price="17" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/rainbowl.png') }}" alt="Rainbow Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Rainbow Bowl</h3>
+        <p>€ 17.00</p>
+        <div class="qty-box">
+          <label for="rainbowBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="rainbowBowlQty" type="button">-</button>
+          <select id="rainbowBowlQty" name="rainbowBowlQty"></select>
+          <button class="qty-plus add-button" data-target="rainbowBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Spicy Tuna Bowl" data-price="15.5" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/spicy-tuna-bowl.jpg') }}" alt="Spicy Tuna Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Spicy Tuna Bowl</h3>
+        <p>€ 15.50</p>
+        <div class="qty-box">
+          <label for="spicyTunaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="spicyTunaBowlQty" type="button">-</button>
+          <select id="spicyTunaBowlQty" name="spicyTunaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="spicyTunaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Flamed Zalm Bowl" data-price="16" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/flamed-salmon-bowl.jpg') }}" alt="Flamed Zalm Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Flamed Zalm Bowl</h3>
+        <p>€ 16.00</p>
+        <div class="qty-box">
+          <label for="flamedZalmBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="flamedZalmBowlQty" type="button">-</button>
+          <select id="flamedZalmBowlQty" name="flamedZalmBowlQty"></select>
+          <button class="qty-plus add-button" data-target="flamedZalmBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="Flamed Tuna Bowl" data-price="16" data-packaging="0.2">
+      <div class="menu-img">
+        <img src="{{ url_for('static', filename='images/flamed-tuna-bowl.png') }}" alt="Flamed Tuna Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>Flamed Tuna Bowl</h3>
+        <p>€ 16.00</p>
+        <div class="qty-box">
+          <label for="flamedTunaBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="flamedTunaBowlQty" type="button">-</button>
+          <select id="flamedTunaBowlQty" name="flamedTunaBowlQty"></select>
+          <button class="qty-plus add-button" data-target="flamedTunaBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu-row menu-item" data-name="X-Bowl" data-price="0" data-packaging="0.2">
+      <div class="menu-img">
+          <img src="{{ url_for('static', filename='images/Xbowl.png') }}" alt="X-Bowl">
+      </div>
+      <div class="menu-content">
+        <h3>X-Bowl (Vrije samenstelling)</h3>
+        <p id="xBowlSummary" class="xbowl-summary"></p>
+        <p id="xBowlPrice" class="xbowl-summary">Prijs afhankelijk van keuzes</p>
+        <div class="bubble-option">
+          <select id="xBowlBase">
+            <option value="">Basis</option>
+            <option value="Sushi rijst" data-price="4">Sushi rijst</option>
+            <option value="IJsbergsla" data-price="5">IJsbergsla</option>
+            <option value="Tempura crispy rijst" data-price="6">Tempura crispy rijst</option>
+          </select>
+        </div>
+        <div id="xBowlMains"></div>
+        <div id="xBowlToppings"></div>
+        <div class="new-set-wrap hidden" id="xBowlNewWrap">
+          <span class="new-set-msg">Toegevoegd. Nieuw selecteren?</span>
+          <button type="button" class="new-set-button" id="xBowlNew">druk op</button>
+        </div>
+        <div class="qty-box">
+          <label for="xBowlQty">Aantal</label>
+          <button class="qty-minus remove-button" data-target="xBowlQty" type="button">-</button>
+          <select id="xBowlQty" class="qty-select" name="xBowlQty"></select>
+          <button class="qty-plus add-button" data-target="xBowlQty" type="button">+</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+<section id="sushi">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Special Sushi Rolls
+</h2>
+<div class="menu-row menu-item" data-name="Salmon Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Green Dragon Roll" src="{{ url_for('static', filename='images/green-dragon-roll.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Salmon Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="salmonRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="salmonRollCount" type="button">-</button>
+<select id="salmonRollCount" name="salmonRollCount"></select>
+<button class="qty-plus add-button" data-target="salmonRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Dragon Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Angry Dragon Roll" src="{{ url_for('static', filename='images/angry-dragon.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Dragon Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="dragonRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="dragonRollCount" type="button">-</button>
+<select id="dragonRollCount" name="dragonRollCount"></select>
+<button class="qty-plus add-button" data-target="dragonRollCount" type="button">+</button>
+</div>
+<div id="dragonPrefs"></div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Beef Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Beef Roll Omakase" src="{{ url_for('static', filename='images/牛圈.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Beef Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="beefRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="beefRollCount" type="button">-</button>
+<select id="beefRollCount" name="beefRollCount"></select>
+<button class="qty-plus add-button" data-target="beefRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Chicken Roll Omakase" data-packaging="0.2" data-price="16">
+<div class="menu-img">
+<img alt="Chicken Roll Omakase" src="{{ url_for('static', filename='images/几卷.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Chicken Roll Omakase</h3>
+<p>9 st verrassing samengesteld<br/>€ 16.00</p>
+<div class="qty-box">
+<label for="chickenRollCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="chickenRollCount" type="button">-</button>
+<select id="chickenRollCount" name="chickenRollCount"></select>
+<button class="qty-plus add-button" data-target="chickenRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div></section>
+<section id="sashimi">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+      Sashimi per 6 stuks
+    </h2>
+
+<div class="menu-row menu-item" data-name="Salmon sashimi" data-packaging="0.2" data-price="9">
+<div class="menu-img">
+<img alt="Salmon sashimi" src="{{ url_for('static', filename='images/ss.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Salmon sashimi</h3>
+<p>€ 9.00</p>
+<div class="qty-box">
+<label for="salmonSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="salmonSashimiQty" type="button">-</button>
+<select id="salmonSashimiQty" name="salmonSashimiQty"></select>
+<button class="qty-plus add-button" data-target="salmonSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+ <div class="menu-row menu-item" data-name="Flamed salmon sashimi" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Flamed salmon sashimi" src="{{ url_for('static', filename='images/fz.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Flamed salmon sashimi</h3>
+<p>€ 10.00</p>
+<div class="qty-box">
+<label for="flamedsalmonSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="flamedsalmonSashimiQty" type="button">-</button>
+<select id="flamedsalmonSashimiQty" name="flamedsalmonSashimiQty"></select>
+<button class="qty-plus add-button" data-target="flamedsalmonSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Tonijn sashimi" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Tonijn sashimi" src="{{ url_for('static', filename='images/st.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tonijn sashimi</h3>
+<p>€ 10.00</p>
+<div class="qty-box">
+<label for="tonijnSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="tonijnSashimiQty" type="button">-</button>
+<select id="tonijnSashimiQty" name="tonijnSashimiQty"></select>
+<button class="qty-plus add-button" data-target="tonijnSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Salmon sashimi" data-packaging="0.2" data-price="10.5">
+<div class="menu-img">
+<img alt="Salmon sashimi" src="{{ url_for('static', filename='images/ft.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Flamed tonijn sashimi</h3>
+<p>€ 10.50</p>
+<div class="qty-box">
+<label for="flamedtonijnSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="flamedtonijnSashimiQty" type="button">-</button>
+<select id="flamedtonijnSashimiQty" name="flamedtonijnSashimiQty"></select>
+<button class="qty-plus add-button" data-target="flamedtonijnSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+
+<div class="menu-row menu-item" data-name="Beef sashimi" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Beef sashimi" src="{{ url_for('static', filename='images/suy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Beef sashimi</h3>
+<p>€ 10.00</p>
+<div class="qty-box">
+<label for="beefSashimiQty">Aantal</label>
+<button class="qty-minus remove-button" data-target="beefSashimiQty" type="button">-</button>
+<select id="beefSashimiQty" name="beefSashimiQty"></select>
+<button class="qty-plus add-button" data-target="beefSashimiQty" type="button">+</button>
+</div>
+</div>
+</div>
+
+</div>
+</section>
+<section id="Crispy-rice-sandwich">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+      Crispy rice sandwich
+    </h2>
+<!-- Zalm -->
+<div class="menu-row menu-item" data-name="Zalm crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Zalm crispy rice sandwich" src="{{ url_for('static', filename='images/zalm.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Zalm crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="zalm-crispy-rice-sandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="zalm-crispy-rice-sandwich" type="button">-</button>
+<select id="zalm-crispy-rice-sandwich" name="Zalm crispy rice sandwich"></select>
+<button class="qty-plus add-button" data-target="zalm-crispy-rice-sandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Spicytuna -->
+<div class="menu-row menu-item" data-name="Spicytuna crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Spicytuna crispy rice sandwich" src="{{ url_for('static', filename='images/zalm.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Spicytuna crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="spicytuna-crispy-rice-sandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="spicytuna-crispy-rice-sandwich" type="button">-</button>
+<select id="spicytuna-crispy-rice-sandwich" name="Spicytuna crispy rice sandwich"></select>
+<button class="qty-plus add-button" data-target="spicytuna-crispy-rice-sandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Ebi -->
+<!-- Ebi Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Ebi crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Ebi Crispy Rice Sandwich" src="{{ url_for('static', filename='images/Ebi.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ebi crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="ebiCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="ebiCrispyRiceSandwich" type="button">-</button>
+<select id="ebiCrispyRiceSandwich" name="ebiCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="ebiCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Beef Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Beef crispy rice sandwich" data-packaging="0.2" data-price="7.5">
+<div class="menu-img">
+<img alt="Beef Crispy Rice Sandwich" src="{{ url_for('static', filename='images/beef-crispy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Beef crispy rice sandwich</h3>
+<p>€ 7.50</p>
+<div class="qty-box">
+<label for="beefCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="beefCrispyRiceSandwich" type="button">-</button>
+<select id="beefCrispyRiceSandwich" name="beefCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="beefCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- California Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="California crispy rice sandwich" data-packaging="0.2" data-price="7.5">
+<div class="menu-img">
+<img alt="California Crispy Rice Sandwich" src="{{ url_for('static', filename='images/california-crispy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>California crispy rice sandwich</h3>
+<p>€ 7.50</p>
+<div class="qty-box">
+<label for="californiaCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="californiaCrispyRiceSandwich" type="button">-</button>
+<select id="californiaCrispyRiceSandwich" name="californiaCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="californiaCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Chicken Crispy Rice Sandwich -->
+<div class="menu-row menu-item" data-name="Chicken crispy rice sandwich" data-packaging="0.2" data-price="7">
+<div class="menu-img">
+<img alt="Chicken Crispy Rice Sandwich" src="{{ url_for('static', filename='images/chicken-crispy.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Chicken crispy rice sandwich</h3>
+<p>€ 7.00</p>
+<div class="qty-box">
+<label for="chickenCrispyRiceSandwich">Aantal</label>
+<button class="qty-minus remove-button" data-target="chickenCrispyRiceSandwich" type="button">-</button>
+<select id="chickenCrispyRiceSandwich" name="chickenCrispyRiceSandwich"></select>
+<button class="qty-plus add-button" data-target="chickenCrispyRiceSandwich" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="snack">
+<div class="menu-group">
+<h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
+  Snack
+</h2>
+<div class="menu-row menu-item" data-name="Karaage" data-packaging="0.2" data-price="6.5">
+<img alt="Karaage" class="menu-img" loading="lazy" src="{{ url_for('static', filename='images/karaage.png') }}">
+<div class="menu-content">
+<h3>Karaage (Japanse gefrituurde kip)</h3>
+<p>€ 6.50</p>
+<div class="qty-box">
+<label for="snackCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="snackCount" type="button">-</button>
+<select id="snackCount" name="snackCount"></select>
+<button class="qty-plus add-button" data-target="snackCount" type="button">+</button>
+</div>
+</div>
+</img></div>
+<!-- Ebi Fry -->
+<div class="menu-row menu-item" data-name="Ebi Fry – 4 st" data-packaging="0.2" data-price="6.2">
+  <div class="menu-img">
+    <img alt="Ebi Fry" loading="lazy" src="{{ url_for('static', filename='images/EB.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Ebi Fry – 4 st</h3>
+    <p>€ 6.20</p>
+    <div class="qty-box">
+      <label for="ebiFryCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="ebiFryCount" type="button">-</button>
+      <select id="ebiFryCount" name="ebiFryCount"></select>
+      <button class="qty-plus add-button" data-target="ebiFryCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Spicy Crispy Chicken -->
+<div class="menu-row menu-item" data-name="Spicy Crispy Chicken – 5 st" data-packaging="0.2" data-price="5.5">
+  <div class="menu-img">
+    <img alt="Spicy Crispy Chicken" loading="lazy" src="{{ url_for('static', filename='images/karaage.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Spicy Crispy Chicken – 5 st</h3>
+    <p>€ 5.50</p>
+    <div class="qty-box">
+      <label for="spicyCrispyChickenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="spicyCrispyChickenCount" type="button">-</button>
+      <select id="spicyCrispyChickenCount" name="spicyCrispyChickenCount"></select>
+      <button class="qty-plus add-button" data-target="spicyCrispyChickenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Chicken Loempia -->
+<div class="menu-row menu-item" data-name="Chicken Loempia – 2 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Chicken Loempia" loading="lazy" src="{{ url_for('static', filename='images/KIPL.png') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Chicken Loempia – 2 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="chickenLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="chickenLoempiaCount" type="button">-</button>
+      <select id="chickenLoempiaCount" name="chickenLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="chickenLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Gyoza -->
+<div class="menu-row menu-item" data-name="Gyoza – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Gyoza" loading="lazy" src="{{ url_for('static', filename='images/GYO.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Gyoza – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="gyozaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="gyozaCount" type="button">-</button>
+      <select id="gyozaCount" name="gyozaCount"></select>
+      <button class="qty-plus add-button" data-target="gyozaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Inktvis Ringen -->
+<div class="menu-row menu-item" data-name="Inktvis Ringen – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Inktvis Ringen" loading="lazy" src="{{ url_for('static', filename='images/INKT.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Inktvis Ringen – 5 st</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="inktvisRingenCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="inktvisRingenCount" type="button">-</button>
+      <select id="inktvisRingenCount" name="inktvisRingenCount"></select>
+      <button class="qty-plus add-button" data-target="inktvisRingenCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Sesambal -->
+<div class="menu-row menu-item" data-name="Sesambal – 5 st" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Sasambal" loading="lazy" src="{{ url_for('static', filename='images/SEM.webp') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Sesambal – 5 st</h3>
+    <p>€ 4.00</p>
+    <div class="qty-box">
+      <label for="sesambalCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="sesambalCount" type="button">-</button>
+      <select id="sesambalCount" name="sesambalCount"></select>
+      <button class="qty-plus add-button" data-target="sesambalCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Yakitori -->
+<div class="menu-row menu-item" data-name="Yakitori – 4 st" data-packaging="0.2" data-price="6">
+  <div class="menu-img">
+    <img alt="Yakitori" loading="lazy" src="{{ url_for('static', filename='images/YAK.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Yakitori – 4 st</h3>
+    <p>€ 6.00</p>
+    <div class="qty-box">
+      <label for="yakitoriCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="yakitoriCount" type="button">-</button>
+      <select id="yakitoriCount" name="yakitoriCount"></select>
+      <button class="qty-plus add-button" data-target="yakitoriCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Mini Loempia -->
+<div class="menu-row menu-item" data-name="Mini Loempia – 6 st" data-packaging="0.2" data-price="3.5">
+  <div class="menu-img">
+    <img alt="Mini Loempia" loading="lazy" src="{{ url_for('static', filename='images/LOM.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Mini Loempia – 6 st</h3>
+    <p>€ 3.50</p>
+    <div class="qty-box">
+      <label for="miniLoempiaCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="miniLoempiaCount" type="button">-</button>
+      <select id="miniLoempiaCount" name="miniLoempiaCount"></select>
+      <button class="qty-plus add-button" data-target="miniLoempiaCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Edamame -->
+<div class="menu-row menu-item" data-name="Edamame" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Edamame" loading="lazy" src="{{ url_for('static', filename='images/EDA.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Edamame</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="edamameCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="edamameCount" type="button">-</button>
+      <select id="edamameCount" name="edamameCount"></select>
+      <button class="qty-plus add-button" data-target="edamameCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Komkommer -->
+<div class="menu-row menu-item" data-name="Kimchi Komkommer" data-packaging="0.2" data-price="4.5">
+  <div class="menu-img">
+    <img alt="Kimchi Komkommer" loading="lazy" src="{{ url_for('static', filename='images/KKK.jpg') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Komkommer</h3>
+    <p>€ 4.50</p>
+    <div class="qty-box">
+      <label for="kimchiKomkommerCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKomkommerCount" type="button">-</button>
+      <select id="kimchiKomkommerCount" name="kimchiKomkommerCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKomkommerCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Kimchi Kool -->
+<div class="menu-row menu-item" data-name="Kimchi Kool" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Kimchi Kool" loading="lazy" src="{{ url_for('static', filename='images/KIM.webp') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Kimchi Kool</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="kimchiKoolCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="kimchiKoolCount" type="button">-</button>
+      <select id="kimchiKoolCount" name="kimchiKoolCount"></select>
+      <button class="qty-plus add-button" data-target="kimchiKoolCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+<!-- Zeewiersalade -->
+<div class="menu-row menu-item" data-name="Zeewiersalade – 100g" data-packaging="0.2" data-price="5">
+  <div class="menu-img">
+    <img alt="Zeewiersalade" loading="lazy" src="{{ url_for('static', filename='images/ZEW.webp') }}">
+    </img></div>
+  <div class="menu-content">
+    <h3>Zeewiersalade – 100g</h3>
+    <p>€ 5.00</p>
+    <div class="qty-box">
+      <label for="zeewiersaladeCount">Aantal</label>
+      <button class="qty-minus remove-button" data-target="zeewiersaladeCount" type="button">-</button>
+      <select id="zeewiersaladeCount" name="zeewiersaladeCount"></select>
+      <button class="qty-plus add-button" data-target="zeewiersaladeCount" type="button">+</button>
+    </div>
+  </div>
+</div>
+</div>
+</section>
+<section id="dessert">
+<div class="menu-group">
+<!-- Mango -->
+<div class="menu-row menu-item" data-name="Mochi Mango" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Mango" loading="lazy" src="{{ url_for('static', filename='images/mochi-mango.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Mango</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiMangoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiMangoCount" type="button">-</button>
+<select id="mochiMangoCount" name="mochiMangoCount"></select>
+<button class="qty-plus add-button" data-target="mochiMangoCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Aardbei -->
+<div class="menu-row menu-item" data-name="Mochi Aardbei" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Aardbei" loading="lazy" src="{{ url_for('static', filename='images/mochi-aardbei.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Aardbei</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiAardbeiCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiAardbeiCount" type="button">-</button>
+<select id="mochiAardbeiCount" name="mochiAardbeiCount"></select>
+<button class="qty-plus add-button" data-target="mochiAardbeiCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Matcha -->
+<div class="menu-row menu-item" data-name="Mochi Matcha" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Matcha" loading="lazy" src="{{ url_for('static', filename='images/mochi-matcha.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Matcha</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiMatchaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiMatchaCount" type="button">-</button>
+<select id="mochiMatchaCount" name="mochiMatchaCount"></select>
+<button class="qty-plus add-button" data-target="mochiMatchaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<!-- Pistachio -->
+<div class="menu-row menu-item" data-name="Mochi Pistachio" data-packaging="0.2" data-price="4">
+<div class="menu-img">
+<img alt="Mochi Pistachio" loading="lazy" src="{{ url_for('static', filename='images/mochi-pistachio.png') }}">
+</img></div>
+<div class="menu-content">
+<h3>Mochi – Pistachio</h3>
+<p>€ 4.00</p>
+<div class="qty-box">
+<label for="mochiPistachioCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="mochiPistachioCount" type="button">-</button>
+<select id="mochiPistachioCount" name="mochiPistachioCount"></select>
+<button class="qty-plus add-button" data-target="mochiPistachioCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section id="drinks">
+<div class="menu-group">
+<div class="menu-row menu-item" data-name="Cola" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaCount" type="button">-</button>
+<select id="colaCount" name="colaCount"></select>
+<button class="qty-plus add-button" data-target="colaCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.2" data-price="2">
+<div class="menu-img">
+<img alt="Cola Zero" loading="lazy" src="https://via.placeholder.com/150">
+</div>
+<div class="menu-content">
+<h3>Cola Zero</h3>
+<p>€ 2.00</p>
+<div class="qty-box">
+<label for="colaZeroCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="colaZeroCount" type="button">-</button>
+<select id="colaZeroCount" name="colaZeroCount"></select>
+<button class="qty-plus add-button" data-target="colaZeroCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
+</section>
     </div>
   </div>
   <div id="cartPanel" class="cart-panel">


### PR DESCRIPTION
## Summary
- add `menu.html` to the electron app directory
- inline the menu template inside `electron-app/pos.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68711cd5eff083338eeddeac89b5d08d