### PR TITLE
Restrict orders to same-day available times

### DIFF
--- a/app.py
+++ b/app.py
@@ -807,6 +807,9 @@ def api_orders():
         if chosen_dt and chosen_dt < start_today:
             return jsonify({"status": "fail", "error": "Gekozen tijd valt buiten openingstijden."}), 403
 
+        if chosen_dt and chosen_dt > end_today:
+            return jsonify({"status": "fail", "error": gesloten_message}), 403
+
         if now > end_today:
             return jsonify({"status": "fail", "error": gesloten_message}), 403
         # ===== 新时间判断逻辑结束 =====

--- a/electron-pos/appB.py
+++ b/electron-pos/appB.py
@@ -807,6 +807,9 @@ def api_orders():
         if chosen_dt and chosen_dt < start_today:
             return jsonify({"status": "fail", "error": "Gekozen tijd valt buiten openingstijden."}), 403
 
+        if chosen_dt and chosen_dt > end_today:
+            return jsonify({"status": "fail", "error": gesloten_message}), 403
+
         if now > end_today:
             return jsonify({"status": "fail", "error": gesloten_message}), 403
         # ===== 新时间判断逻辑结束 =====

--- a/templates/index.html
+++ b/templates/index.html
@@ -5965,6 +5965,27 @@ function checkout() {
   const deliveryValue = deliverySel === 'Z.S.M.' ? getAsapTime() : deliverySel;
   const tijdslotDisplay = orderType === 'afhalen' ? pickupSel : deliverySel;
 
+  const selectedTime = orderType === 'afhalen' ? pickupValue : deliveryValue;
+  const lastAvailableTime = (() => {
+    const sel = document.getElementById(orderType === 'afhalen' ? 'pickup_time' : 'delivery_time');
+    if (!sel) return null;
+    for (let i = sel.options.length - 1; i >= 0; i--) {
+      const val = sel.options[i].value;
+      if (val) return val;
+    }
+    return null;
+  })();
+
+  const toMinutes = t => {
+    const [h, m] = t.split(':').map(Number);
+    return h * 60 + m;
+  };
+
+  if (selectedTime && lastAvailableTime && toMinutes(selectedTime) > toMinutes(lastAvailableTime)) {
+    alert('Gekozen tijd valt buiten openingstijden.');
+    return;
+  }
+
   const summary = {
     subtotal: subtotal.toFixed(2),
     packaging: packagingFee.toFixed(2),

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5554,6 +5554,27 @@ function checkout() {
 
   const tijdslotDisplay = orderType === 'afhalen' ? pickupSel : deliverySel;
 
+  const selectedTime = orderType === 'afhalen' ? pickupValue : deliveryValue;
+  const lastAvailableTime = (() => {
+    const sel = document.getElementById(orderType === 'afhalen' ? 'pickup_time' : 'delivery_time');
+    if (!sel) return null;
+    for (let i = sel.options.length - 1; i >= 0; i--) {
+      const val = sel.options[i].value;
+      if (val) return val;
+    }
+    return null;
+  })();
+
+  const toMinutes = t => {
+    const [h, m] = t.split(':').map(Number);
+    return h * 60 + m;
+  };
+
+  if (selectedTime && lastAvailableTime && toMinutes(selectedTime) > toMinutes(lastAvailableTime)) {
+    alert('Selected time is not available.');
+    return;
+  }
+
   const summary = {
     subtotal: subtotal.toFixed(2),
     packaging: packagingFee.toFixed(2),


### PR DESCRIPTION
## Summary
- validate chosen order time against last available slot on client side
- block orders outside of operating hours on server side
- mirror backend validation in electron POS app

## Testing
- `python -m py_compile app.py electron-pos/appB.py`


------
https://chatgpt.com/codex/tasks/task_e_6896dfe13ae4833395b840fc1d81b81e