### PR TITLE
Enable editing order items and payment method

### DIFF
--- a/app.py
+++ b/app.py
@@ -904,10 +904,23 @@ def update_order_status(order_id: int):
 def edit_order(order_id: int):
     order = Order.query.get_or_404(order_id)
     data = request.get_json() or {}
-    allowed = ['customer_name','phone','email','street','house_number','postcode','city','pickup_time','delivery_time','order_type','items']
+    allowed = ['customer_name','phone','email','street','house_number','postcode','city','pickup_time','delivery_time','order_type','items','payment_method']
     for f in allowed:
         if f in data:
-            setattr(order, f, data[f])
+            if f == 'items':
+                val = data[f]
+                if not isinstance(val, str):
+                    order.items = json.dumps(val)
+                else:
+                    order.items = val
+                try:
+                    items = json.loads(order.items or '{}')
+                except Exception:
+                    items = {}
+                subtotal = sum(float(i.get('price', 0)) * int(i.get('qty', 0)) for i in items.values())
+                order.totaal = float(data.get('totaal') or subtotal)
+            else:
+                setattr(order, f, data[f])
     db.session.commit()
     return jsonify({'success': True})
 

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -158,6 +158,19 @@ th:last-child {
 </div>
 
 <script>
+  let menuPriceMap = null;
+  async function loadMenuPrices(){
+    if(menuPriceMap) return menuPriceMap;
+    try{
+      const r = await fetch('/api/menu');
+      if(r.ok){
+        const d = await r.json();
+        menuPriceMap = {};
+        d.forEach(i=>{menuPriceMap[i.name]=parseFloat(i.price);});
+      }else{ menuPriceMap = {}; }
+    }catch(e){ menuPriceMap = {}; }
+    return menuPriceMap;
+  }
   function orderComplete(btn) {
     const status = btn.nextElementSibling;
     const payload = {
@@ -205,10 +218,11 @@ th:last-child {
     }).then(()=>fetchOrders());
   }
 
-  function editOrder(btn) {
+  async function editOrder(btn) {
     const tr = btn.closest('tr');
     const id = tr.dataset.id;
     const data = JSON.parse(tr.dataset.order || '{}');
+    await loadMenuPrices();
     const name = prompt('Naam', data.customer_name || '');
     if(name === null) return;
     const phone = prompt('Telefoon', data.phone || '');
@@ -227,6 +241,22 @@ th:last-child {
     if(pickup === null) return;
     const delivery = prompt('Bezorgtijd', data.delivery_time || '');
     if(delivery === null) return;
+    const itemsInput = prompt('Items (naam x aantal, gescheiden door comma)',
+      Object.entries(data.items || {}).map(([n,i])=>`${n} x ${i.qty}`).join(', '));
+    if(itemsInput === null) return;
+    const payment = prompt('Betaalwijze', data.payment_method || '');
+    if(payment === null) return;
+
+    const items = {};
+    itemsInput.split(',').map(s=>s.trim()).filter(s=>s).forEach(part=>{
+      const m = part.match(/(.+?)\s*x?\s*(\d+)/);
+      if(m){
+        const nm = m[1].trim();
+        const qty = parseInt(m[2]);
+        const price = (menuPriceMap && menuPriceMap[nm]) ? parseFloat(menuPriceMap[nm]) : 0;
+        items[nm] = {qty, price};
+      }
+    });
 
     fetch(`/api/orders/${id}`, {
       method:'PUT',
@@ -234,7 +264,9 @@ th:last-child {
       body: JSON.stringify({
         customer_name:name, phone, email,
         street, house_number:number, postcode, city,
-        pickup_time:pickup, delivery_time:delivery
+        pickup_time:pickup, delivery_time:delivery,
+        items,
+        payment_method: payment
       })
     }).then(()=>fetchOrders());
   }


### PR DESCRIPTION
## Summary
- support editing `payment_method` and recalc totals on the backend
- fetch menu prices on the POS order table
- enhance edit dialog to modify items and payment method

## Testing
- `python -m py_compile app.py add_watermark.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_6879436502a88333ae5869201efe403b