### PR TITLE
Add Ribeye Bento menu item

### DIFF
--- a/app.py
+++ b/app.py
@@ -532,6 +532,8 @@ with app.app_context():
         "soldout_dimsum_bento": "false",
         "soldout_lamskotelet_bento": "false",
         "soldout_unagi_bento": "false",
+        "soldout_tuna_bento": "false",
+        "soldout_ribeye_bento": "false",
         "soldout_veggie_bento": "false",
         "soldout_sushi_bento": "false",
         "soldout_salmon_roll": "false",
@@ -1101,6 +1103,8 @@ def dashboard():
         soldout_dimsum_bento=get_value('soldout_dimsum_bento', 'false'),
         soldout_lamskotelet_bento=get_value('soldout_lamskotelet_bento', 'false'),
         soldout_unagi_bento=get_value('soldout_unagi_bento', 'false'),
+        soldout_tuna_bento=get_value('soldout_tuna_bento', 'false'),
+        soldout_ribeye_bento=get_value('soldout_ribeye_bento', 'false'),
         soldout_veggie_bento=get_value('soldout_veggie_bento', 'false'),
         soldout_sushi_bento=get_value('soldout_sushi_bento', 'false'),
         soldout_salmon_roll=get_value('soldout_salmon_roll', 'false'),
@@ -1202,6 +1206,8 @@ def update_setting():
     soldout_dimsum_bento_val = data.get('soldout_dimsum_bento', 'false')
     soldout_lamskotelet_bento_val = data.get('soldout_lamskotelet_bento', 'false')
     soldout_unagi_bento_val = data.get('soldout_unagi_bento', 'false')
+    soldout_tuna_bento_val = data.get('soldout_tuna_bento', 'false')
+    soldout_ribeye_bento_val = data.get('soldout_ribeye_bento', 'false')
     soldout_veggie_bento_val = data.get('soldout_veggie_bento', 'false')
     soldout_sushi_bento_val = data.get('soldout_sushi_bento', 'false')
     soldout_salmon_roll_val = data.get('soldout_salmon_roll', 'false')
@@ -1290,6 +1296,8 @@ def update_setting():
         ('soldout_dimsum_bento', soldout_dimsum_bento_val),
         ('soldout_lamskotelet_bento', soldout_lamskotelet_bento_val),
         ('soldout_unagi_bento', soldout_unagi_bento_val),
+        ('soldout_tuna_bento', soldout_tuna_bento_val),
+        ('soldout_ribeye_bento', soldout_ribeye_bento_val),
         ('soldout_veggie_bento', soldout_veggie_bento_val),
         ('soldout_sushi_bento', soldout_sushi_bento_val),
         ('soldout_salmon_roll', soldout_salmon_roll_val),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -153,6 +153,16 @@
             <option value="false" {% if soldout_unagi_bento != 'true' %}selected{% endif %}>Open</option>
             <option value="true" {% if soldout_unagi_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
         </select><br>
+        <label>Tuna Bento:</label>
+        <select id="soldout_tuna_bento_select">
+            <option value="false" {% if soldout_tuna_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_tuna_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
+        <label>Ribeye Bento:</label>
+        <select id="soldout_ribeye_bento_select">
+            <option value="false" {% if soldout_ribeye_bento != 'true' %}selected{% endif %}>Open</option>
+            <option value="true" {% if soldout_ribeye_bento == 'true' %}selected{% endif %}>Uitverkocht</option>
+        </select><br>
         <label>Veggie Bento:</label>
         <select id="soldout_veggie_bento_select">
             <option value="false" {% if soldout_veggie_bento != 'true' %}selected{% endif %}>Open</option>
@@ -707,6 +717,8 @@
             const soldout_dimsum_bento = document.getElementById('soldout_dimsum_bento_select').value;
             const soldout_lamskotelet_bento = document.getElementById('soldout_lamskotelet_bento_select').value;
             const soldout_unagi_bento = document.getElementById('soldout_unagi_bento_select').value;
+            const soldout_tuna_bento = document.getElementById('soldout_tuna_bento_select').value;
+            const soldout_ribeye_bento = document.getElementById('soldout_ribeye_bento_select').value;
             const soldout_veggie_bento = document.getElementById('soldout_veggie_bento_select').value;
             const soldout_sushi_bento = document.getElementById('soldout_sushi_bento_select').value;
             const soldout_salmon_roll = document.getElementById('soldout_salmon_roll_select').value;
@@ -798,6 +810,8 @@
                     soldout_dimsum_bento: soldout_dimsum_bento,
                     soldout_lamskotelet_bento: soldout_lamskotelet_bento,
                     soldout_unagi_bento: soldout_unagi_bento,
+                    soldout_tuna_bento: soldout_tuna_bento,
+                    soldout_ribeye_bento: soldout_ribeye_bento,
                     soldout_veggie_bento: soldout_veggie_bento,
                     soldout_sushi_bento: soldout_sushi_bento,
                     soldout_salmon_roll: soldout_salmon_roll,

--- a/templates/index.html
+++ b/templates/index.html
@@ -2251,6 +2251,40 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Tuna Bento -->
+<div class="menu-row menu-item" data-name="Tuna Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tuna Bento</h3>
+<p>€ 25.00</p>
+<p id="soldoutTunaBento" class="sold-out-msg hidden">Uitverkocht!</p>
+<div class="qty-box">
+<label for="tunaBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="tunaBentoCount" type="button">-</button>
+<select id="tunaBentoCount" name="tunaBentoCount"></select>
+<button class="qty-plus add-button" data-target="tunaBentoCount" type="button">+</button>
+</div>
+</div>
+<!-- Ribeye Bento -->
+<div class="menu-row menu-item" data-name="Ribeye Bento" data-packaging="0.2" data-price="30">
+<div class="menu-img">
+<img alt="Ribeye Bento" src="{{ url_for('static', filename='images/RUSU.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ribeye Bento</h3>
+<p>€ 30.00</p>
+<p id="soldoutRibeyeBento" class="sold-out-msg hidden">Uitverkocht!</p>
+<div class="qty-box">
+<label for="ribeyeBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="ribeyeBentoCount" type="button">-</button>
+<select id="ribeyeBentoCount" name="ribeyeBentoCount"></select>
+<button class="qty-plus add-button" data-target="ribeyeBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
@@ -3694,6 +3728,8 @@ const soldoutMap = {
   "Dimsum Bento": "soldout_dimsum_bento",
   "Lamskotelet Bento": "soldout_lamskotelet_bento",
   "Unagi Bento": "soldout_unagi_bento",
+  "Tuna Bento": "soldout_tuna_bento",
+  "Ribeye Bento": "soldout_ribeye_bento",
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
   "Salmon Roll Omakase": "soldout_salmon_roll",
@@ -6174,6 +6210,8 @@ function updateStatus(settings) {
     {name: 'Dimsum Bento', key: 'soldout_dimsum_bento', qty: 'dimsumBentoCount', msg: 'soldoutDimsumBento'},
     {name: 'Lamskotelet Bento', key: 'soldout_lamskotelet_bento', qty: 'lamsBentoCount', msg: 'soldoutLamskoteletBento'},
     {name: 'Unagi Bento', key: 'soldout_unagi_bento', qty: 'unagiBentoCount', msg: 'soldoutUnagiBento'},
+    {name: 'Tuna Bento', key: 'soldout_tuna_bento', qty: 'tunaBentoCount', msg: 'soldoutTunaBento'},
+    {name: 'Ribeye Bento', key: 'soldout_ribeye_bento', qty: 'ribeyeBentoCount', msg: 'soldoutRibeyeBento'},
     {name: 'Veggie Bento', key: 'soldout_veggie_bento', qty: 'veggieBentoCount', msg: 'soldoutVeggieBento'},
     {name: 'Bento Sushi Omakase', key: 'soldout_sushi_bento', qty: 'sushiBentoCount', msg: 'soldoutSushiBento'},
     {name: 'Xbento', key: 'soldout_xbento', qty: 'xBentoQty', msg: 'soldoutXbento'}

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -2241,6 +2241,40 @@ input:focus, select:focus, textarea:focus {
 </div>
 </div>
 </div>
+<!-- Tuna Bento -->
+<div class="menu-row menu-item" data-name="Tuna Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tuna Bento</h3>
+<p>€ 25.00</p>
+<p id="soldoutTunaBento" class="sold-out-msg hidden">Sold Out!</p>
+<div class="qty-box">
+<label for="tunaBentoCount">Quantity</label>
+<button class="qty-minus remove-button" data-target="tunaBentoCount" type="button">-</button>
+<select id="tunaBentoCount" name="tunaBentoCount"></select>
+<button class="qty-plus add-button" data-target="tunaBentoCount" type="button">+</button>
+</div>
+</div>
+<!-- Ribeye Bento -->
+<div class="menu-row menu-item" data-name="Ribeye Bento" data-packaging="0.2" data-price="30">
+<div class="menu-img">
+<img alt="Ribeye Bento" src="{{ url_for('static', filename='images/RUSU.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ribeye Bento</h3>
+<p>€ 30.00</p>
+<p id="soldoutRibeyeBento" class="sold-out-msg hidden">Sold Out!</p>
+<div class="qty-box">
+<label for="ribeyeBentoCount">Quantity</label>
+<button class="qty-minus remove-button" data-target="ribeyeBentoCount" type="button">-</button>
+<select id="ribeyeBentoCount" name="ribeyeBentoCount"></select>
+<button class="qty-plus add-button" data-target="ribeyeBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
@@ -3685,6 +3719,8 @@ const soldoutMap = {
   "Dimsum Bento": "soldout_dimsum_bento",
   "Lamb Chop Bento": "soldout_lamskotelet_bento",
   "Unagi Bento": "soldout_unagi_bento",
+  "Tuna Bento": "soldout_tuna_bento",
+  "Ribeye Bento": "soldout_ribeye_bento",
   "Veggie Bento": "soldout_veggie_bento",
   "Bento Sushi Omakase": "soldout_sushi_bento",
   "Salmon Roll Omakase": "soldout_salmon_roll",
@@ -6161,6 +6197,8 @@ function updateStatus(settings) {
     {name: 'Dimsum Bento', key: 'soldout_dimsum_bento', qty: 'dimsumBentoCount', msg: 'soldoutDimsumBento'},
     {name: 'Lamb Chop Bento', key: 'soldout_lamskotelet_bento', qty: 'lamsBentoCount', msg: 'soldoutLamskoteletBento'},
     {name: 'Unagi Bento', key: 'soldout_unagi_bento', qty: 'unagiBentoCount', msg: 'soldoutUnagiBento'},
+    {name: 'Tuna Bento', key: 'soldout_tuna_bento', qty: 'tunaBentoCount', msg: 'soldoutTunaBento'},
+    {name: 'Ribeye Bento', key: 'soldout_ribeye_bento', qty: 'ribeyeBentoCount', msg: 'soldoutRibeyeBento'},
     {name: 'Veggie Bento', key: 'soldout_veggie_bento', qty: 'veggieBentoCount', msg: 'soldoutVeggieBento'},
     {name: 'Bento Sushi Omakase', key: 'soldout_sushi_bento', qty: 'sushiBentoCount', msg: 'soldoutSushiBento'},
     {name: 'Xbento', key: 'soldout_xbento', qty: 'xBentoQty', msg: 'soldoutXbento'}

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -213,6 +213,38 @@
 </div>
 </div>
 </div>
+<!-- Tuna Bento -->
+<div class="menu-row menu-item" data-name="Tuna Bento" data-packaging="0.2" data-price="25">
+<div class="menu-img">
+<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Tuna Bento</h3>
+<p>€ 25.00</p>
+<div class="qty-box">
+<label for="tunaBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="tunaBentoCount" type="button">-</button>
+<select id="tunaBentoCount" name="tunaBentoCount"></select>
+<button class="qty-plus add-button" data-target="tunaBentoCount" type="button">+</button>
+</div>
+</div>
+<!-- Ribeye Bento -->
+<div class="menu-row menu-item" data-name="Ribeye Bento" data-packaging="0.2" data-price="30">
+<div class="menu-img">
+<img alt="Ribeye Bento" src="{{ url_for('static', filename='images/RUSU.png') }}"/>
+</div>
+<div class="menu-content">
+<h3>Ribeye Bento</h3>
+<p>€ 30.00</p>
+<div class="qty-box">
+<label for="ribeyeBentoCount">Aantal</label>
+<button class="qty-minus remove-button" data-target="ribeyeBentoCount" type="button">-</button>
+<select id="ribeyeBentoCount" name="ribeyeBentoCount"></select>
+<button class="qty-plus add-button" data-target="ribeyeBentoCount" type="button">+</button>
+</div>
+</div>
+</div>
+</div>
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">


### PR DESCRIPTION
## Summary
- include new Ribeye Bento option in Dutch and English menus
- show Ribeye Bento in POS menu
- wire Ribeye Bento into sold‑out logic across templates
- extend dashboard and backend settings for new Tuna and Ribeye Bento flags

## Testing
- `python -m py_compile add_watermark.py app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_687fea14539c8333a1fbbea94c784740