### PR TITLE
feat: geocode delivery orders with map toggle

### DIFF
--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -148,34 +148,14 @@
 
 
 
-#map-button-container {
-  position: sticky;
-  top: 0;
+#toggle-map-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
   z-index: 1000;
-  background: transparent;
-  padding: 12px 70px;
-  display: flex;
-  justify-content: flex-end; /* ✅ 右对齐 */
-}
-
-
-#map-button-container button {
   padding: 10px 20px;
   font-size: 16px;
   background-color: #6b4f3b;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-}
-#close-map-btn {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: 10000;
-  padding: 10px 14px;
-  font-size: 14px;
-  background: #dc3545;
   color: white;
   border: none;
   border-radius: 5px;
@@ -186,7 +166,8 @@
 
 </style>
 
-
+<div id="map"></div>
+<button id="toggle-map-btn">Show Map</button>
 
 <div class="orders-cards">
   {% for order in orders %}
@@ -233,3 +214,67 @@
   </div>
   {% endfor %}
 </div>
+
+<script>
+const mapEl = document.getElementById('map');
+const toggleBtn = document.getElementById('toggle-map-btn');
+let mapInstance;
+let markers = [];
+let mapVisible = false;
+let apiLoaded = false;
+
+async function loadGoogleMaps() {
+  if (apiLoaded) return;
+  if (!window.api?.getGoogleMapsKey) {
+    console.error('Google Maps key not available');
+    return;
+  }
+  const key = await window.api.getGoogleMapsKey();
+  await new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${key}`;
+    script.onload = () => { apiLoaded = true; resolve(); };
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+function renderMarkers() {
+  markers.forEach(m => m.setMap(null));
+  markers = [];
+  const bounds = new google.maps.LatLngBounds();
+  (window.deliveryOrders || []).forEach(o => {
+    const pos = { lat: o.lat, lng: o.lng };
+    const marker = new google.maps.Marker({
+      position: pos,
+      map: mapInstance,
+      title: `${o.customer_name} (${o.order_number})`
+    });
+    markers.push(marker);
+    bounds.extend(pos);
+  });
+  if (!bounds.isEmpty()) {
+    mapInstance.fitBounds(bounds);
+  }
+}
+
+async function toggleMap() {
+  mapVisible = !mapVisible;
+  mapEl.style.display = mapVisible ? 'block' : 'none';
+  toggleBtn.textContent = mapVisible ? 'Hide Map' : 'Show Map';
+  if (mapVisible) {
+    await loadGoogleMaps();
+    if (!mapInstance) {
+      mapInstance = new google.maps.Map(mapEl, {
+        center: { lat: 0, lng: 0 },
+        zoom: 8
+      });
+    }
+    renderMarkers();
+  }
+}
+
+toggleBtn.addEventListener('click', () => {
+  toggleMap().catch(err => console.error(err));
+});
+</script>

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2684,6 +2684,31 @@ function addRow(order, highlight = false) {
   if (!container) return;
 
   const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
+  const address = isDelivery
+    ? `${order.street || ''} ${order.house_number || ''}, ${order.postcode || ''} ${order.city || ''}`.trim()
+    : '-';
+
+  if (isDelivery && window.api?.getGoogleMapsKey) {
+    (async () => {
+      try {
+        const key = await window.api.getGoogleMapsKey();
+        const res = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${key}`);
+        const data = await res.json();
+        const loc = data.results?.[0]?.geometry?.location;
+        if (loc) {
+          window.deliveryOrders = window.deliveryOrders || [];
+          window.deliveryOrders.push({
+            order_number: order.order_number,
+            customer_name: order.customer_name,
+            lat: loc.lat,
+            lng: loc.lng
+          });
+        }
+      } catch (err) {
+        console.error('Geocoding failed', err);
+      }
+    })();
+  }
 
   const items = Object.entries(order.items || {})
     .sort(([, a], [, b]) => {
@@ -2733,10 +2758,6 @@ function addRow(order, highlight = false) {
   let korting = theoretischTotaal - totaal;
   const showKorting = korting >= 0.01;
   const kortingDisplay = korting.toFixed(2).replace('.', ',');
-
-  const address = isDelivery
-    ? `${order.street || ''} ${order.house_number || ''}, ${order.postcode || ''} ${order.city || ''}`.trim()
-    : '-';
 
   const tijdslotRaw = order.tijdslot_display || (isDelivery ? order.delivery_time : order.pickup_time);
   const tijdslot = order.is_zsm ? 'ZSM' : (tijdslotRaw || '').trim();


### PR DESCRIPTION
## Summary
- geocode delivery addresses via Google API and store results in `window.deliveryOrders`
- add bottom-right toggle button showing Google Map with markers for delivery orders

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894389082e88333b94663ced0095144