### PR TITLE
Handle closed time slots per hour

### DIFF
--- a/app.py
+++ b/app.py
@@ -818,9 +818,12 @@ def api_orders():
         except Exception:
             pickup_closed, delivery_closed = {}, {}
         closed_map = pickup_closed if order_type == 'afhalen' else delivery_closed
-        if gekozen and gekozen in closed_map:
-            msg = 'Tijdslot vol' if closed_map[gekozen] == 'full' else 'Tijdslot gesloten'
-            return jsonify({"status": "fail", "error": msg}), 403
+        if gekozen:
+            hour_key = gekozen[:2] + ':00'
+            status = closed_map.get(gekozen) or closed_map.get(hour_key)
+            if status:
+                msg = 'Tijdslot vol' if status == 'full' else 'Tijdslot gesloten'
+                return jsonify({"status": "fail", "error": msg}), 403
         # ===== 新时间判断逻辑结束 =====
 
         # 1. 构造订单对象（初始字段）

--- a/templates/index.html
+++ b/templates/index.html
@@ -5726,6 +5726,12 @@ let allowedPostcodes = [];
 let pickupClosedSlots = {};
 let deliveryClosedSlots = {};
 let currentSettings = {};
+
+function isSlotClosed(str, closedSlots){
+  if(!str) return false;
+  const hourKey = str.slice(0,2) + ':00';
+  return !!(closedSlots[str] || closedSlots[hourKey]);
+}
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
   el.textContent = msg;
@@ -6098,6 +6104,13 @@ function checkout() {
     const prev = select.value; // 保留当前选中值
     select.innerHTML = '';
 
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Kies een tijd';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    select.appendChild(placeholder);
+
     const now = new Date();
     now.setMinutes(now.getMinutes() + offsetMinutes); // 现在时间 + 制作时间缓冲
 
@@ -6128,16 +6141,13 @@ function checkout() {
     if (allTimes.length) {
         const lastTime = allTimes[allTimes.length - 1].time;
         if (now >= lastTime) {
-            const opt = document.createElement('option');
-            opt.value = '';
-            opt.textContent = 'Geen beschikbare tijd';
-            select.appendChild(opt);
+            placeholder.textContent = 'Geen beschikbare tijd';
             return;
         }
     }
 
     const currentSlot = `${pad(current.getHours())}:00`;
-    const inClosedSlot = !!closedSlots[currentSlot];
+    const inClosedSlot = !!isSlotClosed(currentSlot, closedSlots);
     if (showZSM && current >= open && !inClosedSlot) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'Z.S.M.';
@@ -6153,7 +6163,7 @@ function checkout() {
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
     for (const { time, str } of allTimes) {
-        const status = closedSlots[str];
+        const status = closedSlots[str] || closedSlots[`${str.slice(0,2)}:00`];
         if (status && hideClosed) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
@@ -6167,22 +6177,19 @@ function checkout() {
         select.appendChild(opt);
     }
 
-    if (select.options.length === 0) {
-        const opt = document.createElement('option');
-        opt.value = '';
-        opt.textContent = 'Geen beschikbare tijd';
-        select.appendChild(opt);
+    if (select.options.length === 1) {
+        placeholder.textContent = 'Geen beschikbare tijd';
     }
 
-  if (prev && !closedSlots[prev]) {
+    if (prev && !isSlotClosed(prev, closedSlots)) {
       const option = Array.from(select.options).find(o => o.value === prev);
       if (option) select.value = prev;
-  }
+    }
   }
 
   function clearIfClosed(selectId, closedMap){
     const sel = document.getElementById(selectId);
-    if (sel && sel.value && closedMap[sel.value]){
+    if (sel && sel.value && isSlotClosed(sel.value, closedMap)){
       sel.value = '';
       alert('Geselecteerde tijd is niet meer beschikbaar. Kies een andere.');
     }
@@ -6241,7 +6248,7 @@ function checkout() {
 
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
-      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots, true);
       clearIfClosed('pickup_time', pickupClosedSlots);
       updateCartPaymentOptions();
     } else {
@@ -6250,7 +6257,7 @@ function checkout() {
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
-      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots, true);
       clearIfClosed('delivery_time', deliveryClosedSlots);
       updateCartPaymentOptions();
     }
@@ -7181,8 +7188,8 @@ function updateStatus(settings) {
   pickupClosedSlots = settings.pickup_closed_slots || {};
   deliveryClosedSlots = settings.delivery_closed_slots || {};
 
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots, true);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots, true);
   clearIfClosed('pickup_time', pickupClosedSlots);
   clearIfClosed('delivery_time', deliveryClosedSlots);
 
@@ -7296,8 +7303,8 @@ function updateTimes(settings){
   timeInterval = parseInt(settings.time_interval || timeInterval);
   pickupClosedSlots = settings.pickup_closed_slots || {};
   deliveryClosedSlots = settings.delivery_closed_slots || {};
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots, true);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots, true);
   clearIfClosed('pickup_time', pickupClosedSlots);
   clearIfClosed('delivery_time', deliveryClosedSlots);
 }

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5317,6 +5317,12 @@ let allowedPostcodes = [];
 let pickupClosedSlots = {};
 let deliveryClosedSlots = {};
 let currentSettings = {};
+
+function isSlotClosed(str, closedSlots){
+  if(!str) return false;
+  const hourKey = str.slice(0,2) + ':00';
+  return !!(closedSlots[str] || closedSlots[hourKey]);
+}
 function showFeedback(msg, isError=false) {
   const el = document.getElementById('feedback');
   el.textContent = msg;
@@ -5699,6 +5705,13 @@ function checkout() {
     const prev = select.value; // 保留当前选中值
     select.innerHTML = '';
 
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Choose time';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    select.appendChild(placeholder);
+
     const now = new Date();
     now.setMinutes(now.getMinutes() + offsetMinutes); // 现在时间 + 制作时间缓冲
 
@@ -5729,16 +5742,13 @@ function checkout() {
     if (allTimes.length) {
         const lastTime = allTimes[allTimes.length - 1].time;
         if (now >= lastTime) {
-            const opt = document.createElement('option');
-            opt.value = '';
-            opt.textContent = 'No available time';
-            select.appendChild(opt);
+            placeholder.textContent = 'No available time';
             return;
         }
     }
 
     const currentSlot = `${pad(current.getHours())}:00`;
-    const inClosedSlot = !!closedSlots[currentSlot];
+    const inClosedSlot = !!isSlotClosed(currentSlot, closedSlots);
     if (showZSM && current >= open && !inClosedSlot) {
         const asapOpt = document.createElement('option');
         asapOpt.value = 'ASAP';
@@ -5754,7 +5764,7 @@ function checkout() {
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
     for (const { time, str } of allTimes) {
-        const status = closedSlots[str];
+        const status = closedSlots[str] || closedSlots[`${str.slice(0,2)}:00`];
         if (status && hideClosed) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
@@ -5768,15 +5778,12 @@ function checkout() {
         select.appendChild(opt);
     }
 
-    if (select.options.length === 0) {
-        const opt = document.createElement('option');
-        opt.value = '';
-        opt.textContent = 'Closed';
-        select.appendChild(opt);
+    if (select.options.length === 1) {
+        placeholder.textContent = 'No available time';
     }
 
     // 保留用户上一次选择的时间（如果还存在）
-    if (prev && !closedSlots[prev]) {
+    if (prev && !isSlotClosed(prev, closedSlots)) {
         const option = Array.from(select.options).find(o => o.value === prev);
         if (option) select.value = prev;
     }
@@ -5784,7 +5791,7 @@ function checkout() {
 
   function clearIfClosed(selectId, closedMap){
     const sel = document.getElementById(selectId);
-    if(sel && sel.value && closedMap[sel.value]){
+    if(sel && sel.value && isSlotClosed(sel.value, closedMap)){
       sel.value = '';
       alert('Selected time is no longer available. Please choose again.');
     }
@@ -5843,7 +5850,7 @@ function checkout() {
 
       afhalenFields.classList.remove('hidden');
       bezorgenFields.classList.add('hidden');
-      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
+      populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots, true);
       clearIfClosed('pickup_time', pickupClosedSlots);
       updateCartPaymentOptions();
     } else {
@@ -5852,7 +5859,7 @@ function checkout() {
 
       bezorgenFields.classList.remove('hidden');
       afhalenFields.classList.add('hidden');
-      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+      populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots, true);
       clearIfClosed('delivery_time', deliveryClosedSlots);
       updateCartPaymentOptions();
     }
@@ -6753,8 +6760,8 @@ function updateStatus(settings) {
   pickupClosedSlots = settings.pickup_closed_slots || {};
   deliveryClosedSlots = settings.delivery_closed_slots || {};
 
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots, true);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots, true);
   clearIfClosed('pickup_time', pickupClosedSlots);
   clearIfClosed('delivery_time', deliveryClosedSlots);
 
@@ -6868,8 +6875,8 @@ function updateTimes(settings){
   timeInterval = parseInt(settings.time_interval || timeInterval);
   pickupClosedSlots = settings.pickup_closed_slots || {};
   deliveryClosedSlots = settings.delivery_closed_slots || {};
-  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots);
-  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots);
+  populateTimeOptions('pickup_time', 30, pickupOpenTime, pickupCloseTime, pickupClosedSlots, true);
+  populateTimeOptions('delivery_time', 45, deliveryOpenTime, deliveryCloseTime, deliveryClosedSlots, true);
   clearIfClosed('pickup_time', pickupClosedSlots);
   clearIfClosed('delivery_time', deliveryClosedSlots);
 }


### PR DESCRIPTION
## Summary
- Treat closed hours as unavailable for all minutes in that hour
- Force customers to manually choose a time and hide closed slots
- Validate on backend that chosen times don't fall in closed hours

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68973867f6188333bc317a0b589b8679