### PR TITLE
Fix Pokebowl sauce selection on English page

### DIFF
--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -372,6 +372,11 @@
   width: 100%;
   max-width: 170px;
 }
+.pokebowl-sauces select {
+  width: 100%;
+  max-width: 170px;
+  margin-top: 4px;
+}
   
   .menu-item button,
   .menu-item label {
@@ -2546,6 +2551,7 @@ input:focus, select:focus, textarea:focus {
           <select id="zalmBowlQty" name="zalmBowlQty"></select>
           <button class="qty-plus add-button" data-target="zalmBowlQty" type="button">+</button>
         </div>
+        <div id="zalmBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
     <div class="menu-row menu-item" data-name="Tuna Bowl" data-price="15" data-packaging="0.2">
@@ -2562,6 +2568,7 @@ input:focus, select:focus, textarea:focus {
           <select id="tunaBowlQty" name="tunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="tunaBowlQty" type="button">+</button>
         </div>
+        <div id="tunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2579,6 +2586,7 @@ input:focus, select:focus, textarea:focus {
           <select id="ebiFryBowlQty" name="ebiFryBowlQty"></select>
           <button class="qty-plus add-button" data-target="ebiFryBowlQty" type="button">+</button>
         </div>
+        <div id="ebiFryBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2596,6 +2604,7 @@ input:focus, select:focus, textarea:focus {
           <select id="chickenKaraageBowlQty" name="chickenKaraageBowlQty"></select>
           <button class="qty-plus add-button" data-target="chickenKaraageBowlQty" type="button">+</button>
         </div>
+        <div id="chickenKaraageBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2613,6 +2622,7 @@ input:focus, select:focus, textarea:focus {
           <select id="spicyChickenBowlQty" name="spicyChickenBowlQty"></select>
           <button class="qty-plus add-button" data-target="spicyChickenBowlQty" type="button">+</button>
         </div>
+        <div id="spicyChickenBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2630,6 +2640,7 @@ input:focus, select:focus, textarea:focus {
           <select id="teriyakiChickenBowlQty" name="teriyakiChickenBowlQty"></select>
           <button class="qty-plus add-button" data-target="teriyakiChickenBowlQty" type="button">+</button>
         </div>
+        <div id="teriyakiChickenBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2647,6 +2658,7 @@ input:focus, select:focus, textarea:focus {
           <select id="teriyakiBeefBowlQty" name="teriyakiBeefBowlQty"></select>
           <button class="qty-plus add-button" data-target="teriyakiBeefBowlQty" type="button">+</button>
         </div>
+        <div id="teriyakiBeefBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2664,6 +2676,7 @@ input:focus, select:focus, textarea:focus {
           <select id="californiaBowlQty" name="californiaBowlQty"></select>
           <button class="qty-plus add-button" data-target="californiaBowlQty" type="button">+</button>
         </div>
+        <div id="californiaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2683,6 +2696,7 @@ input:focus, select:focus, textarea:focus {
           <select id="unagiBowlQty" name="unagiBowlQty"></select>
           <button class="qty-plus add-button" data-target="unagiBowlQty" type="button">+</button>
         </div>
+        <div id="unagiBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2700,6 +2714,7 @@ input:focus, select:focus, textarea:focus {
           <select id="vegaBowlQty" name="vegaBowlQty"></select>
           <button class="qty-plus add-button" data-target="vegaBowlQty" type="button">+</button>
         </div>
+        <div id="vegaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2717,6 +2732,7 @@ input:focus, select:focus, textarea:focus {
           <select id="meatloverBowlQty" name="meatloverBowlQty"></select>
           <button class="qty-plus add-button" data-target="meatloverBowlQty" type="button">+</button>
         </div>
+        <div id="meatloverBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2734,6 +2750,7 @@ input:focus, select:focus, textarea:focus {
           <select id="rainbowBowlQty" name="rainbowBowlQty"></select>
           <button class="qty-plus add-button" data-target="rainbowBowlQty" type="button">+</button>
         </div>
+        <div id="rainbowBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2751,6 +2768,7 @@ input:focus, select:focus, textarea:focus {
           <select id="spicyTunaBowlQty" name="spicyTunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="spicyTunaBowlQty" type="button">+</button>
         </div>
+        <div id="spicyTunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2768,6 +2786,7 @@ input:focus, select:focus, textarea:focus {
           <select id="flamedZalmBowlQty" name="flamedZalmBowlQty"></select>
           <button class="qty-plus add-button" data-target="flamedZalmBowlQty" type="button">+</button>
         </div>
+        <div id="flamedZalmBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -2785,6 +2804,7 @@ input:focus, select:focus, textarea:focus {
           <select id="flamedTunaBowlQty" name="flamedTunaBowlQty"></select>
           <button class="qty-plus add-button" data-target="flamedTunaBowlQty" type="button">+</button>
         </div>
+        <div id="flamedTunaBowlQtySauces" class="pokebowl-sauces"></div>
       </div>
     </div>
 
@@ -3598,6 +3618,8 @@ const xbowlMains = [
 ];
 const xbowlToppings=['none','Cucumber','Avocado','Soybeans','Corn','Seaweed salad','Masago','Inari','Tamago'];
 const XBOWL_TOPPING_PRICE=1.5;
+const SAUCE_OPTIONS=['None','Japanese mayo','Spicy mayo','Unagi sauce','Spicy teriyaki sauce','Korean chili sauce','Curry mayo','Japanese chili sauce','Soy sauce','Truffle mayo','Wasabi mayo'];
+const POKEBOWL_IDS=['zalmBowlQty','tunaBowlQty','ebiFryBowlQty','chickenKaraageBowlQty','spicyChickenBowlQty','teriyakiChickenBowlQty','teriyakiBeefBowlQty','californiaBowlQty','unagiBowlQty','vegaBowlQty','meatloverBowlQty','rainbowBowlQty','spicyTunaBowlQty','flamedZalmBowlQty','flamedTunaBowlQty'];
 let currentXBowlName = '';
 let currentPackaging = 0;
 let currentSubtotal = 0;
@@ -4168,6 +4190,37 @@ function setDragonQty() {
   setQty('Dragon Roll Omakase', price, qty, DEFAULT_PACKAGING_FEE, prefs);
 }
 
+function updatePokebowlSauces(id,name){
+  const qty=parseInt(document.getElementById(id).value||0);
+  const container=document.getElementById(id+'Sauces');
+  if(!container) return;
+  container.innerHTML='';
+  const existing=(cart[name]&&cart[name].prefs)||[];
+  for(let i=1;i<=qty;i++){
+    const sel=document.createElement('select');
+    SAUCE_OPTIONS.forEach(opt=>{const o=document.createElement('option');o.value=opt;o.textContent=opt;sel.appendChild(o);});
+    sel.value=existing[i-1]||'None';
+    sel.dataset.index=i;
+    sel.addEventListener('change',()=>setPokebowlQty(id,name));
+    container.appendChild(sel);
+  }
+  setPokebowlQty(id,name);
+}
+
+function setPokebowlQty(id,name){
+  const sel=document.getElementById(id);
+  const qty=parseInt(sel.value||0);
+  const pack=parseFloat(sel.closest('.menu-item').dataset.packaging||DEFAULT_PACKAGING_FEE);
+  const price=parseFloat(sel.closest('.menu-item').dataset.price||0);
+  const container=document.getElementById(id+'Sauces');
+  const prefs=[];
+  for(let i=1;i<=qty;i++){
+    const s=container.querySelector(`select[data-index="${i}"]`);
+    prefs.push(s?s.value:'None');
+  }
+  setQty(name,price,qty,pack,prefs);
+}
+
 function getXBowlSelections(){
   const baseSel=document.getElementById('xBowlBase');
   const baseOpt=baseSel?baseSel.selectedOptions[0]:null;
@@ -4707,6 +4760,9 @@ document.addEventListener('DOMContentLoaded', () => {
       sel.addEventListener('change', () => changeOmakaseQty(0));
     } else if (name === 'Dragon Roll Omakase') {
       sel.addEventListener('change', () => changeDragonQty(0));
+    } else if (POKEBOWL_IDS.includes(sel.id)) {
+      sel.addEventListener('change', () => updatePokebowlSauces(sel.id, name));
+      updatePokebowlSauces(sel.id, name);
     } else {
       sel.addEventListener('change', () => {
         setQty(name, price, parseInt(sel.value), pack);
@@ -4727,6 +4783,8 @@ document.addEventListener('DOMContentLoaded', () => {
         changeOmakaseQty(0);
       } else if (parent.dataset.name === 'Dragon Roll Omakase') {
         changeDragonQty(0);
+      } else if (POKEBOWL_IDS.includes(sel.id)) {
+        updatePokebowlSauces(sel.id, parent.dataset.name);
       } else {
         setQty(parent.dataset.name, parseFloat(parent.dataset.price), val, pack);
       }
@@ -4746,6 +4804,8 @@ document.addEventListener('DOMContentLoaded', () => {
         changeOmakaseQty(0);
       } else if (parent.dataset.name === 'Dragon Roll Omakase') {
         changeDragonQty(0);
+      } else if (POKEBOWL_IDS.includes(sel.id)) {
+        updatePokebowlSauces(sel.id, parent.dataset.name);
       } else {
         setQty(parent.dataset.name, parseFloat(parent.dataset.price), val, pack);
       }


### PR DESCRIPTION
## Summary
- add missing sauce dropdown containers and styles to `indexEN.html`
- define `SAUCE_OPTIONS` and `POKEBOWL_IDS` for English site
- implement `updatePokebowlSauces` and `setPokebowlQty` functions in English script
- wire up event listeners so Pokebowl selections update correctly

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687d00a049b08333bec60f78e11228a9