### PR TITLE
feat: handle closed time slots with status

### DIFF
--- a/app.py
+++ b/app.py
@@ -812,6 +812,15 @@ def api_orders():
 
         if now > end_today:
             return jsonify({"status": "fail", "error": gesloten_message}), 403
+        try:
+            pickup_closed = json.loads(settings.get('pickup_closed_slots') or '{}')
+            delivery_closed = json.loads(settings.get('delivery_closed_slots') or '{}')
+        except Exception:
+            pickup_closed, delivery_closed = {}, {}
+        closed_map = pickup_closed if order_type == 'afhalen' else delivery_closed
+        if gekozen and gekozen in closed_map:
+            msg = 'Tijdslot vol' if closed_map[gekozen] == 'full' else 'Tijdslot gesloten'
+            return jsonify({"status": "fail", "error": msg}), 403
         # ===== 新时间判断逻辑结束 =====
 
         # 1. 构造订单对象（初始字段）
@@ -943,7 +952,27 @@ def get_setting(key):
 @app.route('/api/settings')
 def get_all_settings():
     settings = {s.key: s.value for s in Setting.query.all()}
+    for k in ['pickup_closed_slots', 'delivery_closed_slots']:
+        try:
+            settings[k] = json.loads(settings.get(k) or '{}')
+        except Exception:
+            settings[k] = {}
     return jsonify(settings)
+
+
+@app.route('/api/closed_slots')
+def get_closed_slots():
+    keys = ['pickup_closed_slots', 'delivery_closed_slots']
+    settings = {s.key: s.value for s in Setting.query.filter(Setting.key.in_(keys)).all()}
+    def parse(val):
+        try:
+            return json.loads(val or '{}')
+        except Exception:
+            return {}
+    return jsonify({
+        'pickup': parse(settings.get('pickup_closed_slots')),
+        'delivery': parse(settings.get('delivery_closed_slots'))
+    })
 
 # ----- Menu API -----
 @app.route('/api/menu')
@@ -1175,8 +1204,8 @@ def dashboard():
         delivery_start=get_value('delivery_start', '11:00'),
         delivery_end=get_value('delivery_end', '21:00'),
         delivery_postcodes=get_value('delivery_postcodes', ''),
-        pickup_closed_slots=get_value('pickup_closed_slots', ''),
-        delivery_closed_slots=get_value('delivery_closed_slots', ''),
+        pickup_closed_slots=json.loads(get_value('pickup_closed_slots', '{}') or '{}'),
+        delivery_closed_slots=json.loads(get_value('delivery_closed_slots', '{}') or '{}'),
         time_interval=get_value('time_interval', '15'),
         show_zsm_option=get_value('show_zsm_option', 'true'),
         milktea_soldout=get_value('milktea_soldout', 'false'),
@@ -1285,8 +1314,8 @@ def update_setting():
     delivery_start_val = data.get('delivery_start', '11:00')
     delivery_end_val = data.get('delivery_end', '21:00')
     delivery_postcodes_val = data.get('delivery_postcodes', '')
-    pickup_closed_slots_val = data.get('pickup_closed_slots', '')
-    delivery_closed_slots_val = data.get('delivery_closed_slots', '')
+    pickup_closed_slots_val = json.dumps(data.get('pickup_closed_slots', {}))
+    delivery_closed_slots_val = json.dumps(data.get('delivery_closed_slots', {}))
     time_interval_val = data.get('time_interval', '15')
     show_zsm_option_val = data.get('show_zsm_option', 'true')
     milktea_soldout_val = data.get('milktea_soldout', 'false')
@@ -1461,15 +1490,21 @@ def update_setting():
 
     db.session.commit()
     settings = {s.key: s.value for s in Setting.query.all()}
-    socketio.emit('setting_update', settings)
+    parsed_settings = settings.copy()
+    for k in ['pickup_closed_slots', 'delivery_closed_slots']:
+        try:
+            parsed_settings[k] = json.loads(settings.get(k) or '{}')
+        except Exception:
+            parsed_settings[k] = {}
+    socketio.emit('setting_update', parsed_settings)
     time_settings = {
         'pickup_start': settings.get('pickup_start'),
         'pickup_end': settings.get('pickup_end'),
         'delivery_start': settings.get('delivery_start'),
         'delivery_end': settings.get('delivery_end'),
         'time_interval': settings.get('time_interval'),
-        'pickup_closed_slots': settings.get('pickup_closed_slots', ''),
-        'delivery_closed_slots': settings.get('delivery_closed_slots', '')
+        'pickup_closed_slots': parsed_settings['pickup_closed_slots'],
+        'delivery_closed_slots': parsed_settings['delivery_closed_slots']
     }
     socketio.emit('time_update', time_settings)
     return jsonify({'success': True})
@@ -1481,31 +1516,41 @@ def toggle_slot():
     data = request.get_json()
     slot = data.get('slot')
     slot_type = data.get('type')  # 'pickup' or 'delivery'
+    status = data.get('status', 'closed')
     action = data.get('action', 'close')
     if slot_type not in ['pickup', 'delivery'] or not slot:
         return jsonify({'success': False, 'error': 'invalid parameters'}), 400
     key = f"{slot_type}_closed_slots"
     s = Setting.query.filter_by(key=key).first()
-    slots = set((s.value or '').split(',')) if s and s.value else set()
+    try:
+        slots = json.loads(s.value) if s and s.value else {}
+    except Exception:
+        slots = {}
     if action == 'open':
-        slots.discard(slot)
+        slots.pop(slot, None)
     else:
-        slots.add(slot)
-    new_val = ','.join(sorted(filter(None, slots)))
+        slots[slot] = status
+    new_val = json.dumps(slots)
     if not s:
         db.session.add(Setting(key=key, value=new_val))
     else:
         s.value = new_val
     db.session.commit()
     settings = {s.key: s.value for s in Setting.query.all()}
+    parsed_settings = settings.copy()
+    for k in ['pickup_closed_slots', 'delivery_closed_slots']:
+        try:
+            parsed_settings[k] = json.loads(settings.get(k) or '{}')
+        except Exception:
+            parsed_settings[k] = {}
     time_settings = {
         'pickup_start': settings.get('pickup_start'),
         'pickup_end': settings.get('pickup_end'),
         'delivery_start': settings.get('delivery_start'),
         'delivery_end': settings.get('delivery_end'),
         'time_interval': settings.get('time_interval'),
-        'pickup_closed_slots': settings.get('pickup_closed_slots', ''),
-        'delivery_closed_slots': settings.get('delivery_closed_slots', '')
+        'pickup_closed_slots': parsed_settings['pickup_closed_slots'],
+        'delivery_closed_slots': parsed_settings['delivery_closed_slots']
     }
     socketio.emit('time_update', time_settings)
     return jsonify({'success': True, key: new_val})

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -95,7 +95,7 @@
             {% for h in range(12,22) %}
             {% set t = ("%02d:00" % h) %}
             <label>
-                <input type="checkbox" class="pickup-slot" value="{{ t }}" {% if t not in (pickup_closed_slots or '').split(',') %}checked{% endif %}>
+                <input type="checkbox" class="pickup-slot" value="{{ t }}" {% if t not in pickup_closed_slots %}checked{% endif %}>
                 {{ t }}
             </label>
             {% endfor %}
@@ -106,7 +106,7 @@
             {% for h in range(12,22) %}
             {% set t = ("%02d:00" % h) %}
             <label>
-                <input type="checkbox" class="delivery-slot" value="{{ t }}" {% if t not in (delivery_closed_slots or '').split(',') %}checked{% endif %}>
+                <input type="checkbox" class="delivery-slot" value="{{ t }}" {% if t not in delivery_closed_slots %}checked{% endif %}>
                 {{ t }}
             </label>
             {% endfor %}
@@ -718,12 +718,10 @@
                   .map(input => input.value.trim())
                   .filter(Boolean)
                   .join(',');
-            const pickup_closed_slots = Array.from(document.querySelectorAll('.pickup-slot:not(:checked)'))
-                  .map(cb => cb.value)
-                  .join(',');
-            const delivery_closed_slots = Array.from(document.querySelectorAll('.delivery-slot:not(:checked)'))
-                  .map(cb => cb.value)
-                  .join(',');
+            const pickup_closed_slots = {};
+            document.querySelectorAll('.pickup-slot:not(:checked)').forEach(cb => pickup_closed_slots[cb.value] = 'closed');
+            const delivery_closed_slots = {};
+            document.querySelectorAll('.delivery-slot:not(:checked)').forEach(cb => delivery_closed_slots[cb.value] = 'closed');
             const time_interval = document.getElementById('interval_select').value;
             const show_zsm_option = document.getElementById('show_zsm_select').value;
             const milktea_soldout = document.getElementById('milktea_soldout_select').value;

--- a/templates/index.html
+++ b/templates/index.html
@@ -5723,8 +5723,8 @@ let timeInterval = 15;
 let showZSM = true;
 let pickupAddress = '';
 let allowedPostcodes = [];
-let pickupClosedSlots = [];
-let deliveryClosedSlots = [];
+let pickupClosedSlots = {};
+let deliveryClosedSlots = {};
 let currentSettings = {};
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
@@ -6091,7 +6091,7 @@ function checkout() {
     };
   }
 
-  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr, closedSlots=[]) {
+  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr, closedSlots={}, hideClosed=false) {
     const select = document.getElementById(selectId);
     if (!select) return;
 
@@ -6137,7 +6137,7 @@ function checkout() {
     }
 
     const currentSlot = `${pad(current.getHours())}:00`;
-    const inClosedSlot = closedSlots.includes(currentSlot);
+    const inClosedSlot = !!closedSlots[currentSlot];
     if (showZSM && current >= open && !inClosedSlot) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'Z.S.M.';
@@ -6152,13 +6152,18 @@ function checkout() {
 
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
-    const closedSet = new Set(closedSlots);
     for (const { time, str } of allTimes) {
-        if (closedSet.has(str)) continue;
+        const status = closedSlots[str];
+        if (status && hideClosed) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
         opt.value = str;
-        opt.textContent = str;
+        if (status) {
+            opt.disabled = true;
+            opt.textContent = `${str} (${status === 'full' ? 'Vol' : 'Gesloten'})`;
+        } else {
+            opt.textContent = str;
+        }
         select.appendChild(opt);
     }
 
@@ -6169,9 +6174,17 @@ function checkout() {
         select.appendChild(opt);
     }
 
-    if (prev) {
-        const option = Array.from(select.options).find(o => o.value === prev);
-        if (option) select.value = prev;
+  if (prev && !closedSlots[prev]) {
+      const option = Array.from(select.options).find(o => o.value === prev);
+      if (option) select.value = prev;
+  }
+  }
+
+  function clearIfClosed(selectId, closedMap){
+    const sel = document.getElementById(selectId);
+    if (sel && sel.value && closedMap[sel.value]){
+      sel.value = '';
+      alert('Geselecteerde tijd is niet meer beschikbaar. Kies een andere.');
     }
   }
 
@@ -6229,6 +6242,7 @@ function checkout() {
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
       populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+      clearIfClosed('pickup_time', pickupClosedSlots);
       updateCartPaymentOptions();
     } else {
       transferValues(afhalenFields, bezorgenFields);
@@ -6237,6 +6251,7 @@ function checkout() {
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
       populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+      clearIfClosed('delivery_time', deliveryClosedSlots);
       updateCartPaymentOptions();
     }
     updatePriceBreakdown(currentSubtotal, currentPackaging);
@@ -7163,11 +7178,13 @@ function updateStatus(settings) {
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
-  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
-  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
+  pickupClosedSlots = settings.pickup_closed_slots || {};
+  deliveryClosedSlots = settings.delivery_closed_slots || {};
 
   populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
   populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  clearIfClosed('pickup_time', pickupClosedSlots);
+  clearIfClosed('delivery_time', deliveryClosedSlots);
 
   const websiteOn = settings.is_open !== 'false' && !allClosed;
   const dayOpen = closedDays.indexOf(todayName) === -1;
@@ -7277,10 +7294,12 @@ function updateTimes(settings){
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
-  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
-  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
+  pickupClosedSlots = settings.pickup_closed_slots || {};
+  deliveryClosedSlots = settings.delivery_closed_slots || {};
   populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
   populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  clearIfClosed('pickup_time', pickupClosedSlots);
+  clearIfClosed('delivery_time', deliveryClosedSlots);
 }
 
 function fetchStatus(){

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5314,8 +5314,8 @@ let timeInterval = 15;
 let showZSM = true;
 let pickupAddress = '';
 let allowedPostcodes = [];
-let pickupClosedSlots = [];
-let deliveryClosedSlots = [];
+let pickupClosedSlots = {};
+let deliveryClosedSlots = {};
 let currentSettings = {};
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
@@ -5692,7 +5692,7 @@ function checkout() {
     };
   }
 
-  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr, closedSlots=[]) {
+  function populateTimeOptions(selectId, offsetMinutes, openStr, closeStr, closedSlots={}, hideClosed=false) {
     const select = document.getElementById(selectId);
     if (!select) return;
 
@@ -5738,7 +5738,7 @@ function checkout() {
     }
 
     const currentSlot = `${pad(current.getHours())}:00`;
-    const inClosedSlot = closedSlots.includes(currentSlot);
+    const inClosedSlot = !!closedSlots[currentSlot];
     if (showZSM && current >= open && !inClosedSlot) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'ASAP';
@@ -5753,13 +5753,18 @@ function checkout() {
 
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
-    const closedSet = new Set(closedSlots);
     for (const { time, str } of allTimes) {
-        if (closedSet.has(str)) continue;
+        const status = closedSlots[str];
+        if (status && hideClosed) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
         opt.value = str;
-        opt.textContent = str;
+        if (status) {
+            opt.disabled = true;
+            opt.textContent = `${str} (${status === 'full' ? 'Full' : 'Closed'})`;
+        } else {
+            opt.textContent = str;
+        }
         select.appendChild(opt);
     }
 
@@ -5771,11 +5776,19 @@ function checkout() {
     }
 
     // 保留用户上一次选择的时间（如果还存在）
-    if (prev) {
+    if (prev && !closedSlots[prev]) {
         const option = Array.from(select.options).find(o => o.value === prev);
         if (option) select.value = prev;
     }
-}
+  }
+
+  function clearIfClosed(selectId, closedMap){
+    const sel = document.getElementById(selectId);
+    if(sel && sel.value && closedMap[sel.value]){
+      sel.value = '';
+      alert('Selected time is no longer available. Please choose again.');
+    }
+  }
 
 
   function toggleOrderType() {
@@ -5831,6 +5844,7 @@ function checkout() {
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
       populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+      clearIfClosed('pickup_time', pickupClosedSlots);
       updateCartPaymentOptions();
     } else {
       transferValues(afhalenFields, bezorgenFields);
@@ -5839,6 +5853,7 @@ function checkout() {
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
       populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+      clearIfClosed('delivery_time', deliveryClosedSlots);
       updateCartPaymentOptions();
     }
     updatePriceBreakdown(currentSubtotal, currentPackaging);
@@ -6735,11 +6750,13 @@ function updateStatus(settings) {
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
-  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
-  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
+  pickupClosedSlots = settings.pickup_closed_slots || {};
+  deliveryClosedSlots = settings.delivery_closed_slots || {};
 
   populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
   populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  clearIfClosed('pickup_time', pickupClosedSlots);
+  clearIfClosed('delivery_time', deliveryClosedSlots);
 
   const websiteOn = settings.is_open !== 'false' && !allClosed;
   const dayOpen = closedDays.indexOf(todayName) === -1;
@@ -6849,10 +6866,12 @@ function updateTimes(settings){
   deliveryOpenTime = settings.delivery_start || deliveryOpenTime;
   deliveryCloseTime = settings.delivery_end || deliveryCloseTime;
   timeInterval = parseInt(settings.time_interval || timeInterval);
-  pickupClosedSlots = (settings.pickup_closed_slots || '').split(',').filter(Boolean);
-  deliveryClosedSlots = (settings.delivery_closed_slots || '').split(',').filter(Boolean);
+  pickupClosedSlots = settings.pickup_closed_slots || {};
+  deliveryClosedSlots = settings.delivery_closed_slots || {};
   populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
   populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  clearIfClosed('pickup_time', pickupClosedSlots);
+  clearIfClosed('delivery_time', deliveryClosedSlots);
 }
 
 function fetchStatus(){


### PR DESCRIPTION
## Summary
- serve closed pickup/delivery slots with status and broadcast updates
- front-end disables unavailable slots with reason and clears invalid selections
- validate chosen time slot against closed/full state when placing orders

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68970b22c8f88333a38feaba0f840e65