### PR TITLE
Add orientation responsive layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -292,8 +292,8 @@
     aspect-ratio: 1 / 1;
     overflow: hidden;
     border-radius: 16px;
-    margin: 10px auto;
-    width: 80%;
+    margin: 1rem auto;
+    width: 90%;
     max-width: none;
   }
 
@@ -1833,10 +1833,32 @@ input:focus, select:focus, textarea:focus {
 }
 
 
-body.mobile-mode .menu-container {
-  flex-direction: column;
-  padding: 10px;
-}
+
+/* Base layout for menu items */
+  .menu-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  @media (orientation: landscape) {
+    .menu-group {
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .menu-group .menu-item {
+      flex: 0 0 45%;
+      margin: 1rem;
+    }
+  }
+
+  @media (orientation: portrait) {
+    .menu-group .menu-item {
+      width: 90%;
+    }
+  }
 
 
 
@@ -3781,17 +3803,7 @@ body.mobile-mode .menu-container {
 
 
 
-function applyMobileLayoutIfPortrait() {
-    const isPortrait = window.innerHeight > window.innerWidth;
-    if (isPortrait) {
-        document.body.classList.add("mobile-mode");
-    } else {
-        document.body.classList.remove("mobile-mode");
-    }
-}
 
-window.addEventListener('load', applyMobileLayoutIfPortrait);
-window.addEventListener('resize', applyMobileLayoutIfPortrait);
 
 
   


### PR DESCRIPTION
## Summary
- tweak `.menu-item` for fluid sizing
- add CSS media queries that adapt `.menu-group` layout based on orientation
- remove JS-based orientation handling

## Testing
- `python -m py_compile app.py wsgi.py add_watermark.py`

------
https://chatgpt.com/codex/tasks/task_e_68889772f7508333b64e3e3b7ac5585d