### PR TITLE
feat: enable offline receipt printing without escpos

### DIFF
--- a/electron-pos/preload.js
+++ b/electron-pos/preload.js
@@ -10,8 +10,8 @@ contextBridge.exposeInMainWorld('api', {
   // ✅ 停止提示音
   stopDing: () => ipcRenderer.send('stop-ding'),
 
-  // ✅ 打印小票（发送订单文本到主进程）
-  printReceipt: (text) => ipcRenderer.invoke('print-receipt', text),
+  // ✅ 打印小票（发送订单数据到主进程）
+  printReceipt: (order) => ipcRenderer.invoke('print-receipt', order),
 
   // ✅ 登录成功回调（保留）
   onLoginSuccess: (callback) => ipcRenderer.on('login-success', callback)


### PR DESCRIPTION
## Summary
- replace escpos printing with HTML-based BrowserWindow printing
- expose `printReceipt` API for order data

## Testing
- `cd electron-pos && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895f036e6d88333a0110f1f7ed9d22c