### PR TITLE
Use beep.mp3 for new order notification

### DIFF
--- a/electron-app/pos.html
+++ b/electron-app/pos.html
@@ -998,7 +998,6 @@ th:last-child {
 
 
 
-<audio id="notifySound" src="assets/beep.mp3" preload="auto"></audio>
 
 
 <div id="xBowlAddedModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.4); align-items:center; justify-content:center; z-index:1000;">
@@ -1634,10 +1633,6 @@ document.addEventListener('DOMContentLoaded',()=>{
   updateCart();
   toggleAddress();
   updateTodayBadge();
-  // 🔊 自动解锁 AudioContext
-  if (audioCtx.state === 'suspended') {
-    audioCtx.resume().catch(() => {});
-  }
 
 });
 
@@ -2060,19 +2055,7 @@ function formatCurrency(value){
     });
   }
 
-  // 音效播放
-  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-  function beep() {
-    const osc = audioCtx.createOscillator();
-    const gain = audioCtx.createGain();
-    osc.type = 'sine';
-    osc.frequency.setValueAtTime(660, audioCtx.currentTime);
-    gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
-    osc.connect(gain);
-    gain.connect(audioCtx.destination);
-    osc.start();
-    osc.stop(audioCtx.currentTime + 0.2);
-  }
+
 
   function parseTimeToMinutes(str){
     if(!str) return Infinity;

--- a/electron-app/pos_orders.html
+++ b/electron-app/pos_orders.html
@@ -109,6 +109,13 @@ th:last-child {
   <script>
     const socket = io({transports:['websocket']});
     let pollTimer;
+    let beepAudio = new Audio('assets/beep.mp3');
+    document.addEventListener('DOMContentLoaded', () => {
+      beepAudio.play().then(() => {
+        beepAudio.pause();
+        beepAudio.currentTime = 0;
+      }).catch(() => {});
+    });
     window.addEventListener('beforeunload',()=>socket.disconnect());
     socket.on('connect_error',()=>{setTimeout(()=>socket.connect(),1000);});
     socket.on('disconnect', startPolling);
@@ -126,17 +133,9 @@ function pad(num) {
 }
 
 // 声音提示
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 function beep(){
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.type = 'sine';
-  osc.frequency.setValueAtTime(660, audioCtx.currentTime);
-  gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
-  osc.start();
-  osc.stop(audioCtx.currentTime + 0.2);
+  beepAudio.currentTime = 0;
+  beepAudio.play();
 }
 
 function parseTimeToMinutes(str){


### PR DESCRIPTION
## Summary
- remove unused audio element and oscillator-based beep
- unlock and play beep.mp3 for notifications

## Testing
- `git diff --color --unified=5`


------
https://chatgpt.com/codex/tasks/task_e_6871df0ab16883339f48b87d9220daf7