### PR TITLE
Add Nigiri Box Omakase item

### DIFF
--- a/app.py
+++ b/app.py
@@ -518,6 +518,7 @@ with app.app_context():
         "soldout_dragon_roll": "false",
         "soldout_beef_roll": "false",
         "soldout_chicken_roll": "false",
+        "soldout_nigiri_box": "false",
         "soldout_salmon_sashimi": "false",
         "soldout_flamed_salmon_sashimi": "false",
         "soldout_tonijn_sashimi": "false",
@@ -1080,6 +1081,7 @@ def dashboard():
         soldout_dragon_roll=get_value('soldout_dragon_roll', 'false'),
         soldout_beef_roll=get_value('soldout_beef_roll', 'false'),
         soldout_chicken_roll=get_value('soldout_chicken_roll', 'false'),
+        soldout_nigiri_box=get_value('soldout_nigiri_box', 'false'),
         soldout_salmon_sashimi=get_value('soldout_salmon_sashimi', 'false'),
         soldout_flamed_salmon_sashimi=get_value('soldout_flamed_salmon_sashimi', 'false'),
         soldout_tonijn_sashimi=get_value('soldout_tonijn_sashimi', 'false'),
@@ -1175,6 +1177,7 @@ def update_setting():
     soldout_dragon_roll_val = data.get('soldout_dragon_roll', 'false')
     soldout_beef_roll_val = data.get('soldout_beef_roll', 'false')
     soldout_chicken_roll_val = data.get('soldout_chicken_roll', 'false')
+    soldout_nigiri_box_val = data.get('soldout_nigiri_box', 'false')
     soldout_salmon_sashimi_val = data.get('soldout_salmon_sashimi', 'false')
     soldout_flamed_salmon_sashimi_val = data.get('soldout_flamed_salmon_sashimi', 'false')
     soldout_tonijn_sashimi_val = data.get('soldout_tonijn_sashimi', 'false')
@@ -1257,6 +1260,7 @@ def update_setting():
         ('soldout_dragon_roll', soldout_dragon_roll_val),
         ('soldout_beef_roll', soldout_beef_roll_val),
         ('soldout_chicken_roll', soldout_chicken_roll_val),
+        ('soldout_nigiri_box', soldout_nigiri_box_val),
         ('soldout_salmon_sashimi', soldout_salmon_sashimi_val),
         ('soldout_flamed_salmon_sashimi', soldout_flamed_salmon_sashimi_val),
         ('soldout_tonijn_sashimi', soldout_tonijn_sashimi_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -180,6 +180,11 @@
             <option value="false" {% if soldout_chicken_roll != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_chicken_roll == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+        <label>Nigiri Box Omakase:</label>
+        <select id="soldout_nigiri_box_select">
+            <option value="false" {% if soldout_nigiri_box != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_nigiri_box == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <br>
         <h3>Sashimi uitverkocht</h3>
         <label>Salmon sashimi:</label>
@@ -680,6 +685,7 @@
             const soldout_dragon_roll = document.getElementById('soldout_dragon_roll_select').value;
             const soldout_beef_roll = document.getElementById('soldout_beef_roll_select').value;
             const soldout_chicken_roll = document.getElementById('soldout_chicken_roll_select').value;
+            const soldout_nigiri_box = document.getElementById('soldout_nigiri_box_select').value;
             const soldout_salmon_sashimi = document.getElementById('soldout_salmon_sashimi_select').value;
             const soldout_flamed_salmon_sashimi = document.getElementById('soldout_flamed_salmon_sashimi_select').value;
             const soldout_tonijn_sashimi = document.getElementById('soldout_tonijn_sashimi_select').value;
@@ -765,6 +771,7 @@
                     soldout_dragon_roll: soldout_dragon_roll,
                     soldout_beef_roll: soldout_beef_roll,
                     soldout_chicken_roll: soldout_chicken_roll,
+                    soldout_nigiri_box: soldout_nigiri_box,
                     soldout_salmon_sashimi: soldout_salmon_sashimi,
                     soldout_flamed_salmon_sashimi: soldout_flamed_salmon_sashimi,
                     soldout_tonijn_sashimi: soldout_tonijn_sashimi,

--- a/templates/index.html
+++ b/templates/index.html
@@ -1809,7 +1809,7 @@ input:focus, select:focus, textarea:focus {
 <a href="#bento">Bento Box</a>
 <a href="#Ramen">Ramen</a>
 <a href="#Pokebowl">Pokebowl</a>
-<a href="#sushi">Special Sushi Rolls</a>
+<a href="#sushi">Omakase Sushi</a>
 <a href="#sashimi">Sashimi</a>
 <a href="#Crispy-rice-sandwich">Crispy Rice</a>
 <a href="#snack">Snack</a>
@@ -2816,7 +2816,7 @@ input:focus, select:focus, textarea:focus {
 <section id="sushi">
 <div class="menu-group">
 <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
-  Special Sushi Rolls
+  Omakase Sushi
 </h2>
 <div class="menu-row menu-item" data-name="Salmon Roll Omakase" data-packaging="0.2" data-price="16">
 <div class="menu-img">
@@ -2880,6 +2880,22 @@ input:focus, select:focus, textarea:focus {
 <button class="qty-minus remove-button" data-target="chickenRollCount" type="button">-</button>
 <select id="chickenRollCount" name="chickenRollCount"></select>
 <button class="qty-plus add-button" data-target="chickenRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Nigiri Box Omakase" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Nigiri Box Omakase" src="{{ url_for('static', filename='images/sushi-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Nigiri Box Omakase</h3>
+<p>5 stuks nigiri, verrassend samengesteld door de chef<br/>€ 10.00</p>
+<p id="soldoutNigiriBox" class="sold-out-msg hidden">Uitverkocht!</p>
+<div class="qty-box">
+<label for="nigiriBoxCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="nigiriBoxCount" type="button">-</button>
+<select id="nigiriBoxCount" name="nigiriBoxCount"></select>
+<button class="qty-plus add-button" data-target="nigiriBoxCount" type="button">+</button>
 </div>
 </div>
 </div>
@@ -3548,6 +3564,7 @@ const soldoutMap = {
   "Dragon Roll Omakase": "soldout_dragon_roll",
   "Beef Roll Omakase": "soldout_beef_roll",
   "Chicken Roll Omakase": "soldout_chicken_roll",
+  "Nigiri Box Omakase": "soldout_nigiri_box",
   "Salmon sashimi": "soldout_salmon_sashimi",
   "Flamed salmon sashimi": "soldout_flamed_salmon_sashimi",
   "Tonijn sashimi": "soldout_tonijn_sashimi",
@@ -5818,7 +5835,8 @@ function updateStatus(settings) {
     {name: 'Salmon Roll Omakase', key: 'soldout_salmon_roll', qty: 'salmonRollCount', msg: 'soldoutSalmonRoll'},
     {name: 'Dragon Roll Omakase', key: 'soldout_dragon_roll', qty: 'dragonRollCount', msg: 'soldoutDragonRoll'},
     {name: 'Beef Roll Omakase', key: 'soldout_beef_roll', qty: 'beefRollCount', msg: 'soldoutBeefRoll'},
-    {name: 'Chicken Roll Omakase', key: 'soldout_chicken_roll', qty: 'chickenRollCount', msg: 'soldoutChickenRoll'}
+    {name: 'Chicken Roll Omakase', key: 'soldout_chicken_roll', qty: 'chickenRollCount', msg: 'soldoutChickenRoll'},
+    {name: 'Nigiri Box Omakase', key: 'soldout_nigiri_box', qty: 'nigiriBoxCount', msg: 'soldoutNigiriBox'}
   ];
 
   rollConfig.forEach(cfg => {

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -712,7 +712,7 @@
 <section id="sushi">
 <div class="menu-group">
 <h2 style="margin-top: -8px; font-size: 1.5rem; color: #333; text-align: center; font-weight: bold;">
-  Special Sushi Rolls
+  Omakase Sushi
 </h2>
 <div class="menu-row menu-item" data-name="Salmon Roll Omakase" data-packaging="0.2" data-price="16">
 <div class="menu-img">
@@ -772,6 +772,21 @@
 <button class="qty-minus remove-button" data-target="chickenRollCount" type="button">-</button>
 <select id="chickenRollCount" name="chickenRollCount"></select>
 <button class="qty-plus add-button" data-target="chickenRollCount" type="button">+</button>
+</div>
+</div>
+</div>
+<div class="menu-row menu-item" data-name="Nigiri Box Omakase" data-packaging="0.2" data-price="10">
+<div class="menu-img">
+<img alt="Nigiri Box Omakase" src="{{ url_for('static', filename='images/sushi-bento.jpg') }}"/>
+</div>
+<div class="menu-content">
+<h3>Nigiri Box Omakase</h3>
+<p>5 stuks nigiri, verrassend samengesteld door de chef<br/>€ 10.00</p>
+<div class="qty-box">
+<label for="nigiriBoxCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="nigiriBoxCount" type="button">-</button>
+<select id="nigiriBoxCount" name="nigiriBoxCount"></select>
+<button class="qty-plus add-button" data-target="nigiriBoxCount" type="button">+</button>
 </div>
 </div>
 </div>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -579,7 +579,7 @@ body.today-open .today-toggle {
       <a href="#bento">Bento Box</a>
       <a href="#Ramen">Ramen</a>
       <a href="#Pokebowl">Pokebowl</a>
-      <a href="#sushi">Special Sushi Rolls</a>
+      <a href="#sushi">Omakase Sushi</a>
       <a href="#sashimi">Sashimi</a>
       <a href="#Crispy-rice-sandwich">Crispy Rice</a>
       <a href="#snack">Snack</a>


### PR DESCRIPTION
## Summary
- rename 'Special Sushi Rolls' navigation and header to 'Omakase Sushi'
- add new Nigiri Box Omakase menu item in customer and POS menus
- include sold-out controls for Nigiri Box Omakase
- support new sold-out flag in admin dashboard and backend

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687a1ec576ac8333b6e937a209e4bc1b