### PR TITLE
Fix missing div in Ramen section

### DIFF
--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -2320,7 +2320,7 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </section>
-<!-- Pokebowl Section -->
+<!-- Ramen Section -->
 <section id="Ramen">
 <h2>Ramen</h2>
 <div class="menu-section">
@@ -2328,6 +2328,7 @@ input:focus, select:focus, textarea:focus {
   <div class="menu-row menu-item" data-code="ebi" data-name="Ebi Furai" data-packaging="0.2" data-price="18">
     <div class="menu-img">
       <img alt="Ebi Furai Ramen" src="{{ url_for('static', filename='images/REBI.png') }}"/>
+    </div>
     <div class="menu-content">
       <h3>Ebi Furai</h3>
       <p>€ 18.00</p>


### PR DESCRIPTION
## Summary
- correct the section comment before the Ramen menu
- close the `menu-img` div for "Ebi Furai" so later items render correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687fe2bc52cc83339dcfe52e5ffa151e