### PR TITLE
Fix Dutch hours label

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6226,7 +6226,7 @@ function updateStatus(settings) {
   const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
   const todayName = dayNames[new Date().getDay()];
 
-  const hoursText = `Daily ${settings.open_time} - ${settings.close_time}`;
+  const hoursText = `Dagelijks ${settings.open_time} - ${settings.close_time}`;
   let closedText = '';
   if (allClosed) {
     closedText = ', Closed All Week';


### PR DESCRIPTION
## Summary
- update Dutch index to display "Dagelijks" for open hours

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d508339888333a0b2de664a6ec615