### PR TITLE
Swap order number and tip columns

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1903,12 +1903,12 @@ function formatCurrency(value){
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
-        <td>€${parseFloat(fooi).toFixed(2)}</td>
+        <td>${order.order_number || '-'}</td>
         <td>€${parseFloat(order.totaal).toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${tijdslot || '-'}</td>
         <td>${order.payment_method || ''}</td>
-        <td>${order.order_number || '-'}</td>
+        <td>€${parseFloat(fooi).toFixed(2)}</td>
         <td><button onclick="toggleComplete(this)"
           data-number="${order.order_number}"
           data-name="${order.customer_name || ''}"

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -88,11 +88,11 @@ th:last-child {
        <th>Email</th>
        <th>Items</th>
        <th>Opmerking</th>
-       <th>Fooi</th>
+       <th>Ordernummer</th>
        <th>Totaal</th>
        <th>Adres</th>
        <th>Betaalwijze</th>
-       <th>Ordernummer</th>
+       <th>Fooi</th>
        <th>Acties</th>
       </tr>
     </thead>
@@ -119,7 +119,7 @@ th:last-child {
           </ul>
         </td>
        <td>{{ order.opmerking or '-' }}</td>
-       <td>€{{ '%.2f' % (order.fooi or order.tip or 0) }}</td>
+       <td>{{ order.order_number or '' }}</td>
 
         <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
 
@@ -132,7 +132,7 @@ th:last-child {
           {% else %}-{% endif %}
         </td>
         <td>{{ order.payment_method }}</td>
-        <td>{{ order.order_number or '' }}</td>
+        <td>€{{ '%.2f' % (order.fooi or order.tip or 0) }}</td>
         <td>
           <button onclick="toggleComplete(this)"
             data-number="{{ order.order_number }}"

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1905,11 +1905,11 @@ function formatCurrency(value){
         <td>${order.email || '-'}</td>
         <td><ul>${items}</ul></td>
         <td>${remark || '-'}</td>
-        <td>€${parseFloat(fooi).toFixed(2)}</td>
+        <td>${order.order_number || '-'}</td>
         <td>€${parseFloat(order.totaal).toFixed(2)}</td>
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${order.payment_method || ''}</td>
-        <td>${order.order_number || '-'}</td>
+        <td>€${parseFloat(fooi).toFixed(2)}</td>
         <td><button onclick="toggleComplete(this)"
           data-number="${order.order_number}"
           data-name="${order.customer_name || ''}"


### PR DESCRIPTION
## Summary
- swap positions of `Ordernummer` and `Fooi` columns in the orders table
- update JavaScript row template accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688074104b1c83338ff4840afc3e96e8