### PR TITLE
Fix select reset and reenable checkout

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1918,6 +1918,10 @@ function updateQRCode(){
 }
 
 function clearForm(){
+  // 🟢 Ensure checkout fields are enabled for a new order
+  document.querySelectorAll('#customer-info input, #customer-info select, #customer-info textarea')
+    .forEach(el=>{ el.disabled=false; });
+
   ['custName','custPhone','pickup_time','delivery_time','postcode','houseNumber','street','city'].forEach(id=>{
     const el=document.getElementById(id);
     if(el) el.value='';
@@ -1927,7 +1931,7 @@ function clearForm(){
     if(el) el.value=el.options[0].value;
   });
   document.getElementById('remark').value='';
-  document.querySelectorAll('.product-list select').forEach(sel=>{sel.value=0;});
+  document.querySelectorAll('.product-list select').forEach(sel=>{ sel.selectedIndex=0; });
   for(const k in cart) delete cart[k];
   updateCart();
   toggleAddress();


### PR DESCRIPTION
## Summary
- fix clearForm so menu selects reset correctly and checkout fields become enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b3c6b5ea88333adc3796e17dbf66d