### PR TITLE
Fix updateTodayBadge to fetch order count

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2275,10 +2275,20 @@ function formatCurrency(value){
     return tbody ? tbody.children.length : 0;
   }
   function updateTodayBadge(){
-    const count = getOrderCount();
-    document.querySelectorAll('.today-badge').forEach(badge => {
-      badge.textContent = hasNewOrder ? 'New' : count;
-    });
+    fetch('/pos/orders_today?json=1')
+      .then(r => r.json())
+      .then(data => {
+        const count = Array.isArray(data) ? data.length : getOrderCount();
+        document.querySelectorAll('.today-badge').forEach(badge => {
+          badge.textContent = hasNewOrder ? 'New' : count;
+        });
+      })
+      .catch(() => {
+        const count = getOrderCount();
+        document.querySelectorAll('.today-badge').forEach(badge => {
+          badge.textContent = hasNewOrder ? 'New' : count;
+        });
+      });
   }
 
   

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1881,11 +1881,22 @@ function formatCurrency(value){
     const tbody = document.querySelector('.orders-panel tbody');
     return tbody ? tbody.children.length : 0;
   }
+
   function updateTodayBadge(){
-    const count = getOrderCount();
-    document.querySelectorAll('.today-badge').forEach(badge => {
-      badge.textContent = hasNewOrder ? 'New' : count;
-    });
+    fetch('/pos/orders_today?json=1')
+      .then(r => r.json())
+      .then(data => {
+        const count = Array.isArray(data) ? data.length : getOrderCount();
+        document.querySelectorAll('.today-badge').forEach(badge => {
+          badge.textContent = hasNewOrder ? 'New' : count;
+        });
+      })
+      .catch(() => {
+        const count = getOrderCount();
+        document.querySelectorAll('.today-badge').forEach(badge => {
+          badge.textContent = hasNewOrder ? 'New' : count;
+        });
+      });
   }
 
   


### PR DESCRIPTION
## Summary
- update `updateTodayBadge` so it retrieves the latest order count from the `/pos/orders_today` API
- apply the update to both the Flask template and the Electron copy of `pos.html`

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688bb5534e288333b741273dd1d6f215