### PR TITLE
feat: allow admin to toggle time slots

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -90,6 +90,30 @@
         </select>
         <br><br>
 
+        <h3>Afhaal tijdslots</h3>
+        <div id="pickupSlots">
+            {% for h in range(12,22) %}
+            {% set t = ("%02d:00" % h) %}
+            <label>
+                <input type="checkbox" class="pickup-slot" value="{{ t }}" {% if t not in (pickup_closed_slots or '').split(',') %}checked{% endif %}>
+                {{ t }}
+            </label>
+            {% endfor %}
+        </div>
+
+        <h3>Bezorg tijdslots</h3>
+        <div id="deliverySlots">
+            {% for h in range(12,22) %}
+            {% set t = ("%02d:00" % h) %}
+            <label>
+                <input type="checkbox" class="delivery-slot" value="{{ t }}" {% if t not in (delivery_closed_slots or '').split(',') %}checked{% endif %}>
+                {{ t }}
+            </label>
+            {% endfor %}
+        </div>
+
+        <br>
+
         <label>奶茶价格 (€):</label>
         <input type="number" step="0.01" id="milktea_price_input" value="{{ milktea_price }}">
         <button type="button" id="update_milktea_btn">更新价格</button>
@@ -694,6 +718,12 @@
                   .map(input => input.value.trim())
                   .filter(Boolean)
                   .join(',');
+            const pickup_closed_slots = Array.from(document.querySelectorAll('.pickup-slot:not(:checked)'))
+                  .map(cb => cb.value)
+                  .join(',');
+            const delivery_closed_slots = Array.from(document.querySelectorAll('.delivery-slot:not(:checked)'))
+                  .map(cb => cb.value)
+                  .join(',');
             const time_interval = document.getElementById('interval_select').value;
             const show_zsm_option = document.getElementById('show_zsm_select').value;
             const milktea_soldout = document.getElementById('milktea_soldout_select').value;
@@ -785,6 +815,8 @@
                     delivery_start: delivery_start,
                     delivery_end: delivery_end,
                     delivery_postcodes: delivery_postcodes,
+                    pickup_closed_slots: pickup_closed_slots,
+                    delivery_closed_slots: delivery_closed_slots,
                     time_interval: time_interval,
                     show_zsm_option: show_zsm_option,
                     milktea_soldout: milktea_soldout,

--- a/templates/index.html
+++ b/templates/index.html
@@ -5726,6 +5726,8 @@ let timeInterval = 15;
 let showZSM = true;
 let pickupAddress = '';
 let allowedPostcodes = [];
+let pickupClosedSlots = [];
+let deliveryClosedSlots = [];
 let currentSettings = {};
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
@@ -6092,7 +6094,7 @@ function checkout() {
     };
   }
 
-  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr) {
+  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr, closedSlots=[]) {
     const select = document.getElementById(selectId);
     if (!select) return;
 
@@ -6137,7 +6139,9 @@ function checkout() {
         }
     }
 
-    if (showZSM && current >= open) {
+    const currentSlot = `${pad(current.getHours())}:00`;
+    const inClosedSlot = closedSlots.includes(currentSlot);
+    if (showZSM && current >= open && !inClosedSlot) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'Z.S.M.';
         asapOpt.textContent = 'Z.S.M.';
@@ -6151,7 +6155,9 @@ function checkout() {
 
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
+    const closedSet = new Set(closedSlots);
     for (const { time, str } of allTimes) {
+        if (closedSet.has(str)) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
         opt.value = str;
@@ -6225,7 +6231,7 @@ function checkout() {
 
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
-      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
+      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
       updateCartPaymentOptions();
     } else {
       transferValues(afhalenFields, bezorgenFields);
@@ -6233,7 +6239,7 @@ function checkout() {
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
-      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
+      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
       updateCartPaymentOptions();
     }
     updatePriceBreakdown(currentSubtotal, currentPackaging);
@@ -7160,9 +7166,11 @@ function updateStatus(settings) {
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
+  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
+  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
 
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
 
   const websiteOn = settings.is_open !== 'false' && !allClosed;
   const dayOpen = closedDays.indexOf(todayName) === -1;
@@ -7272,8 +7280,10 @@ function updateTimes(settings){
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
+  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
+  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
 }
 
 function fetchStatus(){

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5314,6 +5314,8 @@ let timeInterval = 15;
 let showZSM = true;
 let pickupAddress = '';
 let allowedPostcodes = [];
+let pickupClosedSlots = [];
+let deliveryClosedSlots = [];
 let currentSettings = {};
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
@@ -5690,7 +5692,7 @@ function checkout() {
     };
   }
 
-  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr) {
+  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr, closedSlots=[]) {
     const select = document.getElementById(selectId);
     if (!select) return;
 
@@ -5735,7 +5737,9 @@ function checkout() {
         }
     }
 
-    if (showZSM && current >= open) {
+    const currentSlot = `${pad(current.getHours())}:00`;
+    const inClosedSlot = closedSlots.includes(currentSlot);
+    if (showZSM && current >= open && !inClosedSlot) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'ASAP';
         asapOpt.textContent = 'ASAP';
@@ -5749,7 +5753,9 @@ function checkout() {
 
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
+    const closedSet = new Set(closedSlots);
     for (const { time, str } of allTimes) {
+        if (closedSet.has(str)) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
         opt.value = str;
@@ -5824,7 +5830,7 @@ function checkout() {
 
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
-      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
+      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
       updateCartPaymentOptions();
     } else {
       transferValues(afhalenFields, bezorgenFields);
@@ -5832,7 +5838,7 @@ function checkout() {
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
-      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
+      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
       updateCartPaymentOptions();
     }
     updatePriceBreakdown(currentSubtotal, currentPackaging);
@@ -6729,9 +6735,11 @@ function updateStatus(settings) {
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
+  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
+  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
 
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
 
   const websiteOn = settings.is_open !== 'false' && !allClosed;
   const dayOpen = closedDays.indexOf(todayName) === -1;
@@ -6841,8 +6849,10 @@ function updateTimes(settings){
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime);
+  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
+  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
 }
 
 function fetchStatus(){


### PR DESCRIPTION
## Summary
- add per-hour pickup and delivery time slot toggles to dashboard
- persist closed slots and broadcast to clients in real time
- support quick slot closure via new `/dashboard/slot` endpoint
- hide ZSM/ASAP option when current time falls in a closed slot

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f9cc49ec8333b6945d5985e32647