### PR TITLE
Add Tuna Bento menu item

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2251,6 +2251,23 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Tuna Bento -->
+<div class="menu-row menu-item" data-name="Tuna Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tuna Bento</h3>
+<p>€ 25.00</p>
+<p id="soldoutTunaBento" class="sold-out-msg hidden">Uitverkocht!</p>
+<div class="qty-box">
+<label for="tunaBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="tunaBentoCount" type="button">-</button>
+<select id="tunaBentoCount" name="tunaBentoCount"></select>
+<button class="qty-plus add-button" data-target="tunaBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
@@ -3694,6 +3711,7 @@ const soldoutMap = {
   "Dimsum Bento": "soldout_dimsum_bento",
   "Lamskotelet Bento": "soldout_lamskotelet_bento",
   "Unagi Bento": "soldout_unagi_bento",
+  "Tuna Bento": "soldout_tuna_bento",
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
   "Salmon Roll Omakase": "soldout_salmon_roll",
@@ -6174,6 +6192,7 @@ function updateStatus(settings) {
     {name: 'Dimsum Bento', key: 'soldout_dimsum_bento', qty: 'dimsumBentoCount', msg: 'soldoutDimsumBento'},
     {name: 'Lamskotelet Bento', key: 'soldout_lamskotelet_bento', qty: 'lamsBentoCount', msg: 'soldoutLamskoteletBento'},
     {name: 'Unagi Bento', key: 'soldout_unagi_bento', qty: 'unagiBentoCount', msg: 'soldoutUnagiBento'},
+    {name: 'Tuna Bento', key: 'soldout_tuna_bento', qty: 'tunaBentoCount', msg: 'soldoutTunaBento'},
     {name: 'Veggie Bento', key: 'soldout_veggie_bento', qty: 'veggieBentoCount', msg: 'soldoutVeggieBento'},
     {name: 'Bento Sushi Omakase', key: 'soldout_sushi_bento', qty: 'sushiBentoCount', msg: 'soldoutSushiBento'},
     {name: 'Xbento', key: 'soldout_xbento', qty: 'xBentoQty', msg: 'soldoutXbento'}

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -2241,6 +2241,23 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Tuna Bento -->
+<div class="menu-row menu-item" data-name="Tuna Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tuna Bento</h3>
+<p>€ 25.00</p>
+<p id="soldoutTunaBento" class="sold-out-msg hidden">Sold Out!</p>
+<div class="qty-box">
+<label for="tunaBentoCount">Quantity</label>
+<button class="qty-minus remove-button" data-target="tunaBentoCount" type="button">-</button>
+<select id="tunaBentoCount" name="tunaBentoCount"></select>
+<button class="qty-plus add-button" data-target="tunaBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
@@ -3685,6 +3702,7 @@ const soldoutMap = {
   "Dimsum Bento": "soldout_dimsum_bento",
   "Lamb Chop Bento": "soldout_lamskotelet_bento",
   "Unagi Bento": "soldout_unagi_bento",
+  "Tuna Bento": "soldout_tuna_bento",
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
   "Salmon Roll Omakase": "soldout_salmon_roll",
@@ -6161,6 +6179,7 @@ function updateStatus(settings) {
     {name: 'Dimsum Bento', key: 'soldout_dimsum_bento', qty: 'dimsumBentoCount', msg: 'soldoutDimsumBento'},
     {name: 'Lamb Chop Bento', key: 'soldout_lamskotelet_bento', qty: 'lamsBentoCount', msg: 'soldoutLamskoteletBento'},
     {name: 'Unagi Bento', key: 'soldout_unagi_bento', qty: 'unagiBentoCount', msg: 'soldoutUnagiBento'},
+    {name: 'Tuna Bento', key: 'soldout_tuna_bento', qty: 'tunaBentoCount', msg: 'soldoutTunaBento'},
     {name: 'Veggie Bento', key: 'soldout_veggie_bento', qty: 'veggieBentoCount', msg: 'soldoutVeggieBento'},
     {name: 'Bento Sushi Omakase', key: 'soldout_sushi_bento', qty: 'sushiBentoCount', msg: 'soldoutSushiBento'},
     {name: 'Xbento', key: 'soldout_xbento', qty: 'xBentoQty', msg: 'soldoutXbento'}

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -213,6 +213,22 @@
 </div>
 </div>
 </div>
+<!-- Tuna Bento -->
+<div class="menu-row menu-item" data-name="Tuna Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tuna Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="tunaBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="tunaBentoCount" type="button">-</button>
+<select id="tunaBentoCount" name="tunaBentoCount"></select>
+<button class="qty-plus add-button" data-target="tunaBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">


### PR DESCRIPTION
## Summary
- add Tuna Bento option to index, English index, and POS menu
- integrate Tuna Bento with soldout logic just like other bento items

## Testing
- `python -m py_compile add_watermark.py app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_687fea14539c8333a1fbbea94c784740