### PR TITLE
refactor: use snake case for discount fields on frontend

### DIFF
--- a/electron-pos/main.js
+++ b/electron-pos/main.js
@@ -229,12 +229,12 @@ function normalizeForPrint(order) {
   const tip          = pickMax(order.fooi, order.tip);
 
   // 折扣字段：本次使用 vs 下次可用（重要区分）
-  // 折扣字段：兼容新老字段命名
+  // 折扣字段：采用下划线命名
   const discount_used_amount = toNumOrNull(
-    order.discount_used_amount ?? order.discountAmount ?? order.discount_amount
+    order.discount_used_amount ?? order.discount_amount
   ); // 本次使用金额
   const discount_used_code = toStr(
-    order.discount_used_code ?? order.discountCode ?? order.discount_code
+    order.discount_used_code ?? order.discount_code
   ); // 本次使用的代码
   const discount_earned_amount = toNumOrNull(
     order.discount_earned_amount ?? order.next_discount_amount
@@ -546,13 +546,11 @@ col2('Subtotaal',   `EUR ${to2(order.subtotal)}`);
 {
   const usedAmt = Number(
     order.discount_used_amount       // 已在 normalize 写入
-    ?? order.discountAmount          // payload: 本次使用金额
     ?? order.discount_amount
     ?? 0
   );
   const usedCode = String(
     order.discount_used_code         // 已在 normalize 写入
-    ?? order.discountCode            // payload: 本次使用 code
     ?? order.discount_code
     ?? ''
   ).trim();

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2221,7 +2221,7 @@ function submitOrder() {
     delivery: parseFloat(deliveryCost.toFixed(2)),
     discountType,
     discountValue: parseFloat(discountVal.toFixed(2)),
-    discountAmount: parseFloat(discount.toFixed(2)),
+    discount_amount: parseFloat(discount.toFixed(2)),
     btw: parseFloat(btw.toFixed(2)),
     btw_9: parseFloat(btw9.toFixed(2)),
     btw_21: parseFloat(btw21.toFixed(2)),
@@ -2268,8 +2268,8 @@ function submitOrder() {
 
   // ✅ 手动折扣：无真实折扣码但有折扣金额时，写入固定折扣码
   if (discount > 0) {
-    payload.discountCode = 'KASSA';
-    payload.discountAmount = parseFloat(discount.toFixed(2));
+    payload.discount_code = 'KASSA';
+    payload.discount_amount = parseFloat(discount.toFixed(2));
   }
 
   // ✅ 提交到后端
@@ -2842,9 +2842,9 @@ function addRow(order, highlight = false) {
   const sourceRaw = (order.source || '').toLowerCase();
   const sourceDisplay = sourceRaw === 'index' ? 'Website' : 'POS';
   // Prefer newer discount fields if available
-  const discountCode = order.discount_used_code || order.discountCode || order.next_discount_code || '';
+  const discount_code = order.discount_used_code || order.discount_code || order.next_discount_code || '';
   const discountLabel = sourceRaw === 'index'
-    ? `Online Korting${discountCode ? ` (${discountCode})` : ''}`
+    ? `Online Korting${discount_code ? ` (${discount_code})` : ''}`
     : 'Kassa Korting';
 
   const tijdslotRaw = order.tijdslot_display || (isDelivery ? order.delivery_time : order.pickup_time);

--- a/templates/index.html
+++ b/templates/index.html
@@ -2571,8 +2571,8 @@ body.portrait-mode .cart-badge {
       <div class="spacer"></div>
       <div class="spacer"></div>
       <div class="price-row">
-        <label for="discountCode">Kortingscode:</label>
-        <input id="discountCode" />
+        <label for="discount_code">Kortingscode:</label>
+        <input id="discount_code" />
         <!-- 桌面端按钮（原样保留） -->
         <button id="validateDiscountBtn" class="apply-discount-btn" type="button">Apply</button>
 
@@ -4804,7 +4804,7 @@ const localOk = (() => {
 function saveOrderForm() {
   if (!storageOk) return;
   const data = { orderType: document.querySelector('input[name="orderType"]:checked')?.id };
-  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discountCode, #tipSelect').forEach(el => {
+  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discount_code, #tipSelect').forEach(el => {
     if (el.id) data[el.id] = el.value;
   });
   sessionStorage.setItem(FORM_KEY, JSON.stringify(data));
@@ -4831,7 +4831,7 @@ function loadOrderForm() {
 
 function attachFormListeners() {
   if (!storageOk) return;
-  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discountCode, #tipSelect, input[name="orderType"]').forEach(el => {
+  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discount_code, #tipSelect, input[name="orderType"]').forEach(el => {
     ['input', 'change'].forEach(evt => el.addEventListener(evt, saveOrderForm));
   });
 }
@@ -4897,7 +4897,7 @@ function updatePriceBreakdown(subtotal, packaging, heineken = currentHeineken) {
 let isValidating = false; // 防止重复点击的锁
 
 function applyDiscount() {
-  const code = document.getElementById('discountCode').value.trim();
+  const code = document.getElementById('discount_code').value.trim();
   if (!code) {
     currentDiscount = 0;
     updatePriceBreakdown(currentSubtotal, currentPackaging);
@@ -5975,11 +5975,11 @@ function checkout() {
 
   const orderNumber = generateOrderNumber();
 
-  const discountCode = document.getElementById('discountCode').value.trim();
+  const discount_code = document.getElementById('discount_code').value.trim();
   const deliveryLine = deliveryFee > 0 ? `\nBezorgkosten: €${deliveryFee.toFixed(2)}` : '';
   const packagingLine = packagingFee > 0 ? `\nVerpakkingskosten: €${packagingFee.toFixed(2)}` : '';
   const tipLine = tip > 0 ? `\nFooi: €${tip.toFixed(2)}` : '';
-  const discountLine = `\nKorting: -€${discount.toFixed(2)} (Code: ${discountCode || 'geen'})`;
+  const discountLine = `\nKorting: -€${discount.toFixed(2)} (Code: ${discount_code || 'geen'})`;
 
   const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}${deliveryLine}${packagingLine}${tipLine}${discountLine}\nTotaal: €${totalPrice}`;
 
@@ -6064,8 +6064,8 @@ function checkout() {
       btw_split: { '9': btw9.toFixed(2), '21': btw21.toFixed(2) },
       // totaal = total（含税）——和后端一致口径
       totaal: totalPrice,
-      discountAmount: discount.toFixed(2),
-      discountCode,
+      discount_amount: discount.toFixed(2),
+      discount_code,
       message,
       summary
     })

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -2216,8 +2216,8 @@ body.portrait-mode #cart-toggle {
       <div class="spacer"></div>
       <div class="spacer"></div>
       <div class="price-row">
-        <label for="discountCode">Discount code:</label>
-        <input id="discountCode" />
+        <label for="discount_code">Discount code:</label>
+        <input id="discount_code" />
         <!-- 桌面端按钮（原样保留） -->
         <button id="validateDiscountBtn" class="apply-discount-btn" type="button">Apply</button>
 
@@ -4395,7 +4395,7 @@ const localOk = (() => {
 function saveOrderForm() {
   if (!storageOk) return;
   const data = { orderType: document.querySelector('input[name="orderType"]:checked')?.id };
-  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discountCode, #tipSelect').forEach(el => {
+  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discount_code, #tipSelect').forEach(el => {
     if (el.id) data[el.id] = el.value;
   });
   sessionStorage.setItem(FORM_KEY, JSON.stringify(data));
@@ -4422,7 +4422,7 @@ function loadOrderForm() {
 
 function attachFormListeners() {
   if (!storageOk) return;
-  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discountCode, #tipSelect, input[name="orderType"]').forEach(el => {
+  document.querySelectorAll('#afhalenFields input, #afhalenFields select, #bezorgenFields input, #bezorgenFields select, #checkbox-group select, #remark, #discount_code, #tipSelect, input[name="orderType"]').forEach(el => {
     ['input', 'change'].forEach(evt => el.addEventListener(evt, saveOrderForm));
   });
 }
@@ -4485,7 +4485,7 @@ function updatePriceBreakdown(subtotal, packaging) {
 let isValidating = false; // 防止重复点击的锁
 
 function applyDiscount() {
-  const code = document.getElementById('discountCode').value.trim();
+  const code = document.getElementById('discount_code').value.trim();
   if (!code) {
     currentDiscount = 0;
     updatePriceBreakdown(currentSubtotal, currentPackaging);
@@ -5539,8 +5539,8 @@ function checkout() {
     tipLine = `\nTip: €${tip.toFixed(2)}`;
   }
 
-  const discountCode = document.getElementById('discountCode').value.trim();
-  const discountLine = `\nDiscount: -€${currentDiscount.toFixed(2)} (Code: ${discountCode || 'none'})`;
+  const discount_code = document.getElementById('discount_code').value.trim();
+  const discountLine = `\nDiscount: -€${currentDiscount.toFixed(2)} (Code: ${discount_code || 'none'})`;
   const message = `📦 Nieuwe bestelling bij *Nova Asia*:\n\n${orderSummary}\n${customerDetails}${tipLine}${discountLine}\nTotal: €${totalPrice}`;
 
   const itemsToSend = { ...cart };
@@ -5612,8 +5612,8 @@ function checkout() {
       delivery_fee: deliveryFee.toFixed(2),
       btw: btw.toFixed(2),
       totaal: isNaN(total) ? "0.00" : total.toFixed(2),
-      discountAmount: currentDiscount.toFixed(2),
-      discountCode: discountCode,
+      discount_amount: currentDiscount.toFixed(2),
+      discount_code: discount_code,
       message,
       email,
       summary

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1715,7 +1715,7 @@ function submitOrder() {
     delivery: parseFloat(deliveryCost.toFixed(2)),
     discountType,
     discountValue: parseFloat(discountVal.toFixed(2)),
-    discountAmount: parseFloat(discount.toFixed(2)),
+    discount_amount: parseFloat(discount.toFixed(2)),
     btw: parseFloat(btw.toFixed(2)),
     btw_9: parseFloat(btw9.toFixed(2)),
     btw_21: parseFloat(btw21.toFixed(2)),
@@ -1761,8 +1761,8 @@ function submitOrder() {
 
   // ✅ 手动折扣：无真实折扣码但有折扣金额时，写入固定折扣码
   if (discount > 0) {
-    payload.discountCode = 'KASSA';
-    payload.discountAmount = parseFloat(discount.toFixed(2));
+    payload.discount_code = 'KASSA';
+    payload.discount_amount = parseFloat(discount.toFixed(2));
   }
 
   // ✅ 提交到后端


### PR DESCRIPTION
## Summary
- replace discount inputs and payload fields with `discount_code` and `discount_amount`
- align POS templates and electron scripts to snake_case discount fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a1d63f7a8833380a63700f4e11919