### PR TITLE
Fix form reset issues

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1927,7 +1927,13 @@ function clearForm(){
     if(el) el.value=el.options[0].value;
   });
   document.getElementById('remark').value='';
-  document.querySelectorAll('.product-list select').forEach(sel=>{sel.value=0;});
+  document.querySelectorAll('.product-list select').forEach(sel => {
+    // Reset menu dropdowns to their first option
+    if (sel.options.length) sel.selectedIndex = 0;
+  });
+  // Re-enable checkout fields in case they were disabled
+  document.querySelectorAll('.checkout-panel input, .checkout-panel select, .checkout-panel textarea')
+          .forEach(el => el.disabled = false);
   for(const k in cart) delete cart[k];
   updateCart();
   toggleAddress();


### PR DESCRIPTION
## Summary
- reset dropdowns to their first option when clearing the form
- re-enable checkout fields after submitting an order

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b3c6b5ea88333adc3796e17dbf66d