### PR TITLE
Fix delivery fee display

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2342,6 +2342,7 @@ function addRow(order, highlight = false) {
 
   const verpakkingDisplay = verpakkingskosten.toFixed(2).replace('.', ',');
   const bezorgkosten = parseFloat(order.bezorgkosten || order.delivery_cost || 0) || 0;
+  const bezorgDisplay = bezorgkosten.toFixed(2).replace('.', ',');
   let fooi = parseFloat(order.fooi || order.tip || 0); if (isNaN(fooi)) fooi = 0;
   const fooiDisplay = fooi.toFixed(2).replace('.', ',');
 
@@ -2409,6 +2410,7 @@ function addRow(order, highlight = false) {
     <div><strong>Items:</strong><ul>${items}</ul></div>
     ${order.opmerking ? `<div><strong>Opmerking:</strong> ${order.opmerking}</div>` : ''}
     ${verpakkingskosten > 0 ? `<div><strong>Verpakkingskosten:</strong> €${verpakkingDisplay}</div>` : ''}
+    ${bezorgkosten > 0 ? `<div><strong>Bezorgkosten:</strong> €${bezorgDisplay}</div>` : ''}
     ${showKorting ? `<div><strong>Korting:</strong> -€${kortingDisplay}</div>` : ''}
     <div><strong>Totaal:</strong> €${totaalDisplay}</div>
     ${fooi > 0 ? `<div><strong>Fooi:</strong> €${fooiDisplay}</div>` : ''}

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -90,6 +90,7 @@ th:last-child {
        <th>Opmerking</th>
        <th>Ordernummer</th>
        <th>Totaal</th>
+       <th>Bezorgkosten</th>
        <th>Adres</th>
        <th>Betaalwijze</th>
        <th>Fooi</th>
@@ -122,6 +123,11 @@ th:last-child {
        <td>{{ order.order_number or '' }}</td>
 
         <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
+        <td>
+          {% if is_delivery %}
+            €{{ '%.2f' % (order.bezorgkosten or 0) }}
+          {% else %}-{% endif %}
+        </td>
 
         <td>
           {% if is_delivery %}


### PR DESCRIPTION
## Summary
- keep delivery fee separate from discount
- store delivery cost on order creation
- return delivery cost in order API responses
- show delivery cost on order cards
- display delivery fee in web POS order table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b513ed8ec8333b26a01f148580a49