### PR TITLE
Add Z.S.M. time option

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,6 +65,9 @@ with app.app_context():
         if "is_cancelled" not in cols:
             with db.engine.begin() as conn:
                 conn.execute(text("ALTER TABLE orders ADD COLUMN is_cancelled BOOLEAN DEFAULT FALSE"))
+        if "tijdslot_display" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN tijdslot_display TEXT"))
         cols = {c["name"] for c in inspector.get_columns("reviews")}
         if "rating" not in cols:
             with db.engine.begin() as conn:
@@ -313,6 +316,7 @@ def orders_to_dicts(orders):
             "payment_method": o.payment_method,
             "pickup_time": o.pickup_time,
             "delivery_time": o.delivery_time,
+            "tijdslot_display": o.tijdslot_display,
             "pickupTime": o.pickup_time,
             "deliveryTime": o.delivery_time,
             "postcode": o.postcode,
@@ -406,6 +410,7 @@ class Order(db.Model):
     email = db.Column(db.String(120))
     pickup_time = db.Column(db.String(20))
     delivery_time = db.Column(db.String(20))
+    tijdslot_display = db.Column(db.String(20))
     payment_method = db.Column(db.String(20))
     postcode = db.Column(db.String(10))
     house_number = db.Column(db.String(10))
@@ -716,6 +721,7 @@ def api_orders():
             email=data.get("customerEmail") or data.get("email"),
             pickup_time=data.get("pickup_time") or data.get("pickupTime"),
             delivery_time=data.get("delivery_time") or data.get("deliveryTime"),
+            tijdslot_display=data.get("tijdslot_display"),
             payment_method=data.get("paymentMethod") or data.get("payment_method"),
             postcode=data.get("postcode"),
             house_number=data.get("house_number"),
@@ -1660,6 +1666,7 @@ def pos_orders_today():
             "payment_method": o.payment_method,
             "pickup_time": o.pickup_time,
             "delivery_time": o.delivery_time,
+            "tijdslot_display": o.tijdslot_display,
             "pickupTime": o.pickup_time,
             "deliveryTime": o.delivery_time,
             "postcode": o.postcode,

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1572,14 +1572,20 @@ function submitOrder() {
   };
 
   const orderType = delivery ? 'bezorgen' : 'afhalen';
+  const pickupSel = document.getElementById('pickup_time').value;
+  const deliverySel = document.getElementById('delivery_time').value;
+  const pickupVal = pickupSel === 'Z.S.M.' ? getAsapTime() : pickupSel;
+  const deliveryVal = deliverySel === 'Z.S.M.' ? getAsapTime() : deliverySel;
+  const tijdslotDisplay = delivery ? deliverySel : pickupSel;
   const payload = {
     orderType,
     name,
     phone,
     email: '',
     customerEmail: '',
-    pickup_time: !delivery ? document.getElementById('pickup_time').value : '',
-    delivery_time: delivery ? document.getElementById('delivery_time').value : '',
+    pickup_time: !delivery ? pickupVal : '',
+    delivery_time: delivery ? deliveryVal : '',
+    tijdslot_display: tijdslotDisplay,
     paymentMethod: delivery
       ? document.getElementById('deliveryPayment').value
       : document.getElementById('pickupPayment').value,
@@ -1624,12 +1630,18 @@ function submitOrder() {
     return num.toString().padStart(2,'0');
   }
 
+  function getAsapTime(){
+    const d=new Date();
+    d.setMinutes(d.getMinutes()+30);
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
   function populateTimeOptions(selectId,offsetMinutes){
     const select=document.getElementById(selectId);
     if(!select) return;
     select.innerHTML='';
     const asap=document.createElement('option');
-    asap.value='ZSM';
+    asap.value='Z.S.M.';
     asap.textContent='Z.S.M.';
     select.appendChild(asap);
     const now=new Date();
@@ -1821,7 +1833,7 @@ function formatCurrency(value){
   function parseTimeToMinutes(str){
     if(!str) return Infinity;
     const s = str.trim().toUpperCase();
-    if(s === 'ZSM' || s === 'Z.S.M.') return -1;
+    if(s === 'Z.S.M.') return -1;
     const parts = str.split(':');
     const h = parseInt(parts[0],10);
     const m = parseInt(parts[1],10);
@@ -1870,6 +1882,7 @@ function formatCurrency(value){
     const remark = order.opmerking || order.remark || '';
     const pickup = order.pickup_time || order.pickupTime;
     const delivery = order.delivery_time || order.deliveryTime;
+    const tijdslot = order.tijdslot_display || (isDelivery ? delivery : pickup);
 
     let time = order.created_at || '';
     if (time && time.length > 5) {
@@ -1893,7 +1906,7 @@ function formatCurrency(value){
         <td>€${parseFloat(fooi).toFixed(2)}</td>
         <td>€${parseFloat(order.totaal).toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
-        <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
+        <td>${tijdslot || '-'}</td>
         <td>${order.payment_method || ''}</td>
         <td>${order.order_number || '-'}</td>
         <td><button onclick="toggleComplete(this)"

--- a/templates/index.html
+++ b/templates/index.html
@@ -4995,6 +4995,13 @@ function checkout() {
     if (qty > 0) itemsToSend[extras[id].label] = { price: 0, qty };
   });
 
+  const pickupSel = document.getElementById('pickup_time').value;
+  const deliverySel = document.getElementById('delivery_time').value;
+  const pickupValue = pickupSel === 'Z.S.M.' ? getAsapTime() : pickupSel;
+  const deliveryValue = deliverySel === 'Z.S.M.' ? getAsapTime() : deliverySel;
+
+  const tijdslotDisplay = orderType === 'afhalen' ? pickupSel : deliverySel;
+
   fetch('https://flask-order-api.onrender.com/submit_order', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -5004,8 +5011,9 @@ function checkout() {
       phone: orderType === 'afhalen' ? document.getElementById('pickupPhone').value.trim() : document.getElementById('deliveryPhone').value.trim(),
       email: email,
       customerEmail: email,
-      pickup_time: orderType === 'afhalen' ? document.getElementById('pickup_time').value : '',
-      delivery_time: orderType === 'bezorgen' ? document.getElementById('delivery_time').value : '',
+      pickup_time: orderType === 'afhalen' ? pickupValue : '',
+      delivery_time: orderType === 'bezorgen' ? deliveryValue : '',
+      tijdslot_display: tijdslotDisplay,
       paymentMethod: paymentMethod,
       postcode: orderType === 'bezorgen' ? document.getElementById('deliveryPostcode').value.trim() : '',
       house_number: orderType === 'bezorgen' ? document.getElementById('deliveryHouseNumber').value.trim() : '',
@@ -5081,6 +5089,12 @@ function checkout() {
     return num.toString().padStart(2, '0');
   }
 
+  function getAsapTime() {
+    const d = new Date();
+    d.setMinutes(d.getMinutes() + 30);
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
   function getSelectTimes(selectId, startStr){
     const sel = document.getElementById(selectId);
     if(!sel || sel.options.length === 0) return {};
@@ -5098,6 +5112,11 @@ function checkout() {
 
     const prev = select.value; // 保留当前选中值
     select.innerHTML = '';
+
+    const asapOpt = document.createElement('option');
+    asapOpt.value = 'Z.S.M.';
+    asapOpt.textContent = 'Z.S.M.';
+    select.appendChild(asapOpt);
 
     const now = new Date();
     now.setMinutes(now.getMinutes() + offsetMinutes); // 现在时间 + 制作时间缓冲

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -102,13 +102,7 @@ th:last-child {
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
         <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
-        <td>
-          {% if is_delivery %}
-            {{ order.delivery_time or '-' }}
-          {% else %}
-            {{ order.pickup_time or '-' }}
-          {% endif %}
-        </td>
+        <td>{{ order.tijdslot_display or (order.delivery_time if is_delivery else order.pickup_time) or '-' }}</td>
         <td>
           <span class="{{ 'type-bezorging' if is_delivery else 'type-afhalen' }}">
             {{ 'Bezorging' if is_delivery else 'Afhalen' }}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1560,14 +1560,20 @@ function submitOrder() {
   };
 
   const orderType = delivery ? 'bezorgen' : 'afhalen';
+  const pickupSel = document.getElementById('pickup_time').value;
+  const deliverySel = document.getElementById('delivery_time').value;
+  const pickupVal = pickupSel === 'Z.S.M.' ? getAsapTime() : pickupSel;
+  const deliveryVal = deliverySel === 'Z.S.M.' ? getAsapTime() : deliverySel;
+  const tijdslotDisplay = delivery ? deliverySel : pickupSel;
   const payload = {
     orderType,
     name,
     phone,
     email: '',
     customerEmail: '',
-    pickup_time: !delivery ? document.getElementById('pickup_time').value : '',
-    delivery_time: delivery ? document.getElementById('delivery_time').value : '',
+    pickup_time: !delivery ? pickupVal : '',
+    delivery_time: delivery ? deliveryVal : '',
+    tijdslot_display: tijdslotDisplay,
     paymentMethod: delivery
       ? document.getElementById('deliveryPayment').value
       : document.getElementById('pickupPayment').value,
@@ -1612,10 +1618,20 @@ function submitOrder() {
     return num.toString().padStart(2,'0');
   }
 
+  function getAsapTime(){
+    const d=new Date();
+    d.setMinutes(d.getMinutes()+30);
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
   function populateTimeOptions(selectId,offsetMinutes){
     const select=document.getElementById(selectId);
     if(!select) return;
     select.innerHTML='';
+    const asap=document.createElement('option');
+    asap.value='Z.S.M.';
+    asap.textContent='Z.S.M.';
+    select.appendChild(asap);
     const now=new Date();
     now.setMinutes(now.getMinutes()+offsetMinutes);
 
@@ -1839,6 +1855,7 @@ function formatCurrency(value){
     const remark = order.opmerking || order.remark || '';
     const pickup = order.pickup_time || order.pickupTime;
     const delivery = order.delivery_time || order.deliveryTime;
+    const tijdslot = order.tijdslot_display || (isDelivery ? delivery : pickup);
 
     let time = order.created_at || '';
     if (time && time.length > 5) {
@@ -1853,7 +1870,7 @@ function formatCurrency(value){
       tr.innerHTML = `
         <td>${order.created_date || ''}</td>
         <td>${time}</td>
-        <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
+        <td>${tijdslot || '-'}</td>
         <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
         <td>${order.customer_name || ''}</td>
         <td>${order.phone || ''}</td>


### PR DESCRIPTION
## Summary
- support nieuwe tijdslot_display in database
- add helper to calculate Z.S.M. time
- include tijdslot_display field when creating orders
- show tijdslot_display in POS interfaces and admin table
- add Z.S.M. to time selection on index and POS pages

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687b59c89c7c8333bb1202f8a0942bd8