### PR TITLE
Fix delivery payload

### DIFF
--- a/app.py
+++ b/app.py
@@ -380,7 +380,8 @@ def send_telegram_to_customer(phone, text):
         return False
 def send_telegram_to_delivery(chat_id, delivery_person, customer_name, order_number,
                                street=None, house_number=None, postcode=None, city=None,
-                               tijdslot=None, phone=None, opmerking=None):
+                               tijdslot=None, phone=None, opmerking=None,
+                               totaal=None, payment_method=None, created_at=None):
     """Send Telegram message to selected delivery person with order info."""
     if not chat_id or not order_number:
         print("⚠️ Ontbrekend chat_id of ordernummer")
@@ -396,12 +397,18 @@ def send_telegram_to_delivery(chat_id, delivery_person, customer_name, order_num
     phone = phone or "Geen nummer"
     tijdslot = tijdslot or "ZSM"
     opmerking = opmerking or "Geen"
+    totaal_display = f"€{float(totaal):.2f}" if totaal is not None else "Onbekend"
+    payment_method = payment_method or "Onbekend"
+    created_at = created_at or "-"
 
     message = (
         f"📦 *Nieuwe bezorging toegewezen!*\n"
         f"🧾 *Ordernummer:* #{order_number}\n"
         f"👤 *Klant:* {customer_name}\n"
+        f"💶 *Totaal:* {totaal_display}\n"
+        f"💳 *Betaling:* {payment_method}\n"
         f"⏰ *Tijdslot:* {tijdslot}\n"
+        f"🕒 *Besteld om:* {created_at}\n"
         f"📞 *Telefoon:* {phone}\n"
         f"📍 *Adres:* {full_address}\n"
         f"🌐 [Bekijk op Google Maps]({maps_link})\n"
@@ -857,6 +864,9 @@ def order_complete():
     city = data.get("city", "")
     tijdslot = data.get("tijdslot", "")
     opmerking = data.get("opmerking", "")
+    totaal = data.get("totaal") or data.get("total")
+    payment_method = data.get("payment_method")
+    created_at = data.get("created_at")
 
     if not order_number:
         return jsonify({"status": "fail", "error": "Ontbrekend ordernummer"}), 400
@@ -877,7 +887,10 @@ def order_complete():
             city=city,
             tijdslot=tijdslot,
             phone=phone,
-            opmerking=opmerking
+            opmerking=opmerking,
+            totaal=totaal,
+            payment_method=payment_method,
+            created_at=created_at
         )
 
     # ✅ 邮件通知客户（保持原样）

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2115,12 +2115,23 @@ function orderComplete(btn) {
   const status = row ? row.querySelector('.notify') : null;
   const orderType = btn.dataset.type;
 
+  const orderData = row ? JSON.parse(row.dataset.order || '{}') : {};
+
   const payload = {
-    order_number: btn.dataset.number,
-    name: btn.dataset.name,
-    phone: btn.dataset.phone,
-    email: btn.dataset.email,
-    order_type: orderType
+    order_number: orderData.order_number || btn.dataset.number,
+    name: orderData.customer_name || btn.dataset.name,
+    phone: orderData.phone || btn.dataset.phone,
+    email: orderData.email || btn.dataset.email,
+    order_type: orderType,
+    tijdslot: orderData.tijdslot || orderData.delivery_time || orderData.pickup_time || '',
+    street: orderData.street || '',
+    house_number: orderData.house_number || '',
+    postcode: orderData.postcode || '',
+    city: orderData.city || '',
+    opmerking: orderData.opmerking || '',
+    totaal: orderData.totaal || orderData.total || '',
+    payment_method: orderData.payment_method || '',
+    created_at: orderData.created_at || ''
   };
 
   // 👇 如果是配送订单，弹出配送员选择菜单
@@ -2212,12 +2223,23 @@ function confirmDeliveryPerson() {
   const row = btn.closest('.order-card');
   const status = row ? row.querySelector('.notify') : null;
 
+  const orderData = row ? JSON.parse(row.dataset.order || '{}') : {};
+
   const payload = {
-    order_number: btn.dataset.number,
-    name: btn.dataset.name,
-    phone: btn.dataset.phone,
-    email: btn.dataset.email,
+    order_number: orderData.order_number || btn.dataset.number,
+    name: orderData.customer_name || btn.dataset.name,
+    phone: orderData.phone || btn.dataset.phone,
+    email: orderData.email || btn.dataset.email,
     order_type: btn.dataset.type,
+    tijdslot: orderData.tijdslot || orderData.delivery_time || orderData.pickup_time || '',
+    street: orderData.street || '',
+    house_number: orderData.house_number || '',
+    postcode: orderData.postcode || '',
+    city: orderData.city || '',
+    opmerking: orderData.opmerking || '',
+    totaal: orderData.totaal || orderData.total || '',
+    payment_method: orderData.payment_method || '',
+    created_at: orderData.created_at || '',
     delivery_person: person.name,
     delivery_chat_id: person.chat_id
   };


### PR DESCRIPTION
## Summary
- capture full order details in POS when marking complete
- include total, payment and timestamps in telegram delivery messages

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688634ae6da4833392d917c4a76ff33b