### PR TITLE
Add sauce options for Pokebowls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -372,6 +372,11 @@
   width: 100%;
   max-width: 170px;
 }
+.pokebowl-sauces select {
+  width: 100%;
+  max-width: 170px;
+  margin-top: 4px;
+}
   
   .menu-item button,
   .menu-item label {
@@ -2556,6 +2561,7 @@ input:focus, select:focus, textarea:focus {
           <select id="zalmBowlQty" name="zalmBowlQty"></select>
           <button class="qty-plus add-button" data-target="zalmBowlQty" type="button">+</button>
         </div>
+        <div id="zalmBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
     <div class="menu-row menu-item" data-name="Tuna Bowl" data-price="15" data-packaging="0.2">
@@ -2572,6 +2578,7 @@ input:focus, select:focus, textarea:focus {
           <select id="tunaBowlQty" name="tunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="tunaBowlQty" type="button">+</button>
         </div>
+        <div id="tunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2589,6 +2596,7 @@ input:focus, select:focus, textarea:focus {
           <select id="ebiFryBowlQty" name="ebiFryBowlQty"></select>
           <button class="qty-plus add-button" data-target="ebiFryBowlQty" type="button">+</button>
         </div>
+        <div id="ebiFryBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2606,6 +2614,7 @@ input:focus, select:focus, textarea:focus {
           <select id="chickenKaraageBowlQty" name="chickenKaraageBowlQty"></select>
           <button class="qty-plus add-button" data-target="chickenKaraageBowlQty" type="button">+</button>
         </div>
+        <div id="chickenKaraageBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2623,6 +2632,7 @@ input:focus, select:focus, textarea:focus {
           <select id="spicyChickenBowlQty" name="spicyChickenBowlQty"></select>
           <button class="qty-plus add-button" data-target="spicyChickenBowlQty" type="button">+</button>
         </div>
+        <div id="spicyChickenBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2640,6 +2650,7 @@ input:focus, select:focus, textarea:focus {
           <select id="teriyakiChickenBowlQty" name="teriyakiChickenBowlQty"></select>
           <button class="qty-plus add-button" data-target="teriyakiChickenBowlQty" type="button">+</button>
         </div>
+        <div id="teriyakiChickenBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2657,6 +2668,7 @@ input:focus, select:focus, textarea:focus {
           <select id="teriyakiBeefBowlQty" name="teriyakiBeefBowlQty"></select>
           <button class="qty-plus add-button" data-target="teriyakiBeefBowlQty" type="button">+</button>
         </div>
+        <div id="teriyakiBeefBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2674,6 +2686,7 @@ input:focus, select:focus, textarea:focus {
           <select id="californiaBowlQty" name="californiaBowlQty"></select>
           <button class="qty-plus add-button" data-target="californiaBowlQty" type="button">+</button>
         </div>
+        <div id="californiaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2693,6 +2706,7 @@ input:focus, select:focus, textarea:focus {
           <select id="unagiBowlQty" name="unagiBowlQty"></select>
           <button class="qty-plus add-button" data-target="unagiBowlQty" type="button">+</button>
         </div>
+        <div id="unagiBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2710,6 +2724,7 @@ input:focus, select:focus, textarea:focus {
           <select id="vegaBowlQty" name="vegaBowlQty"></select>
           <button class="qty-plus add-button" data-target="vegaBowlQty" type="button">+</button>
         </div>
+        <div id="vegaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2727,6 +2742,7 @@ input:focus, select:focus, textarea:focus {
           <select id="meatloverBowlQty" name="meatloverBowlQty"></select>
           <button class="qty-plus add-button" data-target="meatloverBowlQty" type="button">+</button>
         </div>
+        <div id="meatloverBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2744,6 +2760,7 @@ input:focus, select:focus, textarea:focus {
           <select id="rainbowBowlQty" name="rainbowBowlQty"></select>
           <button class="qty-plus add-button" data-target="rainbowBowlQty" type="button">+</button>
         </div>
+        <div id="rainbowBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2761,6 +2778,7 @@ input:focus, select:focus, textarea:focus {
           <select id="spicyTunaBowlQty" name="spicyTunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="spicyTunaBowlQty" type="button">+</button>
         </div>
+        <div id="spicyTunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2778,6 +2796,7 @@ input:focus, select:focus, textarea:focus {
           <select id="flamedZalmBowlQty" name="flamedZalmBowlQty"></select>
           <button class="qty-plus add-button" data-target="flamedZalmBowlQty" type="button">+</button>
         </div>
+        <div id="flamedZalmBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2795,6 +2814,7 @@ input:focus, select:focus, textarea:focus {
           <select id="flamedTunaBowlQty" name="flamedTunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="flamedTunaBowlQty" type="button">+</button>
         </div>
+        <div id="flamedTunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -3608,6 +3628,8 @@ const xbowlMains = [
 ];
 const xbowlToppings=['geen','Komkommer','Avocado','Sojabonen','Mais','Zeewiersalade','Masago','Inari','Tamago'];
 const XBOWL_TOPPING_PRICE=1.5;
+const SAUCE_OPTIONS=['Geen','Japans mayo','Spicy mayo','Unagi saus','Spicy teriyaki saus','Korean chili saus','Cury mayo','Japans chili saus','Soy saus','Truffel mayo','Wasabi mayo'];
+const POKEBOWL_IDS=['zalmBowlQty','tunaBowlQty','ebiFryBowlQty','chickenKaraageBowlQty','spicyChickenBowlQty','teriyakiChickenBowlQty','teriyakiBeefBowlQty','californiaBowlQty','unagiBowlQty','vegaBowlQty','meatloverBowlQty','rainbowBowlQty','spicyTunaBowlQty','flamedZalmBowlQty','flamedTunaBowlQty'];
 let currentXBowlName = '';
 let currentPackaging = 0;
 let currentSubtotal = 0;
@@ -4178,6 +4200,37 @@ function setDragonQty() {
   setQty('Dragon Roll Omakase', price, qty, DEFAULT_PACKAGING_FEE, prefs);
 }
 
+function updatePokebowlSauces(id,name){
+  const qty=parseInt(document.getElementById(id).value||0);
+  const container=document.getElementById(id+'Sauces');
+  if(!container) return;
+  container.innerHTML='';
+  const existing=(cart[name]&&cart[name].prefs)||[];
+  for(let i=1;i<=qty;i++){
+    const sel=document.createElement('select');
+    SAUCE_OPTIONS.forEach(opt=>{const o=document.createElement('option');o.value=opt;o.textContent=opt;sel.appendChild(o);});
+    sel.value=existing[i-1]||'Geen';
+    sel.dataset.index=i;
+    sel.addEventListener('change',()=>setPokebowlQty(id,name));
+    container.appendChild(sel);
+  }
+  setPokebowlQty(id,name);
+}
+
+function setPokebowlQty(id,name){
+  const sel=document.getElementById(id);
+  const qty=parseInt(sel.value||0);
+  const pack=parseFloat(sel.closest('.menu-item').dataset.packaging||DEFAULT_PACKAGING_FEE);
+  const price=parseFloat(sel.closest('.menu-item').dataset.price||0);
+  const container=document.getElementById(id+'Sauces');
+  const prefs=[];
+  for(let i=1;i<=qty;i++){
+    const s=container.querySelector(`select[data-index="${i}"]`);
+    prefs.push(s?s.value:'Geen');
+  }
+  setQty(name,price,qty,pack,prefs);
+}
+
 function getXBowlSelections(){
   const baseSel=document.getElementById('xBowlBase');
   const baseOpt=baseSel?baseSel.selectedOptions[0]:null;
@@ -4717,6 +4770,9 @@ document.addEventListener('DOMContentLoaded', () => {
       sel.addEventListener('change', () => changeOmakaseQty(0));
     } else if (name === 'Dragon Roll Omakase') {
       sel.addEventListener('change', () => changeDragonQty(0));
+    } else if (POKEBOWL_IDS.includes(sel.id)) {
+      sel.addEventListener('change', () => updatePokebowlSauces(sel.id, name));
+      updatePokebowlSauces(sel.id, name);
     } else {
       sel.addEventListener('change', () => {
         setQty(name, price, parseInt(sel.value), pack);
@@ -4737,6 +4793,8 @@ document.addEventListener('DOMContentLoaded', () => {
         changeOmakaseQty(0);
       } else if (parent.dataset.name === 'Dragon Roll Omakase') {
         changeDragonQty(0);
+      } else if (POKEBOWL_IDS.includes(sel.id)) {
+        updatePokebowlSauces(sel.id, parent.dataset.name);
       } else {
         setQty(parent.dataset.name, parseFloat(parent.dataset.price), val, pack);
       }
@@ -4756,6 +4814,8 @@ document.addEventListener('DOMContentLoaded', () => {
         changeOmakaseQty(0);
       } else if (parent.dataset.name === 'Dragon Roll Omakase') {
         changeDragonQty(0);
+      } else if (POKEBOWL_IDS.includes(sel.id)) {
+        updatePokebowlSauces(sel.id, parent.dataset.name);
       } else {
         setQty(parent.dataset.name, parseFloat(parent.dataset.price), val, pack);
       }

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -482,6 +482,7 @@
           <select id="zalmBowlQty" name="zalmBowlQty"></select>
           <button class="qty-plus add-button" data-target="zalmBowlQty" type="button">+</button>
         </div>
+        <div id="zalmBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
     <div class="menu-row menu-item" data-name="Tuna Bowl" data-price="15" data-packaging="0.2">
@@ -497,6 +498,7 @@
           <select id="tunaBowlQty" name="tunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="tunaBowlQty" type="button">+</button>
         </div>
+        <div id="tunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -513,6 +515,7 @@
           <select id="ebiFryBowlQty" name="ebiFryBowlQty"></select>
           <button class="qty-plus add-button" data-target="ebiFryBowlQty" type="button">+</button>
         </div>
+        <div id="ebiFryBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -529,6 +532,7 @@
           <select id="chickenKaraageBowlQty" name="chickenKaraageBowlQty"></select>
           <button class="qty-plus add-button" data-target="chickenKaraageBowlQty" type="button">+</button>
         </div>
+        <div id="chickenKaraageBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -545,6 +549,7 @@
           <select id="spicyChickenBowlQty" name="spicyChickenBowlQty"></select>
           <button class="qty-plus add-button" data-target="spicyChickenBowlQty" type="button">+</button>
         </div>
+        <div id="spicyChickenBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -561,6 +566,7 @@
           <select id="teriyakiChickenBowlQty" name="teriyakiChickenBowlQty"></select>
           <button class="qty-plus add-button" data-target="teriyakiChickenBowlQty" type="button">+</button>
         </div>
+        <div id="teriyakiChickenBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -577,6 +583,7 @@
           <select id="teriyakiBeefBowlQty" name="teriyakiBeefBowlQty"></select>
           <button class="qty-plus add-button" data-target="teriyakiBeefBowlQty" type="button">+</button>
         </div>
+        <div id="teriyakiBeefBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -593,6 +600,7 @@
           <select id="californiaBowlQty" name="californiaBowlQty"></select>
           <button class="qty-plus add-button" data-target="californiaBowlQty" type="button">+</button>
         </div>
+        <div id="californiaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -609,6 +617,7 @@
           <select id="vegaBowlQty" name="vegaBowlQty"></select>
           <button class="qty-plus add-button" data-target="vegaBowlQty" type="button">+</button>
         </div>
+        <div id="vegaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -625,6 +634,7 @@
           <select id="meatloverBowlQty" name="meatloverBowlQty"></select>
           <button class="qty-plus add-button" data-target="meatloverBowlQty" type="button">+</button>
         </div>
+        <div id="meatloverBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -641,6 +651,7 @@
           <select id="rainbowBowlQty" name="rainbowBowlQty"></select>
           <button class="qty-plus add-button" data-target="rainbowBowlQty" type="button">+</button>
         </div>
+        <div id="rainbowBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -657,6 +668,7 @@
           <select id="spicyTunaBowlQty" name="spicyTunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="spicyTunaBowlQty" type="button">+</button>
         </div>
+        <div id="spicyTunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -673,6 +685,7 @@
           <select id="flamedZalmBowlQty" name="flamedZalmBowlQty"></select>
           <button class="qty-plus add-button" data-target="flamedZalmBowlQty" type="button">+</button>
         </div>
+        <div id="flamedZalmBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -689,6 +702,7 @@
           <select id="flamedTunaBowlQty" name="flamedTunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="flamedTunaBowlQty" type="button">+</button>
         </div>
+        <div id="flamedTunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -142,6 +142,11 @@
     width: 100%;
     max-width: 160px;
   }
+  .pokebowl-sauces select {
+    width: 100%;
+    max-width: 160px;
+    margin-top: 4px;
+  }
   .menu-item button {
     width: 2.2rem;
     height: 2.2rem;
@@ -792,6 +797,8 @@ const xbowlMains=[
 ];
 const xbowlToppings=['geen','Komkommer','Avocado','Sojabonen','Mais','Zeewiersalade','Masago','Inari','Tamago'];
 const XBOWL_TOPPING_PRICE=1.5;
+const SAUCE_OPTIONS=['Geen','Japans mayo','Spicy mayo','Unagi saus','Spicy teriyaki saus','Korean chili saus','Cury mayo','Japans chili saus','Soy saus','Truffel mayo','Wasabi mayo'];
+const POKEBOWL_IDS=['zalmBowlQty','tunaBowlQty','ebiFryBowlQty','chickenKaraageBowlQty','spicyChickenBowlQty','teriyakiChickenBowlQty','teriyakiBeefBowlQty','californiaBowlQty','vegaBowlQty','meatloverBowlQty','rainbowBowlQty','spicyTunaBowlQty','flamedZalmBowlQty','flamedTunaBowlQty'];
 let currentXBowlName="";
 
 function getOptionPrice(cat,name){
@@ -1092,6 +1099,37 @@ function setDragonQty(){
   setQty('Dragon Roll Omakase',price,qty,0.2,prefs);
 }
 
+function updatePokebowlSauces(id,name){
+  const qty=parseInt(document.getElementById(id).value||0);
+  const container=document.getElementById(id+'Sauces');
+  if(!container) return;
+  container.innerHTML='';
+  const existing=(cart[name]&&cart[name].prefs)||[];
+  for(let i=1;i<=qty;i++){
+    const sel=document.createElement('select');
+    SAUCE_OPTIONS.forEach(opt=>{const o=document.createElement('option');o.value=opt;o.textContent=opt;sel.appendChild(o);});
+    sel.value=existing[i-1]||'Geen';
+    sel.dataset.index=i;
+    sel.addEventListener('change',()=>setPokebowlQty(id,name));
+    container.appendChild(sel);
+  }
+  setPokebowlQty(id,name);
+}
+
+function setPokebowlQty(id,name){
+  const sel=document.getElementById(id);
+  const qty=parseInt(sel.value||0);
+  const pack=parseFloat(sel.closest('.menu-item').dataset.packaging||0);
+  const price=parseFloat(sel.closest('.menu-item').dataset.price||0);
+  const container=document.getElementById(id+'Sauces');
+  const prefs=[];
+  for(let i=1;i<=qty;i++){
+    const s=container.querySelector(`select[data-index="${i}"]`);
+    prefs.push(s?s.value:'Geen');
+  }
+  setQty(name,price,qty,pack,prefs);
+}
+
 function isRamenValid(code){
   return document.getElementById(code+'Base').value && document.getElementById(code+'Smaak').value;
 }
@@ -1238,6 +1276,9 @@ document.addEventListener('DOMContentLoaded',()=>{
         sel.addEventListener('change',()=>changeOmakaseQty(0));
       } else if(name==='Dragon Roll Omakase'){
         sel.addEventListener('change',()=>changeDragonQty(0));
+      } else if(POKEBOWL_IDS.includes(sel.id)){
+        sel.addEventListener('change',()=>updatePokebowlSauces(sel.id,name));
+        updatePokebowlSauces(sel.id,name);
       } else {
         sel.addEventListener('change',()=>{ setQty(name,price,parseInt(sel.value),pack); });
       }
@@ -1288,6 +1329,8 @@ document.addEventListener('DOMContentLoaded',()=>{
         changeOmakaseQty(0);
       } else if(parent.dataset.name==='Dragon Roll Omakase'){
         changeDragonQty(0);
+      } else if(POKEBOWL_IDS.includes(sel.id)){
+        updatePokebowlSauces(sel.id,parent.dataset.name);
       } else {
         setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0));
       }
@@ -1305,6 +1348,8 @@ document.addEventListener('DOMContentLoaded',()=>{
         changeOmakaseQty(0);
       } else if(parent.dataset.name==='Dragon Roll Omakase'){
         changeDragonQty(0);
+      } else if(POKEBOWL_IDS.includes(sel.id)){
+        updatePokebowlSauces(sel.id,parent.dataset.name);
       } else {
         setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0));
       }


### PR DESCRIPTION
## Summary
- add sauce dropdown containers for Pokebowls
- style sauce selectors
- implement sauce selection logic in JS for web and POS pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cee9fa96883339923aae84bc7a295