### PR TITLE
fix: ensure map overlay centered regardless of scroll

### DIFF
--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -145,9 +145,7 @@
 
 </style>
 
-<!-- 地图容器，全屏显示 -->
-<div id="map" style="display: none;">
-</div>
+<!-- 地图容器已移至 pos.html 以确保其始终覆盖整个视口 -->
 
 
 
@@ -257,7 +255,6 @@ async function toggleMap() {
   document.body.style.overflow = mapVisible ? 'hidden' : '';
 
   if (mapVisible) {
-    window.scrollTo({ top: 0, behavior: 'smooth' }); // ⬅️ 添加这行
     await loadGoogleMaps();
     if (!mapInstance) {
       mapInstance = new google.maps.Map(mapEl, {

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -939,7 +939,9 @@ dialog::backdrop {
 </style>
 </head>
 <body>
-<div class="navbar-container" id="navbar-container">
+  <!-- 全屏地图容器，确保在任何滚动位置都位于视口中央 -->
+  <div id="map" style="display: none;"></div>
+  <div class="navbar-container" id="navbar-container">
   <nav class="navbar" id="navbar">
     <div class="nav-categories">
       <a href="#customer-info">Klant</a>


### PR DESCRIPTION
## Summary
- show order map directly on top of viewport by moving map container to `pos.html`
- simplify toggle logic to avoid scrolling to top when map is opened

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689490aba6688333a00a7ef615523b25