### PR TITLE
Show delivery fee info for bezorg orders

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6207,7 +6207,7 @@ function checkout() {
       updateCartPaymentOptions();
     } else {
       transferValues(afhalenFields, bezorgenFields);
-      infoBox.textContent = 'Wij bezorgen in de volgende postcodegebieden:\n' + allowedPostcodes.join(', ');
+      infoBox.textContent = 'Bezorging vanaf €20 – bezorgkosten €2,50\nWij bezorgen in de volgende postcodegebieden:\n' + allowedPostcodes.join(', ');
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5806,7 +5806,7 @@ function checkout() {
       updateCartPaymentOptions();
     } else {
       transferValues(afhalenFields, bezorgenFields);
-      infoBox.textContent = 'We deliver to the following postcode areas:\n' + allowedPostcodes.join(', ');
+      infoBox.textContent = 'Delivery from €20 – delivery fee €2.50\nWe deliver to the following postcode areas:\n' + allowedPostcodes.join(', ');
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Display delivery minimum and fee message when customers choose bezorg on the index page
- Display delivery minimum and fee message when customers choose bezorg on the English index page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bd2d7d088333abcb5cf6bfca3dfd