### PR TITLE
Add full order edit support

### DIFF
--- a/app.py
+++ b/app.py
@@ -904,10 +904,18 @@ def update_order_status(order_id: int):
 def edit_order(order_id: int):
     order = Order.query.get_or_404(order_id)
     data = request.get_json() or {}
-    allowed = ['customer_name','phone','email','street','house_number','postcode','city','pickup_time','delivery_time','order_type','items']
+    allowed = ['customer_name','phone','email','street','house_number','postcode','city','pickup_time','delivery_time','order_type','items','payment_method','fooi','totaal']
     for f in allowed:
         if f in data:
-            setattr(order, f, data[f])
+            val = data[f]
+            if f == 'items' and isinstance(val, (dict, list)):
+                val = json.dumps(val)
+            if f in ['fooi', 'totaal'] and val is not None:
+                try:
+                    val = float(val)
+                except Exception:
+                    pass
+            setattr(order, f, val)
     db.session.commit()
     return jsonify({'success': True})
 

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -227,6 +227,17 @@ th:last-child {
     if(pickup === null) return;
     const delivery = prompt('Bezorgtijd', data.delivery_time || '');
     if(delivery === null) return;
+    const itemsStr = prompt('Items (JSON)', JSON.stringify(data.items || {}));
+    if(itemsStr === null) return;
+    let items;
+    try{ items = JSON.parse(itemsStr); }
+    catch(e){ alert('Ongeldige items'); return; }
+    const payment = prompt('Betaalwijze', data.payment_method || '');
+    if(payment === null) return;
+    const tip = prompt('Fooi', data.fooi ?? data.tip ?? 0);
+    if(tip === null) return;
+    const total = prompt('Totaal', data.totaal ?? data.total ?? 0);
+    if(total === null) return;
 
     fetch(`/api/orders/${id}`, {
       method:'PUT',
@@ -234,7 +245,9 @@ th:last-child {
       body: JSON.stringify({
         customer_name:name, phone, email,
         street, house_number:number, postcode, city,
-        pickup_time:pickup, delivery_time:delivery
+        pickup_time:pickup, delivery_time:delivery,
+        items, payment_method:payment,
+        fooi: parseFloat(tip), totaal: parseFloat(total)
       })
     }).then(()=>fetchOrders());
   }


### PR DESCRIPTION
## Summary
- allow editing payment method, fooi and total in backend
- add prompts in order table to modify items, payment method, fooi and total

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68795bb10b188333a9930234e3383363