### PR TITLE
Ensure final slots remain selectable

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5099,7 +5099,8 @@ function checkout() {
     const prev = select.value; // 保留当前选中值
     select.innerHTML = '';
 
-    const now = new Date();
+    const current = new Date();
+    const now = new Date(current);
     now.setMinutes(now.getMinutes() + offsetMinutes); // 现在时间 + 制作时间缓冲
 
     const oStr = openStr || '00:00';
@@ -5118,13 +5119,9 @@ function checkout() {
         close.setDate(close.getDate() + 1);
     }
 
-    // 只有营业开始时间还有效，才显示开始时间
-    const includeStart = open.getTime() >= now.getTime();
-    if (includeStart) {
-        const firstOpt = document.createElement('option');
-        firstOpt.value = oStr;
-        firstOpt.textContent = oStr;
-        select.appendChild(firstOpt);
+    let times = [];
+    if (open.getTime() >= now.getTime()) {
+        times.push(oStr);
     }
 
     let start = now > open ? now : open;
@@ -5135,32 +5132,42 @@ function checkout() {
         const hh = pad(t.getHours());
         const mm = pad(t.getMinutes());
         const timeStr = `${hh}:${mm}`;
-
         if (timeStr === oStr || timeStr === cStr) continue; // 避免重复
+        times.push(timeStr);
+    }
 
+    if (current <= close) {
+        times.push(cStr);
+    }
+
+    // 总是包含最后两个可选时间
+    for (let i = 1; i <= 2; i++) {
+        const t = new Date(close);
+        t.setMinutes(t.getMinutes() - i * timeInterval);
+        if (t >= open && t >= current) {
+            const hh = pad(t.getHours());
+            const mm = pad(t.getMinutes());
+            const str = `${hh}:${mm}`;
+            if (!times.includes(str)) times.push(str);
+        }
+    }
+
+    times = Array.from(new Set(times)).sort((a, b) => parseTime(a, oStr) - parseTime(b, oStr));
+
+    times.forEach(timeStr => {
         const opt = document.createElement('option');
         opt.value = timeStr;
         opt.textContent = timeStr;
         select.appendChild(opt);
-    }
+    });
 
-    // 只有当前时间还没超过结束时间，才显示结束时间选项
-    if (now <= close) {
-        const lastOpt = document.createElement('option');
-        lastOpt.value = cStr;
-        lastOpt.textContent = cStr;
-        select.appendChild(lastOpt);
-    }
-
-    // 如果所有时间都被过滤掉，显示 "无可用时间"
     if (select.options.length === 0) {
         const opt = document.createElement('option');
         opt.value = '';
-        opt.textContent = 'Geen beschikbare tijd meer'; // 无可用时间
+        opt.textContent = 'Geen beschikbare tijd meer';
         select.appendChild(opt);
     }
 
-    // 保留用户上一次选择的时间（如果还存在）
     if (prev) {
         const option = Array.from(select.options).find(o => o.value === prev);
         if (option) select.value = prev;


### PR DESCRIPTION
## Summary
- adjust time slot logic so closing slots are offered when current time is before closing
- only add the last two slots if they have not yet passed

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687aa56a9fa08333a4eb14f3cbe9db2f