### PR TITLE
Add Korean Beef Bento

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,6 +524,7 @@ with app.app_context():
         "price_chicken_crispy_rice_sandwich": "7",
         "soldout_japans_chicken_bento": "false",
         "soldout_korean_chicken_bento": "false",
+        "soldout_korean_beef_bento": "false",
         "soldout_meatlover_bento": "false",
         "soldout_zalm_lover_bento": "false",
         "soldout_ebi_lover_bento": "false",
@@ -1092,6 +1093,7 @@ def dashboard():
         price_chicken_crispy_rice_sandwich=get_value('price_chicken_crispy_rice_sandwich', '7'),
         soldout_japans_chicken_bento=get_value('soldout_japans_chicken_bento', 'false'),
         soldout_korean_chicken_bento=get_value('soldout_korean_chicken_bento', 'false'),
+        soldout_korean_beef_bento=get_value('soldout_korean_beef_bento', 'false'),
         soldout_meatlover_bento=get_value('soldout_meatlover_bento', 'false'),
         soldout_zalm_lover_bento=get_value('soldout_zalm_lover_bento', 'false'),
         soldout_ebi_lover_bento=get_value('soldout_ebi_lover_bento', 'false'),
@@ -1192,6 +1194,7 @@ def update_setting():
     milktea_soldout_val = data.get('milktea_soldout', 'false')
     soldout_japans_chicken_bento_val = data.get('soldout_japans_chicken_bento', 'false')
     soldout_korean_chicken_bento_val = data.get('soldout_korean_chicken_bento', 'false')
+    soldout_korean_beef_bento_val = data.get('soldout_korean_beef_bento', 'false')
     soldout_meatlover_bento_val = data.get('soldout_meatlover_bento', 'false')
     soldout_zalm_lover_bento_val = data.get('soldout_zalm_lover_bento', 'false')
     soldout_ebi_lover_bento_val = data.get('soldout_ebi_lover_bento', 'false')
@@ -1279,6 +1282,7 @@ def update_setting():
         ('milktea_soldout', milktea_soldout_val),
         ('soldout_japans_chicken_bento', soldout_japans_chicken_bento_val),
         ('soldout_korean_chicken_bento', soldout_korean_chicken_bento_val),
+        ('soldout_korean_beef_bento', soldout_korean_beef_bento_val),
         ('soldout_meatlover_bento', soldout_meatlover_bento_val),
         ('soldout_zalm_lover_bento', soldout_zalm_lover_bento_val),
         ('soldout_ebi_lover_bento', soldout_ebi_lover_bento_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -113,6 +113,11 @@
             <option value="false" {% if soldout_korean_chicken_bento != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_korean_chicken_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+        <label>Korean Beef Bento:</label>
+        <select id="soldout_korean_beef_bento_select">
+            <option value="false" {% if soldout_korean_beef_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_korean_beef_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <label>Meatlover Bento:</label>
         <select id="soldout_meatlover_bento_select">
             <option value="false" {% if soldout_meatlover_bento != 'true' %}selected{% endif %}>Open</option>
@@ -694,6 +699,7 @@
             const milktea_soldout = document.getElementById('milktea_soldout_select').value;
             const soldout_japans_chicken_bento = document.getElementById('soldout_japans_chicken_bento_select').value;
             const soldout_korean_chicken_bento = document.getElementById('soldout_korean_chicken_bento_select').value;
+            const soldout_korean_beef_bento = document.getElementById('soldout_korean_beef_bento_select').value;
             const soldout_meatlover_bento = document.getElementById('soldout_meatlover_bento_select').value;
             const soldout_zalm_lover_bento = document.getElementById('soldout_zalm_lover_bento_select').value;
             const soldout_ebi_lover_bento = document.getElementById('soldout_ebi_lover_bento_select').value;
@@ -784,6 +790,7 @@
                     milktea_soldout: milktea_soldout,
                     soldout_japans_chicken_bento: soldout_japans_chicken_bento,
                     soldout_korean_chicken_bento: soldout_korean_chicken_bento,
+                    soldout_korean_beef_bento: soldout_korean_beef_bento,
                     soldout_meatlover_bento: soldout_meatlover_bento,
                     soldout_zalm_lover_bento: soldout_zalm_lover_bento,
                     soldout_ebi_lover_bento: soldout_ebi_lover_bento,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2140,6 +2140,23 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Korean Beef Bento -->
+<div class="menu-row menu-item" data-name="Korean Beef Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Korean Beef Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Korean Beef Bento</h3>
+<p>€ 25.00</p>
+<p id="soldoutKoreanBeefBento" class="sold-out-msg hidden">Uitverkocht!</p>
+<div class="qty-box">
+<label for="koreanBeefBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="koreanBeefBentoCount" type="button">-</button>
+<select id="koreanBeefBentoCount" name="koreanBeefBentoCount"></select>
+<button class="qty-plus add-button" data-target="koreanBeefBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Meatlover Bento -->
 <!-- Meatlover Bento -->
 <div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">
@@ -3599,6 +3616,7 @@ let xbentoSetControls;
 const soldoutMap = {
   "Japans Chicken Bento": "soldout_japans_chicken_bento",
   "Korean Chicken Bento": "soldout_korean_chicken_bento",
+  "Korean Beef Bento": "soldout_korean_beef_bento",
   "Meatlover Bento": "soldout_meatlover_bento",
   "Zalm Lover Bento": "soldout_zalm_lover_bento",
   "Ebi Lover Bento": "soldout_ebi_lover_bento",
@@ -6033,6 +6051,7 @@ function updateStatus(settings) {
   const bentoConfig = [
     {name: 'Japans Chicken Bento', key: 'soldout_japans_chicken_bento', qty: 'japansChickenBentoCount', msg: 'soldoutJapansChickenBento'},
     {name: 'Korean Chicken Bento', key: 'soldout_korean_chicken_bento', qty: 'koreanChickenBentoCount', msg: 'soldoutKoreanChickenBento'},
+    {name: 'Korean Beef Bento', key: 'soldout_korean_beef_bento', qty: 'koreanBeefBentoCount', msg: 'soldoutKoreanBeefBento'},
     {name: 'Meatlover Bento', key: 'soldout_meatlover_bento', qty: 'meatloverBentoCount', msg: 'soldoutMeatloverBento'},
     {name: 'Zalm Lover Bento', key: 'soldout_zalm_lover_bento', qty: 'zalmLoverBentoCount', msg: 'soldoutZalmLoverBento'},
     {name: 'Ebi Lover Bento', key: 'soldout_ebi_lover_bento', qty: 'ebiLoverBentoCount', msg: 'soldoutEbiLoverBento'},

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -2131,6 +2131,23 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Korean Beef Bento -->
+<div class="menu-row menu-item" data-name="Korean Beef Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Korean Beef Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Korean Beef Bento</h3>
+<p>€ 25.00</p>
+<p id="soldoutKoreanBeefBento" class="sold-out-msg hidden">Sold Out!</p>
+<div class="qty-box">
+<label for="koreanBeefBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="koreanBeefBentoCount" type="button">-</button>
+<select id="koreanBeefBentoCount" name="koreanBeefBentoCount"></select>
+<button class="qty-plus add-button" data-target="koreanBeefBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Meatlover Bento -->
 <!-- Meatlover Bento -->
 <div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">
@@ -3590,6 +3607,7 @@ let xbentoSetControls;
 const soldoutMap = {
   "Japans Chicken Bento": "soldout_japans_chicken_bento",
   "Korean Chicken Bento": "soldout_korean_chicken_bento",
+  "Korean Beef Bento": "soldout_korean_beef_bento",
   "Meatlover Bento": "soldout_meatlover_bento",
   "Salmon Lover Bento": "soldout_zalm_lover_bento",
   "Ebi Lover Bento": "soldout_ebi_lover_bento",
@@ -6025,6 +6043,7 @@ function updateStatus(settings) {
   const bentoConfig = [
     {name: 'Japans Chicken Bento', key: 'soldout_japans_chicken_bento', qty: 'japansChickenBentoCount', msg: 'soldoutJapansChickenBento'},
     {name: 'Korean Chicken Bento', key: 'soldout_korean_chicken_bento', qty: 'koreanChickenBentoCount', msg: 'soldoutKoreanChickenBento'},
+    {name: 'Korean Beef Bento', key: 'soldout_korean_beef_bento', qty: 'koreanBeefBentoCount', msg: 'soldoutKoreanBeefBento'},
     {name: 'Meatlover Bento', key: 'soldout_meatlover_bento', qty: 'meatloverBentoCount', msg: 'soldoutMeatloverBento'},
     {name: 'Salmon Lover Bento', key: 'soldout_zalm_lover_bento', qty: 'zalmLoverBentoCount', msg: 'soldoutZalmLoverBento'},
     {name: 'Ebi Lover Bento', key: 'soldout_ebi_lover_bento', qty: 'ebiLoverBentoCount', msg: 'soldoutEbiLoverBento'},

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -84,6 +84,22 @@
 </div>
 </div>
 </div>
+<!-- Korean Beef Bento -->
+<div class="menu-row menu-item" data-name="Korean Beef Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Korean Beef Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Korean Beef Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="koreanBeefBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="koreanBeefBentoCount" type="button">-</button>
+<select id="koreanBeefBentoCount" name="koreanBeefBentoCount"></select>
+<button class="qty-plus add-button" data-target="koreanBeefBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Meatlover Bento -->
 <!-- Meatlover Bento -->
 <div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">


### PR DESCRIPTION
## Summary
- include Korean Beef Bento in menu templates
- track soldout state via dashboard and app settings

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ccb365f1483339972fc1c6efbc7f1