### PR TITLE
Add Unagi Bento

### DIFF
--- a/app.py
+++ b/app.py
@@ -510,6 +510,7 @@ with app.app_context():
         "soldout_surf_turf_bento": "false",
         "soldout_dimsum_bento": "false",
         "soldout_lamskotelet_bento": "false",
+        "soldout_unagi_bento": "false",
         "soldout_veggie_bento": "false",
         "soldout_sushi_bento": "false",
         "soldout_salmon_roll": "false",
@@ -1048,6 +1049,7 @@ def dashboard():
         soldout_surf_turf_bento=get_value('soldout_surf_turf_bento', 'false'),
         soldout_dimsum_bento=get_value('soldout_dimsum_bento', 'false'),
         soldout_lamskotelet_bento=get_value('soldout_lamskotelet_bento', 'false'),
+        soldout_unagi_bento=get_value('soldout_unagi_bento', 'false'),
         soldout_veggie_bento=get_value('soldout_veggie_bento', 'false'),
         soldout_sushi_bento=get_value('soldout_sushi_bento', 'false'),
         soldout_salmon_roll=get_value('soldout_salmon_roll', 'false'),
@@ -1141,6 +1143,7 @@ def update_setting():
     soldout_surf_turf_bento_val = data.get('soldout_surf_turf_bento', 'false')
     soldout_dimsum_bento_val = data.get('soldout_dimsum_bento', 'false')
     soldout_lamskotelet_bento_val = data.get('soldout_lamskotelet_bento', 'false')
+    soldout_unagi_bento_val = data.get('soldout_unagi_bento', 'false')
     soldout_veggie_bento_val = data.get('soldout_veggie_bento', 'false')
     soldout_sushi_bento_val = data.get('soldout_sushi_bento', 'false')
     soldout_salmon_roll_val = data.get('soldout_salmon_roll', 'false')
@@ -1221,6 +1224,7 @@ def update_setting():
         ('soldout_surf_turf_bento', soldout_surf_turf_bento_val),
         ('soldout_dimsum_bento', soldout_dimsum_bento_val),
         ('soldout_lamskotelet_bento', soldout_lamskotelet_bento_val),
+        ('soldout_unagi_bento', soldout_unagi_bento_val),
         ('soldout_veggie_bento', soldout_veggie_bento_val),
         ('soldout_sushi_bento', soldout_sushi_bento_val),
         ('soldout_salmon_roll', soldout_salmon_roll_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -132,6 +132,11 @@
             <option value="false" {% if soldout_lamskotelet_bento != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_lamskotelet_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+        <label>Unagi Bento:</label>
+        <select id="soldout_unagi_bento_select">
+            <option value="false" {% if soldout_unagi_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_unagi_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <label>Veggie Bento:</label>
         <select id="soldout_veggie_bento_select">
             <option value="false" {% if soldout_veggie_bento != 'true' %}selected{% endif %}>Open</option>
@@ -662,6 +667,7 @@
             const soldout_surf_turf_bento = document.getElementById('soldout_surf_turf_bento_select').value;
             const soldout_dimsum_bento = document.getElementById('soldout_dimsum_bento_select').value;
             const soldout_lamskotelet_bento = document.getElementById('soldout_lamskotelet_bento_select').value;
+            const soldout_unagi_bento = document.getElementById('soldout_unagi_bento_select').value;
             const soldout_veggie_bento = document.getElementById('soldout_veggie_bento_select').value;
             const soldout_sushi_bento = document.getElementById('soldout_sushi_bento_select').value;
             const soldout_salmon_roll = document.getElementById('soldout_salmon_roll_select').value;
@@ -745,6 +751,7 @@
                     soldout_surf_turf_bento: soldout_surf_turf_bento,
                     soldout_dimsum_bento: soldout_dimsum_bento,
                     soldout_lamskotelet_bento: soldout_lamskotelet_bento,
+                    soldout_unagi_bento: soldout_unagi_bento,
                     soldout_veggie_bento: soldout_veggie_bento,
                     soldout_sushi_bento: soldout_sushi_bento,
                     soldout_salmon_roll: soldout_salmon_roll,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2222,6 +2222,23 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Unagi Bento -->
+<div class="menu-row menu-item" data-name="Unagi Bento" data-packaging="0.2" data-price="24">
+<div class="menu-img">
+<img alt="Unagi Bento" src="{{ url_for('static', filename='images/Unagi.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Unagi Bento</h3>
+<p>€ 24.00</p>
+<p id="soldoutUnagiBento" class="sold-out-msg hidden">Uitverkocht!</p>
+<div class="qty-box">
+<label for="unagiBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="unagiBentoCount" type="button">-</button>
+<select id="unagiBentoCount" name="unagiBentoCount"></select>
+<button class="qty-plus add-button" data-target="unagiBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
@@ -3502,6 +3519,7 @@ const soldoutMap = {
   "Surf & Turf Bento": "soldout_surf_turf_bento",
   "Dimsum Bento": "soldout_dimsum_bento",
   "Lamskotelet Bento": "soldout_lamskotelet_bento",
+  "Unagi Bento": "soldout_unagi_bento",
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
   "Salmon Roll Omakase": "soldout_salmon_roll",
@@ -5906,6 +5924,7 @@ function updateStatus(settings) {
     {name: 'Surf & Turf Bento', key: 'soldout_surf_turf_bento', qty: 'surfTurfBentoCount', msg: 'soldoutSurfTurfBento'},
     {name: 'Dimsum Bento', key: 'soldout_dimsum_bento', qty: 'dimsumBentoCount', msg: 'soldoutDimsumBento'},
     {name: 'Lamskotelet Bento', key: 'soldout_lamskotelet_bento', qty: 'lamsBentoCount', msg: 'soldoutLamskoteletBento'},
+    {name: 'Unagi Bento', key: 'soldout_unagi_bento', qty: 'unagiBentoCount', msg: 'soldoutUnagiBento'},
     {name: 'Veggie Bento', key: 'soldout_veggie_bento', qty: 'veggieBentoCount', msg: 'soldoutVeggieBento'},
     {name: 'Bento Sushi Omakase', key: 'soldout_sushi_bento', qty: 'sushiBentoCount', msg: 'soldoutSushiBento'},
     {name: 'Xbento', key: 'soldout_xbento', qty: 'xBentoQty', msg: 'soldoutXbento'}

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -165,6 +165,22 @@
 </div>
 </div>
 </div>
+<!-- Unagi Bento -->
+<div class="menu-row menu-item" data-name="Unagi Bento" data-packaging="0.2" data-price="24">
+<div class="menu-img">
+<img alt="Unagi Bento" src="{{ url_for('static', filename='images/Unagi.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Unagi Bento</h3>
+<p>€ 24.00</p>
+<div class="qty-box">
+<label for="unagiBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="unagiBentoCount" type="button">-</button>
+<select id="unagiBentoCount" name="unagiBentoCount"></select>
+<button class="qty-plus add-button" data-target="unagiBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">


### PR DESCRIPTION
## Summary
- add Unagi Bento to bento section of index and POS menu
- support Unagi Bento sold-out status in dashboard and client logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68767f329df48333a9f8166cc2ec84a2