### PR TITLE
Fix VAT display in order cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -367,6 +367,10 @@ def orders_to_dicts(orders):
         delivery_calc = totaal + o.discount_amount - subtotal - o.verpakkingskosten - (o.fooi or 0)
         delivery_calc = round(delivery_calc, 2)
         delivery = o.bezorgkosten if o.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
+        o.bezorgkosten = delivery
+        total_before_btw = subtotal + (o.verpakkingskosten or 0) + delivery - (o.discount_amount or 0)
+        btw_base = total_before_btw - delivery if delivery else total_before_btw
+        o.btw = round(btw_base * 0.09, 2)
         result.append({
             "id": o.id,
             "order_type": o.order_type,
@@ -392,6 +396,7 @@ def orders_to_dicts(orders):
             "totaal": totaal,
             "verpakkingskosten": o.verpakkingskosten,
             "bezorgkosten": delivery,
+            "btw": o.btw,
             "fooi": o.fooi or 0,
             "order_number": o.order_number,
             "korting": o.discount_amount,
@@ -1836,6 +1841,17 @@ def pos_orders_today():
 
         # ✅ 正确使用数据库中的 totaal
         totaal = o.totaal or 0
+        subtotal = sum(
+            float(i.get("price", 0)) * int(i.get("qty", 0))
+            for i in o.items_dict.values()
+        )
+        delivery_calc = totaal + o.discount_amount - subtotal - o.verpakkingskosten - (o.fooi or 0)
+        delivery_calc = round(delivery_calc, 2)
+        delivery = o.bezorgkosten if o.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
+        o.bezorgkosten = delivery
+        total_before_btw = subtotal + (o.verpakkingskosten or 0) + delivery - (o.discount_amount or 0)
+        btw_base = total_before_btw - delivery if delivery else total_before_btw
+        o.btw = round(btw_base * 0.09, 2)
 
         o.created_at_local = to_nl(o.created_at)
         summary = "\n".join(f"{name} x {item['qty']}" for name, item in o.items_dict.items())
@@ -1889,6 +1905,7 @@ def pos_orders_today():
             "totaal": totaal,
             "verpakkingskosten": o.verpakkingskosten,
             "bezorgkosten": o.bezorgkosten,
+            "btw": o.btw,
             "fooi": o.fooi or 0,
             "order_number": o.order_number,  # ✅ 加上这行
             "korting": o.discount_amount,

--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -157,6 +157,10 @@
         <p><strong>Opmerking:</strong> {{ order.opmerking or '-' }}</p>
         <p><strong>Ordernummer:</strong> {{ order.order_number or '' }}</p>
         <p><strong>Totaal:</strong> €{{ '%.2f' % (order.totaal or 0) }}</p>
+        {% if is_delivery %}
+        <p><strong>Bezorgkosten:</strong> €{{ '%.2f' % (order.bezorgkosten or 0) }}</p>
+        {% endif %}
+        <p><strong>BTW:</strong> €{{ '%.2f' % (order.btw or 0) }}</p>
         <p><strong>Adres:</strong>
           {% if is_delivery %}
             {{ order.street }} {{ order.house_number }} {{ order.postcode }} {{ order.city }}


### PR DESCRIPTION
## Summary
- compute VAT for each order on the backend and expose it via API
- display bezorgkosten and BTW on order cards

## Testing
- `python -m py_compile app.py electron-pos/appB.py`
- `pytest` *(fails: collected 0 items)*
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_689841e41c40833391713adeaab113e8