### PR TITLE
Apply hourly closures across pickers

### DIFF
--- a/app.py
+++ b/app.py
@@ -818,9 +818,12 @@ def api_orders():
         except Exception:
             pickup_closed, delivery_closed = {}, {}
         closed_map = pickup_closed if order_type == 'afhalen' else delivery_closed
-        if gekozen and gekozen in closed_map:
-            msg = 'Tijdslot vol' if closed_map[gekozen] == 'full' else 'Tijdslot gesloten'
-            return jsonify({"status": "fail", "error": msg}), 403
+        if gekozen:
+            hour_key = f"{gekozen.split(':')[0]}:00" if ':' in gekozen else None
+            status = closed_map.get(gekozen) or (hour_key and closed_map.get(hour_key))
+            if status:
+                msg = 'Tijdslot vol' if status in ['full', 'closed'] else 'Tijdslot gesloten'
+                return jsonify({"status": "fail", "error": msg}), 403
         # ===== 新时间判断逻辑结束 =====
 
         # 1. 构造订单对象（初始字段）

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -719,9 +719,9 @@
                   .filter(Boolean)
                   .join(',');
             const pickup_closed_slots = {};
-            document.querySelectorAll('.pickup-slot:not(:checked)').forEach(cb => pickup_closed_slots[cb.value] = 'closed');
+            document.querySelectorAll('.pickup-slot:not(:checked)').forEach(cb => pickup_closed_slots[cb.value] = 'full');
             const delivery_closed_slots = {};
-            document.querySelectorAll('.delivery-slot:not(:checked)').forEach(cb => delivery_closed_slots[cb.value] = 'closed');
+            document.querySelectorAll('.delivery-slot:not(:checked)').forEach(cb => delivery_closed_slots[cb.value] = 'full');
             const time_interval = document.getElementById('interval_select').value;
             const show_zsm_option = document.getElementById('show_zsm_select').value;
             const milktea_soldout = document.getElementById('milktea_soldout_select').value;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6153,14 +6153,15 @@ function checkout() {
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
     for (const { time, str } of allTimes) {
-        const status = closedSlots[str];
+        const hourKey = `${pad(time.getHours())}:00`;
+        const status = closedSlots[str] || closedSlots[hourKey];
         if (status && hideClosed) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
         opt.value = str;
         if (status) {
             opt.disabled = true;
-            opt.textContent = `${str} (${status === 'full' ? 'Vol' : 'Gesloten'})`;
+            opt.textContent = `${str} (${status === 'full' || status === 'closed' ? 'Vol' : 'Gesloten'})`;
         } else {
             opt.textContent = str;
         }
@@ -6182,7 +6183,8 @@ function checkout() {
 
   function clearIfClosed(selectId, closedMap){
     const sel = document.getElementById(selectId);
-    if (sel && sel.value && closedMap[sel.value]){
+    const hourKey = sel && sel.value ? sel.value.split(':')[0] + ':00' : null;
+    if (sel && sel.value && (closedMap[sel.value] || (hourKey && closedMap[hourKey]))){
       sel.value = '';
       alert('Geselecteerde tijd is niet meer beschikbaar. Kies een andere.');
     }

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5754,14 +5754,15 @@ function checkout() {
     const lastTwo = allTimes.slice(-2).map(t => t.str);
 
     for (const { time, str } of allTimes) {
-        const status = closedSlots[str];
+        const hourKey = `${pad(time.getHours())}:00`;
+        const status = closedSlots[str] || closedSlots[hourKey];
         if (status && hideClosed) continue;
         if (time < start && !lastTwo.includes(str)) continue;
         const opt = document.createElement('option');
         opt.value = str;
         if (status) {
             opt.disabled = true;
-            opt.textContent = `${str} (${status === 'full' ? 'Full' : 'Closed'})`;
+            opt.textContent = `${str} (${status === 'full' || status === 'closed' ? 'Full' : 'Closed'})`;
         } else {
             opt.textContent = str;
         }
@@ -5784,7 +5785,8 @@ function checkout() {
 
   function clearIfClosed(selectId, closedMap){
     const sel = document.getElementById(selectId);
-    if(sel && sel.value && closedMap[sel.value]){
+    const hourKey = sel && sel.value ? sel.value.split(':')[0] + ':00' : null;
+    if(sel && sel.value && (closedMap[sel.value] || (hourKey && closedMap[hourKey]))){
       sel.value = '';
       alert('Selected time is no longer available. Please choose again.');
     }


### PR DESCRIPTION
## Summary
- Mark unchecked dashboard time slots as `full` so closures cover the whole hour
- Expand time pickers to disable every quarter-hour within closed hours and show "Vol"/"Full"
- Validate closed hours on the server to block orders in any minute of that hour

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897628d1a3c8333a99d834d9911d401