### PR TITLE
Persist order VAT data

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,6 +72,16 @@ with app.app_context():
         if "tijdslot_display" not in cols:
             with db.engine.begin() as conn:
                 conn.execute(text("ALTER TABLE orders ADD COLUMN tijdslot_display TEXT"))
+        # Ensure BTW columns exist
+        if "btw_9" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN btw_9 FLOAT DEFAULT 0"))
+        if "btw_21" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN btw_21 FLOAT DEFAULT 0"))
+        if "btw" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN btw FLOAT DEFAULT 0"))
         cols = {c["name"] for c in inspector.get_columns("reviews")}
         if "rating" not in cols:
             with db.engine.begin() as conn:
@@ -379,22 +389,24 @@ def orders_to_dicts(orders):
         delivery = o.bezorgkosten if o.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
         o.bezorgkosten = delivery
 
-        # 21% VAT 仅对 heineken
-        heineken_total = sum(
-            float(item.get("price", 0)) * int(item.get("qty", 0))
-            for name, item in (o.items_dict or {}).items()
-            if "heineken" in str(name).lower()
-        )
+        # Recalculate BTW if not stored
+        if o.btw is None:
+            heineken_total = sum(
+                float(item.get("price", 0)) * int(item.get("qty", 0))
+                for name, item in (o.items_dict or {}).items()
+                if "heineken" in str(name).lower()
+            )
 
-        if o.btw_21 is None:
-            o.btw_21 = round(heineken_total * 0.21, 2)
+            if o.btw_21 is None:
+                o.btw_21 = round(heineken_total * 0.21, 2)
 
-        if o.btw_9 is None:
-            base_total = subtotal - heineken_total + verpakkings + delivery
-            o.btw_9 = round(base_total * 0.09, 2)
+            if o.btw_9 is None:
+                base_total = subtotal - heineken_total + verpakkings + delivery
+                o.btw_9 = round(base_total * 0.09, 2)
 
-        btw_total = (o.btw_9 or 0) + (o.btw_21 or 0)
-        o.btw = btw_total
+            o.btw = (o.btw_9 or 0) + (o.btw_21 or 0)
+
+        btw_total = o.btw or 0
 
         result.append({
             "id": o.id,
@@ -528,6 +540,7 @@ class Order(db.Model):
     discount_amount = db.Column(db.Float, default=0.0)  # ✅ 新增
     btw_9 = db.Column(db.Float, default=0.0)
     btw_21 = db.Column(db.Float, default=0.0)
+    btw = db.Column(db.Float, default=0.0)
     is_completed = db.Column(db.Boolean, default=False)
     is_cancelled = db.Column(db.Boolean, default=False)
 
@@ -558,9 +571,10 @@ class Order(db.Model):
             "discount_code": self.discount_code,
             "discount_amount": self.discount_amount,
             "bezorging": self.bezorgkosten,
+            "btw": self.btw or (self.btw_9 or 0.0) + (self.btw_21 or 0.0),
             "btw_9": self.btw_9 or 0.0,
             "btw_21": self.btw_21 or 0.0,
-            "btw_total": (self.btw_9 or 0.0) + (self.btw_21 or 0.0),
+            "btw_total": self.btw or (self.btw_9 or 0.0) + (self.btw_21 or 0.0),
             "is_completed": self.is_completed,
             "is_cancelled": self.is_cancelled
         }
@@ -919,6 +933,7 @@ def api_orders():
             order.btw_21 = round(heineken_total * 0.21, 2)
             base_total = subtotal - heineken_total + order.verpakkingskosten + order.bezorgkosten
             order.btw_9 = round(base_total * 0.09, 2)
+        order.btw = (order.btw_9 or 0) + (order.btw_21 or 0)
         # 3. 保存订单到数据库
         db.session.add(order)
         db.session.commit()


### PR DESCRIPTION
## Summary
- Ensure `orders` table has `btw_9`, `btw_21`, and total `btw` columns
- Populate VAT fields when creating orders in both Flask app and Electron POS backend
- Expose VAT amounts via `Order.to_dict`

## Testing
- `python -m py_compile app.py electron-pos/appB.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a94988708333a9c69fd4ce054ff5