### PR TITLE
Add dashboard control for Z.S.M option

### DIFF
--- a/app.py
+++ b/app.py
@@ -513,6 +513,7 @@ with app.app_context():
         "delivery_start": "11:00",
         "delivery_end": "21:00",
         "time_interval": "15",
+        "show_zsm_option": "true",
         "milktea_soldout": "false",
         "milktea_price": "5",
         "price_zalm_crispy_rice_sandwich": "7",
@@ -1080,6 +1081,7 @@ def dashboard():
         delivery_end=get_value('delivery_end', '21:00'),
         delivery_postcodes=get_value('delivery_postcodes', ''),
         time_interval=get_value('time_interval', '15'),
+        show_zsm_option=get_value('show_zsm_option', 'true'),
         milktea_soldout=get_value('milktea_soldout', 'false'),
         milktea_price=get_value('milktea_price', '5'),
         price_zalm_crispy_rice_sandwich=get_value('price_zalm_crispy_rice_sandwich', '7'),
@@ -1186,6 +1188,7 @@ def update_setting():
     delivery_end_val = data.get('delivery_end', '21:00')
     delivery_postcodes_val = data.get('delivery_postcodes', '')
     time_interval_val = data.get('time_interval', '15')
+    show_zsm_option_val = data.get('show_zsm_option', 'true')
     milktea_soldout_val = data.get('milktea_soldout', 'false')
     soldout_japans_chicken_bento_val = data.get('soldout_japans_chicken_bento', 'false')
     soldout_korean_chicken_bento_val = data.get('soldout_korean_chicken_bento', 'false')
@@ -1272,6 +1275,7 @@ def update_setting():
         ('delivery_end', delivery_end_val),
         ('delivery_postcodes', delivery_postcodes_val),
         ('time_interval', time_interval_val),
+        ('show_zsm_option', show_zsm_option_val),
         ('milktea_soldout', milktea_soldout_val),
         ('soldout_japans_chicken_bento', soldout_japans_chicken_bento_val),
         ('soldout_korean_chicken_bento', soldout_korean_chicken_bento_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -82,6 +82,12 @@
             <option value="{{ n }}" {% if time_interval == n|string %}selected{% endif %}>{{ n }} min</option>
             {% endfor %}
         </select>
+        <br>
+        <label>Z.S.M. optie:</label>
+        <select id="show_zsm_select">
+            <option value="true" {% if show_zsm_option != 'false' %}selected{% endif %}>Aan</option>
+            <option value="false" {% if show_zsm_option == 'false' %}selected{% endif %}>Uit</option>
+        </select>
         <br><br>
 
         <label>奶茶价格 (€):</label>
@@ -684,6 +690,7 @@
                   .filter(Boolean)
                   .join(',');
             const time_interval = document.getElementById('interval_select').value;
+            const show_zsm_option = document.getElementById('show_zsm_select').value;
             const milktea_soldout = document.getElementById('milktea_soldout_select').value;
             const soldout_japans_chicken_bento = document.getElementById('soldout_japans_chicken_bento_select').value;
             const soldout_korean_chicken_bento = document.getElementById('soldout_korean_chicken_bento_select').value;
@@ -773,6 +780,7 @@
                     delivery_end: delivery_end,
                     delivery_postcodes: delivery_postcodes,
                     time_interval: time_interval,
+                    show_zsm_option: show_zsm_option,
                     milktea_soldout: milktea_soldout,
                     soldout_japans_chicken_bento: soldout_japans_chicken_bento,
                     soldout_korean_chicken_bento: soldout_korean_chicken_bento,

--- a/templates/index.html
+++ b/templates/index.html
@@ -4783,6 +4783,7 @@ let pickupCloseTime = '23:59';
 let deliveryOpenTime = '12:00';
 let deliveryCloseTime = '23:59';
 let timeInterval = 15;
+let showZSM = true;
 let pickupAddress = '';
 let allowedPostcodes = [];
 let currentSettings = {};
@@ -5159,10 +5160,12 @@ function checkout() {
         }
     }
 
-    const asapOpt = document.createElement('option');
-    asapOpt.value = 'Z.S.M.';
-    asapOpt.textContent = 'Z.S.M.';
-    select.appendChild(asapOpt);
+    if (showZSM) {
+        const asapOpt = document.createElement('option');
+        asapOpt.value = 'Z.S.M.';
+        asapOpt.textContent = 'Z.S.M.';
+        select.appendChild(asapOpt);
+    }
 
     // 只有营业开始时间还有效，才显示开始时间
     let start = now > open ? now : open;
@@ -5885,6 +5888,7 @@ function updateStatus(settings) {
   const bubbleSection = document.getElementById('bubble');
   pickupAddress = settings.pickup_address || pickupAddress;
   allowedPostcodes = (settings.delivery_postcodes || '').split(',').map(s => s.trim()).filter(Boolean);
+  showZSM = settings.show_zsm_option !== 'false';
 
   if (bubbleSoldOutMsg && bubbleSection) {
     const soldout = settings.milktea_soldout === 'true';

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -4774,6 +4774,7 @@ let pickupCloseTime = '23:59';
 let deliveryOpenTime = '12:00';
 let deliveryCloseTime = '23:59';
 let timeInterval = 15;
+let showZSM = true;
 let pickupAddress = '';
 let allowedPostcodes = [];
 let currentSettings = {};
@@ -5150,10 +5151,12 @@ function checkout() {
         }
     }
 
-    const asapOpt = document.createElement('option');
-    asapOpt.value = 'Z.S.M.';
-    asapOpt.textContent = 'Z.S.M.';
-    select.appendChild(asapOpt);
+    if (showZSM) {
+        const asapOpt = document.createElement('option');
+        asapOpt.value = 'Z.S.M.';
+        asapOpt.textContent = 'Z.S.M.';
+        select.appendChild(asapOpt);
+    }
 
     // 只有营业开始时间还有效，才显示开始时间
     let start = now > open ? now : open;
@@ -5877,6 +5880,7 @@ function updateStatus(settings) {
   const bubbleSection = document.getElementById('bubble');
   pickupAddress = settings.pickup_address || pickupAddress;
   allowedPostcodes = (settings.delivery_postcodes || '').split(',').map(s => s.trim()).filter(Boolean);
+  showZSM = settings.show_zsm_option !== 'false';
 
   if (bubbleSoldOutMsg && bubbleSection) {
     const soldout = settings.milktea_soldout === 'true';


### PR DESCRIPTION
## Summary
- add `show_zsm_option` setting with default value
- expose new toggle on dashboard to hide/show Z.S.M. choice
- send new setting value when saving dashboard
- adjust index pages to respect the setting when populating time dropdowns

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687caa77d3388333a47e09d4c351d62a