### PR TITLE
Support ZSM option

### DIFF
--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -113,6 +113,8 @@ function beep(){
 
 function parseTimeToMinutes(str){
   if(!str) return Infinity;
+  const s=str.trim().toUpperCase();
+  if(s==='ZSM' || s==='Z.S.M.') return -1;
   const p=str.split(':');
   const h=parseInt(p[0],10);
   const m=parseInt(p[1],10);

--- a/electron-pos/public/pos-order.html
+++ b/electron-pos/public/pos-order.html
@@ -113,6 +113,8 @@ function beep(){
 
 function parseTimeToMinutes(str){
   if(!str) return Infinity;
+  const s=str.trim().toUpperCase();
+  if(s==='ZSM' || s==='Z.S.M.') return -1;
   const p=str.split(':');
   const h=parseInt(p[0],10);
   const m=parseInt(p[1],10);

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1820,6 +1820,8 @@ function formatCurrency(value){
 
   function parseTimeToMinutes(str){
     if(!str) return Infinity;
+    const s = str.trim().toUpperCase();
+    if(s === 'ZSM' || s === 'Z.S.M.') return -1;
     const parts = str.split(':');
     const h = parseInt(parts[0],10);
     const m = parseInt(parts[1],10);

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1795,6 +1795,8 @@ function formatCurrency(value){
   
   function parseTimeToMinutes(str){
     if(!str) return Infinity;
+    const s = str.trim().toUpperCase();
+    if(s === 'ZSM' || s === 'Z.S.M.') return -1;
     const parts = str.split(':');
     const h = parseInt(parts[0],10);
     const m = parseInt(parts[1],10);

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -139,6 +139,8 @@ function beep(){
 
 function parseTimeToMinutes(str){
   if(!str) return Infinity;
+  const s=str.trim().toUpperCase();
+  if(s==='ZSM' || s==='Z.S.M.') return -1;
   const p=str.split(':');
   const h=parseInt(p[0],10);
   const m=parseInt(p[1],10);


### PR DESCRIPTION
## Summary
- handle `ZSM` (as soon as possible) time values when sorting orders

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687b3c4a4a6c8333961680ba838ee72f