### PR TITLE
refactor: migrate discount fields to next order variants

### DIFF
--- a/electron-pos/appB.py
+++ b/electron-pos/appB.py
@@ -187,7 +187,7 @@ def order_to_dict(order):
         float(i.get("price", 0)) * int(i.get("qty", 0))
         for i in items.values()
     )
-    delivery_calc = order.totaal + order.discount_amount - subtotal - order.verpakkingskosten - (order.fooi or 0)
+    delivery_calc = order.totaal + order.next_discount_amount - subtotal - order.verpakkingskosten - (order.fooi or 0)
     delivery_calc = round(delivery_calc, 2)
     delivery = order.bezorgkosten if order.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
 
@@ -211,8 +211,8 @@ def order_to_dict(order):
         "verpakkingskosten": order.verpakkingskosten,
         "bezorgkosten": delivery,
         "fooi": order.fooi,
-        "discount_code": order.discount_code,
-        "discount_amount": order.discount_amount,
+        "next_discount_code": order.next_discount_code,
+        "next_discount_amount": order.next_discount_amount,
         "opmerking": order.opmerking,
         "items": items,
         "created_at": order.created_at.isoformat() if order.created_at else None,
@@ -373,7 +373,7 @@ def orders_to_dicts(orders):
             float(i.get("price", 0)) * int(i.get("qty", 0))
             for i in o.items_dict.values()
         )
-        delivery_calc = totaal + o.discount_amount - subtotal - o.verpakkingskosten - (o.fooi or 0)
+        delivery_calc = totaal + o.next_discount_amount - subtotal - o.verpakkingskosten - (o.fooi or 0)
         delivery_calc = round(delivery_calc, 2)
         delivery = o.bezorgkosten if o.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
         o.bezorgkosten = delivery
@@ -420,7 +420,7 @@ def orders_to_dicts(orders):
             "btw_total": o.btw,
             "fooi": o.fooi or 0,
             "order_number": o.order_number,
-            "korting": o.discount_amount,
+            "korting": o.next_discount_amount,
             "is_completed": o.is_completed,
             "is_cancelled": o.is_cancelled
         })
@@ -516,8 +516,8 @@ class Order(db.Model):
     verpakkingskosten = db.Column(db.Float, default=0.0)
     fooi = db.Column(db.Float, default=0.0)
     bezorgkosten = db.Column(db.Float, default=0.0)
-    discount_code = db.Column(db.String(50))  # ✅ 新增
-    discount_amount = db.Column(db.Float, default=0.0)  # ✅ 新增
+    next_discount_code = db.Column(db.String(50))  # ✅ 新增
+    next_discount_amount = db.Column(db.Float, default=0.0)  # ✅ 新增
     btw_9 = db.Column(db.Float, default=0.0)
     btw_21 = db.Column(db.Float, default=0.0)
     btw = db.Column(db.Float, default=0.0)
@@ -548,8 +548,8 @@ class Order(db.Model):
             "verpakkingskosten": self.verpakkingskosten,
             "bezorgkosten": self.bezorgkosten,
             "fooi": self.fooi,
-            "discount_code": self.discount_code,
-            "discount_amount": self.discount_amount,
+            "next_discount_code": self.next_discount_code,
+            "next_discount_amount": self.next_discount_amount,
             "bezorging": self.bezorgkosten,
             "btw": self.btw or (self.btw_9 or 0.0) + (self.btw_21 or 0.0),
             "btw_9": self.btw_9 or 0.0,
@@ -865,8 +865,8 @@ def api_orders():
             items=json.dumps(data.get("items", {})),
             order_number=order_number,
             fooi=float(data.get("tip") or data.get("fooi") or 0),
-            discount_code=None,
-            discount_amount=data.get("discount_amount")
+            next_discount_code=None,
+            next_discount_amount=data.get("next_discount_amount")
         )
 
         # 2. 计算 subtotal / totaal
@@ -880,8 +880,12 @@ def api_orders():
         summary_data = data.get("summary") or {}
         order.verpakkingskosten = float(summary_data.get("packaging") or 0)
         order.bezorgkosten = float(summary_data.get("delivery") or 0)
-        if summary_data.get("discountAmount") is not None:
-            order.discount_amount = float(summary_data.get("discountAmount") or 0)
+        if summary_data.get("next_discount_amount") is not None:
+            order.next_discount_amount = float(summary_data.get("next_discount_amount") or 0)
+        elif summary_data.get("nextDiscountAmount") is not None:
+            order.next_discount_amount = float(summary_data.get("nextDiscountAmount") or 0)
+        elif summary_data.get("discountAmount") is not None:
+            order.next_discount_amount = float(summary_data.get("discountAmount") or 0)
         btw_split = summary_data.get("btw_split") or data.get("btw_split") or {}
         try:
             order.btw_9 = float(btw_split.get("9") or btw_split.get("btw_9") or 0)
@@ -901,12 +905,12 @@ def api_orders():
         order.btw = (order.btw_9 or 0) + (order.btw_21 or 0)
 
         # 3. 处理折扣码
-        raw_discount_code = data.get("discount_code") or data.get("discountCode")
+        raw_discount_code = data.get("next_discount_code") or data.get("discountCode")
         if raw_discount_code and raw_discount_code.upper() == "KASSA":
-            order.discount_code = "kassa korting"
+            order.next_discount_code = "kassa korting"
             discount_code = None
         else:
-            order.discount_code = raw_discount_code
+            order.next_discount_code = raw_discount_code
             discount_code = raw_discount_code
 
         # 4. 保存订单到数据库
@@ -919,19 +923,23 @@ def api_orders():
             or data.get("customerEmail")
             or order.email
         )
-        discount_amount = data.get("discount_amount") or 0
+        next_discount_amount = (
+            data.get("next_discount_amount")
+            or data.get("discountAmount")
+            or 0
+        )
 
         if discount_code and customer_email:
             disc = DiscountCode(
                 code=discount_code,
                 customer_email=customer_email,
                 discount_percentage=3.0,
-                discount_amount=discount_amount,
+                discount_amount=next_discount_amount,
                 is_used=False,
             )
             db.session.add(disc)
             db.session.commit()
-            print(f"✅ 折扣码保存成功: {discount_code} for {customer_email} met korting {discount_amount}")
+            print(f"✅ 折扣码保存成功: {discount_code} for {customer_email} met korting {next_discount_amount}")
 
         print("✅ 接收到订单:", data)
 
@@ -964,13 +972,13 @@ def validate_discount():
         data = request.get_json()
         code = data.get("code")
         order_total = float(data.get("order_total") or 0)
-        manual_amount = float(data.get("discount_amount") or 0)
+        manual_amount = float(data.get("next_discount_amount") or 0)
 
         if code and code.upper() == "KASSA":
             new_total = max(0, order_total - manual_amount)
             return jsonify({
                 "valid": True,
-                "discount_amount": manual_amount,
+                "next_discount_amount": manual_amount,
                 "new_total": new_total,
                 "note": "kassa korting"
             }), 200
@@ -983,16 +991,16 @@ def validate_discount():
             return jsonify({"valid": False, "error": "Minimum order total not met"}), 400
 
         # ✅ 改成使用数据库折扣金额
-        discount_amount = disc.discount_amount
+        next_discount_amount = disc.discount_amount
 
-        new_total = max(0, order_total - discount_amount)
+        new_total = max(0, order_total - next_discount_amount)
 
         disc.is_used = True
         db.session.commit()
 
         return jsonify({
             "valid": True,
-            "discount_amount": discount_amount,
+            "next_discount_amount": next_discount_amount,
             "new_total": new_total
         }), 200
 
@@ -1814,7 +1822,7 @@ def pos_orders_today():
             float(i.get("price", 0)) * int(i.get("qty", 0))
             for i in o.items_dict.values()
         )
-        delivery_calc = totaal + o.discount_amount - subtotal - o.verpakkingskosten - (o.fooi or 0)
+        delivery_calc = totaal + o.next_discount_amount - subtotal - o.verpakkingskosten - (o.fooi or 0)
         delivery_calc = round(delivery_calc, 2)
         delivery = o.bezorgkosten if o.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
         o.bezorgkosten = delivery
@@ -1889,7 +1897,7 @@ def pos_orders_today():
             "btw_total": o.btw,
             "fooi": o.fooi or 0,
             "order_number": o.order_number,  # ✅ 加上这行
-            "korting": o.discount_amount,
+            "korting": o.next_discount_amount,
             "is_completed": o.is_completed,
             "is_cancelled": o.is_cancelled
         })

--- a/electron-pos/main.js
+++ b/electron-pos/main.js
@@ -237,10 +237,10 @@ function normalizeForPrint(order) {
     order.discount_used_code ?? order.discountCode
   ); // 本次使用的代码
   const discount_earned_amount = toNumOrNull(
-    order.discount_earned_amount ?? order.discount_amount
+    order.discount_earned_amount ?? order.next_discount_amount
   ); // 下次可用金额
   const discount_earned_code = toStr(
-    order.discount_earned_code ?? order.discount_code
+    order.discount_earned_code ?? order.next_discount_code
   ); // 下次可用代码
 
   // 历史/兜底折扣（若上面未给时才使用）
@@ -598,10 +598,10 @@ if (order.total != null) {
 // ===== 下一次优惠券提醒 =====
 {
   const earnedAmt = Number(
-    order.discount_earned_amount ?? order.discount_amount ?? 0
+    order.discount_earned_amount ?? order.next_discount_amount ?? 0
   );
   const earnedCode = String(
-    order.discount_earned_code ?? order.discount_code ?? ''
+    order.discount_earned_code ?? order.next_discount_code ?? ''
   ).trim();
   if (earnedAmt > 0 || earnedCode) {
     line('-');

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2842,7 +2842,7 @@ function addRow(order, highlight = false) {
   const sourceRaw = (order.source || '').toLowerCase();
   const sourceDisplay = sourceRaw === 'index' ? 'Website' : 'POS';
   // Prefer newer discount fields if available
-  const discountCode = order.discount_used_code || order.discountCode || order.discount_code || '';
+  const discountCode = order.discount_used_code || order.discountCode || order.next_discount_code || '';
   const discountLabel = sourceRaw === 'index'
     ? `Online Korting${discountCode ? ` (${discountCode})` : ''}`
     : 'Kassa Korting';


### PR DESCRIPTION
## Summary
- replace `discount_code`/`discount_amount` references with `next_discount_code`/`next_discount_amount` in electron POS
- update order model and API logic to store and expose next-order discount fields
- adjust POS UI to read new discount field names

## Testing
- `python -m py_compile electron-pos/appB.py`
- `node --check electron-pos/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6899f77d77188333bab61145928f1c7c