### PR TITLE
Hide ZSM option before opening

### DIFF
--- a/electron-pos/public/pos-order.html
+++ b/electron-pos/public/pos-order.html
@@ -2271,10 +2271,7 @@ function submitOrder() {
     const select=document.getElementById(selectId);
     if(!select) return;
     select.innerHTML='';
-    const asap=document.createElement('option');
-    asap.value='Z.S.M.';
-    asap.textContent='Z.S.M.';
-    select.appendChild(asap);
+    const current=new Date();
     const now=new Date();
     now.setMinutes(now.getMinutes()+offsetMinutes);
 
@@ -2282,6 +2279,13 @@ function submitOrder() {
     open.setHours(12,0,0,0);
     const close=new Date();
     close.setHours(23,59,0,0);
+
+    if(current>=open){
+      const asap=document.createElement('option');
+      asap.value='Z.S.M.';
+      asap.textContent='Z.S.M.';
+      select.appendChild(asap);
+    }
 
     let start=now>open?now:open;
     start=new Date(start);

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2276,10 +2276,7 @@ function submitOrder() {
     const select=document.getElementById(selectId);
     if(!select) return;
     select.innerHTML='';
-    const asap=document.createElement('option');
-    asap.value='Z.S.M.';
-    asap.textContent='Z.S.M.';
-    select.appendChild(asap);
+    const current=new Date();
     const now=new Date();
     now.setMinutes(now.getMinutes()+offsetMinutes);
 
@@ -2287,6 +2284,13 @@ function submitOrder() {
     open.setHours(12,0,0,0);
     const close=new Date();
     close.setHours(23,59,0,0);
+
+    if(current>=open){
+      const asap=document.createElement('option');
+      asap.value='Z.S.M.';
+      asap.textContent='Z.S.M.';
+      select.appendChild(asap);
+    }
 
     let start=now>open?now:open;
     start=new Date(start);

--- a/templates/index.html
+++ b/templates/index.html
@@ -6109,6 +6109,7 @@ function checkout() {
 
     const open = new Date();
     open.setHours(oh, om, 0, 0);
+    const current = new Date();
 
     const close = new Date();
     close.setHours(ch, cm, 0, 0);
@@ -6136,7 +6137,7 @@ function checkout() {
         }
     }
 
-    if (showZSM) {
+    if (showZSM && current >= open) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'Z.S.M.';
         asapOpt.textContent = 'Z.S.M.';

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5707,6 +5707,7 @@ function checkout() {
 
     const open = new Date();
     open.setHours(oh, om, 0, 0);
+    const current = new Date();
 
     const close = new Date();
     close.setHours(ch, cm, 0, 0);
@@ -5734,7 +5735,7 @@ function checkout() {
         }
     }
 
-    if (showZSM) {
+    if (showZSM && current >= open) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'ASAP';
         asapOpt.textContent = 'ASAP';

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1773,10 +1773,7 @@ function submitOrder() {
     const select=document.getElementById(selectId);
     if(!select) return;
     select.innerHTML='';
-    const asap=document.createElement('option');
-    asap.value='Z.S.M.';
-    asap.textContent='Z.S.M.';
-    select.appendChild(asap);
+    const current=new Date();
     const now=new Date();
     now.setMinutes(now.getMinutes()+offsetMinutes);
 
@@ -1784,6 +1781,13 @@ function submitOrder() {
     open.setHours(12,0,0,0);
     const close=new Date();
     close.setHours(23,59,0,0);
+
+    if(current>=open){
+      const asap=document.createElement('option');
+      asap.value='Z.S.M.';
+      asap.textContent='Z.S.M.';
+      select.appendChild(asap);
+    }
 
     let start=now>open?now:open;
     start=new Date(start);


### PR DESCRIPTION
## Summary
- hide ASAP/Z.S.M. option until current time reaches first slot on web index
- apply same safeguard for English index and POS interfaces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896e3f917048333bf1de09da806611e