### PR TITLE
Add sauce selector for snacks in indexEN

### DIFF
--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -3148,6 +3148,7 @@ input:focus, select:focus, textarea:focus {
 <select id="snackCount" name="snackCount"></select>
 <button class="qty-plus add-button" data-target="snackCount" type="button">+</button>
 </div>
+<div id="snackCountSauces" class="pokebowl-sauces"></div>
 </div>
 </img></div>
 <!-- Ebi Fry -->
@@ -3165,6 +3166,7 @@ input:focus, select:focus, textarea:focus {
       <select id="ebiFryCount" name="ebiFryCount"></select>
       <button class="qty-plus add-button" data-target="ebiFryCount" type="button">+</button>
     </div>
+    <div id="ebiFryCountSauces" class="pokebowl-sauces"></div>
   </div>
 </div>
  <div class="menu-row menu-item" data-name="Ebi Croquette" data-packaging="0.2" data-price="5">
@@ -3181,8 +3183,9 @@ input:focus, select:focus, textarea:focus {
       <select id="ebikroketCount" name="ebikroketCount"></select>
       <button class="qty-plus add-button" data-target="ebikroketCount" type="button">+</button>
     </div>
+    <div id="ebikroketCountSauces" class="pokebowl-sauces"></div>
   </div>
-</div> 
+</div>
  
 <!-- Spicy Crispy Chicken -->
 <div class="menu-row menu-item" data-name="Spicy Crispy Chicken – 5 pcs" data-packaging="0.2" data-price="6.5">
@@ -3199,6 +3202,7 @@ input:focus, select:focus, textarea:focus {
       <select id="spicyCrispyChickenCount" name="spicyCrispyChickenCount"></select>
       <button class="qty-plus add-button" data-target="spicyCrispyChickenCount" type="button">+</button>
     </div>
+    <div id="spicyCrispyChickenCountSauces" class="pokebowl-sauces"></div>
   </div>
 </div>
 <div class="menu-row menu-item" data-name="Mini Spring Rolls – 6 pcs" data-packaging="0.2" data-price="3.5">
@@ -3215,8 +3219,9 @@ input:focus, select:focus, textarea:focus {
       <select id="miniLoempiaCount" name="miniLoempiaCount"></select>
       <button class="qty-plus add-button" data-target="miniLoempiaCount" type="button">+</button>
     </div>
+    <div id="miniLoempiaCountSauces" class="pokebowl-sauces"></div>
   </div>
-</div>  
+</div>
 <!-- Chicken Loempia -->
 <div class="menu-row menu-item" data-name="Chicken Spring Rolls – 2 pcs" data-packaging="0.2" data-price="5">
   <div class="menu-img">
@@ -3232,6 +3237,7 @@ input:focus, select:focus, textarea:focus {
       <select id="chickenLoempiaCount" name="chickenLoempiaCount"></select>
       <button class="qty-plus add-button" data-target="chickenLoempiaCount" type="button">+</button>
     </div>
+    <div id="chickenLoempiaCountSauces" class="pokebowl-sauces"></div>
   </div>
 </div>
 <!-- Gyoza -->
@@ -3249,6 +3255,7 @@ input:focus, select:focus, textarea:focus {
       <select id="gyozaCount" name="gyozaCount"></select>
       <button class="qty-plus add-button" data-target="gyozaCount" type="button">+</button>
     </div>
+    <div id="gyozaCountSauces" class="pokebowl-sauces"></div>
   </div>
 </div>
 <!-- Squid Rings -->
@@ -3266,6 +3273,7 @@ input:focus, select:focus, textarea:focus {
       <select id="inktvisRingenCount" name="inktvisRingenCount"></select>
       <button class="qty-plus add-button" data-target="inktvisRingenCount" type="button">+</button>
     </div>
+    <div id="inktvisRingenCountSauces" class="pokebowl-sauces"></div>
   </div>
 </div>
 <!-- Crispy Rijst -->
@@ -3619,7 +3627,7 @@ const xbowlMains = [
 const xbowlToppings=['none','Cucumber','Avocado','Soybeans','Corn','Seaweed salad','Masago','Inari','Tamago'];
 const XBOWL_TOPPING_PRICE=1.5;
 const SAUCE_OPTIONS=['No saus','Japanese mayo','Spicy mayo','Unagi sauce','Spicy teriyaki sauce','Korean chili sauce','Curry mayo','Japanese chili sauce','Soy sauce','Truffle mayo','Wasabi mayo'];
-const POKEBOWL_IDS=['zalmBowlQty','tunaBowlQty','ebiFryBowlQty','chickenKaraageBowlQty','spicyChickenBowlQty','teriyakiChickenBowlQty','teriyakiBeefBowlQty','californiaBowlQty','unagiBowlQty','vegaBowlQty','meatloverBowlQty','rainbowBowlQty','spicyTunaBowlQty','flamedZalmBowlQty','flamedTunaBowlQty'];
+const POKEBOWL_IDS=['zalmBowlQty','tunaBowlQty','ebiFryBowlQty','chickenKaraageBowlQty','spicyChickenBowlQty','teriyakiChickenBowlQty','teriyakiBeefBowlQty','californiaBowlQty','unagiBowlQty','vegaBowlQty','meatloverBowlQty','rainbowBowlQty','spicyTunaBowlQty','flamedZalmBowlQty','flamedTunaBowlQty','snackCount','ebiFryCount','ebikroketCount','spicyCrispyChickenCount','miniLoempiaCount','chickenLoempiaCount','gyozaCount','inktvisRingenCount'];
 let currentXBowlName = '';
 let currentPackaging = 0;
 let currentSubtotal = 0;


### PR DESCRIPTION
## Summary
- replicate Pokebowl sauce picker for snack items on `indexEN.html`
- extend `POKEBOWL_IDS` so snack items use the same logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d1193347c83339c5452eac68b0df7