### PR TITLE
Extend order editing

### DIFF
--- a/app.py
+++ b/app.py
@@ -904,10 +904,32 @@ def update_order_status(order_id: int):
 def edit_order(order_id: int):
     order = Order.query.get_or_404(order_id)
     data = request.get_json() or {}
-    allowed = ['customer_name','phone','email','street','house_number','postcode','city','pickup_time','delivery_time','order_type','items']
+    allowed = [
+        'customer_name', 'phone', 'email', 'street', 'house_number', 'postcode',
+        'city', 'pickup_time', 'delivery_time', 'order_type', 'items',
+        'payment_method', 'totaal', 'fooi'
+    ]
     for f in allowed:
-        if f in data:
-            setattr(order, f, data[f])
+        if f not in data:
+            continue
+        val = data[f]
+        if f == 'items':
+            if not isinstance(val, str):
+                order.items = json.dumps(val)
+            else:
+                order.items = val
+        elif f in ('totaal', 'fooi'):
+            try:
+                setattr(order, f, float(val))
+            except (TypeError, ValueError):
+                setattr(order, f, 0.0)
+        else:
+            setattr(order, f, val)
+    if 'tip' in data:
+        try:
+            order.fooi = float(data['tip'])
+        except (TypeError, ValueError):
+            order.fooi = 0.0
     db.session.commit()
     return jsonify({'success': True})
 

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -205,6 +205,20 @@ th:last-child {
     }).then(()=>fetchOrders());
   }
 
+  function parseItemsString(str, existing){
+    const result={};
+    if(!str) return result;
+    str.split(',').forEach(part=>{
+      const [name, qty] = part.split('=').map(s=>s.trim());
+      const q = parseInt(qty,10);
+      if(name && q>0){
+        const price = existing && existing[name] ? existing[name].price : 0;
+        result[name] = {qty: q, price};
+      }
+    });
+    return result;
+  }
+
   function editOrder(btn) {
     const tr = btn.closest('tr');
     const id = tr.dataset.id;
@@ -228,13 +242,30 @@ th:last-child {
     const delivery = prompt('Bezorgtijd', data.delivery_time || '');
     if(delivery === null) return;
 
+    const itemsStr = Object.entries(data.items || {}).map(([n,i])=>`${n}=${i.qty}`).join(', ');
+    const newItemsInput = prompt('Items (naam=qty, gescheiden door komma)', itemsStr);
+    if(newItemsInput === null) return;
+
+    const payment = prompt('Betaalwijze', data.payment_method || '');
+    if(payment === null) return;
+
+    const totaal = prompt('Totaal', data.totaal != null ? data.totaal : '');
+    if(totaal === null) return;
+
+    const fooi = prompt('Fooi', data.fooi != null ? data.fooi : (data.tip || '0'));
+    if(fooi === null) return;
+
     fetch(`/api/orders/${id}`, {
       method:'PUT',
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify({
         customer_name:name, phone, email,
         street, house_number:number, postcode, city,
-        pickup_time:pickup, delivery_time:delivery
+        pickup_time:pickup, delivery_time:delivery,
+        items: parseItemsString(newItemsInput, data.items || {}),
+        payment_method: payment,
+        totaal: parseFloat(totaal) || 0,
+        fooi: parseFloat(fooi) || 0
       })
     }).then(()=>fetchOrders());
   }


### PR DESCRIPTION
## Summary
- allow API order edits to change payment method, totals and tip
- update POS orders edit dialog to also edit items, payment method, total and tip
- ensure edited items are json encoded when saving

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68795337de1483339b5aa5a0cb3a30c6