### PR TITLE
Separate discount fields for new and used codes

### DIFF
--- a/app.py
+++ b/app.py
@@ -188,7 +188,7 @@ def order_to_dict(order):
         float(i.get("price", 0)) * int(i.get("qty", 0))
         for i in items.values()
     )
-    delivery_calc = order.totaal + order.discount_amount - subtotal - order.verpakkingskosten - (order.fooi or 0)
+    delivery_calc = order.totaal + (order.discountAmount or 0) - subtotal - order.verpakkingskosten - (order.fooi or 0)
     delivery_calc = round(delivery_calc, 2)
     delivery = order.bezorgkosten if order.bezorgkosten not in [None, 0] else max(delivery_calc, 0)
 
@@ -209,8 +209,8 @@ def order_to_dict(order):
         "tijdslot": order.tijdslot_display,
         "payment_method": order.payment_method,
         "totaal": order.totaal,
-        "discountAmount": order.discount_amount,
-        "discountCode": order.discount_code,
+        "discountAmount": order.discountAmount,
+        "discountCode": order.discountCode,
         "verpakkingskosten": order.verpakkingskosten,
         "bezorgkosten": delivery,
         "fooi": order.fooi,
@@ -382,7 +382,7 @@ def orders_to_dicts(orders):
         )
 
         # 计算配送费兜底
-        discount = o.discount_amount or 0
+        discount = o.discountAmount or 0
         verpakkings = o.verpakkingskosten or 0
         fooi = o.fooi or 0
 
@@ -538,8 +538,10 @@ class Order(db.Model):
     verpakkingskosten = db.Column(db.Float, default=0.0)
     fooi = db.Column(db.Float, default=0.0)
     bezorgkosten = db.Column(db.Float, default=0.0)
-    discount_code = db.Column(db.String(50))  # ✅ 新增
-    discount_amount = db.Column(db.Float, default=0.0)  # ✅ 新增
+    discount_code = db.Column(db.Text)
+    discount_amount = db.Column(db.Float)
+    discountAmount = db.Column('discountAmount', db.Float)
+    discountCode = db.Column('discountCode', db.Text)
     btw_9 = db.Column(db.Float, default=0.0)
     btw_21 = db.Column(db.Float, default=0.0)
     btw = db.Column(db.Float, default=0.0)
@@ -572,6 +574,8 @@ class Order(db.Model):
             "fooi": self.fooi,
             "discount_code": self.discount_code,
             "discount_amount": self.discount_amount,
+            "discountCode": self.discountCode,
+            "discountAmount": self.discountAmount,
             "bezorging": self.bezorgkosten,
             "btw": self.btw or (self.btw_9 or 0.0) + (self.btw_21 or 0.0),
             "btw_9": self.btw_9 or 0.0,
@@ -884,7 +888,7 @@ def api_orders():
                     return jsonify({"status": "fail", "error": msg}), 403
         # ===== 新时间判断逻辑结束 =====
 
-        # 1. 构造订单对象（初始字段）
+        summary_data = data.get("summary") or {}
         order = Order(
             order_type=order_type,
             customer_name=data.get("name") or data.get("customer_name"),
@@ -902,8 +906,15 @@ def api_orders():
             items=json.dumps(data.get("items", {})),
             order_number=order_number,
             fooi=float(data.get("tip") or data.get("fooi") or 0),
-            discount_code=None,
-            discount_amount=data.get("discount_amount")
+            discount_code=data.get("discount_code"),
+            discount_amount=float(data.get("discount_amount") or 0),
+            discountCode=data.get("discountCode"),
+            discountAmount=float(
+                data.get("discountAmount")
+                or summary_data.get("discount_amount")
+                or summary_data.get("discountAmount")
+                or 0
+            )
         )
 
         # 2. 计算 subtotal / totaal
@@ -914,13 +925,8 @@ def api_orders():
         )
         order.totaal = float(data.get("totaal") or subtotal)
 
-        summary_data = data.get("summary") or {}
         order.verpakkingskosten = float(summary_data.get("packaging") or 0)
         order.bezorgkosten = float(summary_data.get("delivery") or 0)
-        if summary_data.get("discount_amount") is not None:
-            order.discount_amount = float(summary_data.get("discount_amount") or 0)
-        elif summary_data.get("discountAmount") is not None:
-            order.discount_amount = float(summary_data.get("discountAmount") or 0)
 
         btw_split = summary_data.get("btw_split") or data.get("btw_split") or {}
         try:
@@ -939,38 +945,37 @@ def api_orders():
             base_total = subtotal - heineken_total + order.verpakkingskosten + order.bezorgkosten
             order.btw_9 = round(base_total * 0.09, 2)
         order.btw = (order.btw_9 or 0) + (order.btw_21 or 0)
-        # 3. 处理折扣码
-        raw_discount_code = data.get("discount_code") or data.get("discountCode")
-        if raw_discount_code and raw_discount_code.upper() == "KASSA":
-            order.discount_code = "kassa korting"
-            discount_code = None
-        else:
-            order.discount_code = raw_discount_code
-            discount_code = raw_discount_code
+
+        # 3. 处理折扣码（本次使用）
+        if order.discountCode and str(order.discountCode).upper() == "KASSA":
+            order.discountCode = "kassa korting"
 
         # 4. 保存订单到数据库
         db.session.add(order)
         db.session.commit()
 
-        # 5. 如有折扣码，记录到 discount_codes 表
+        # 5. 如有新折扣码，记录到 discount_codes 表
         customer_email = (
             data.get("customer_email")
             or data.get("customerEmail")
             or order.email
         )
-        discount_amount = data.get("discount_amount") or 0
+        new_code = order.discount_code
+        new_amount = order.discount_amount or 0
 
-        if discount_code and customer_email:
+        if new_code and customer_email:
             disc = DiscountCode(
-                code=discount_code,
+                code=new_code,
                 customer_email=customer_email,
                 discount_percentage=3.0,
-                discount_amount=discount_amount,
+                discount_amount=new_amount,
                 is_used=False,
             )
             db.session.add(disc)
             db.session.commit()
-            print(f"✅ 折扣码保存成功: {discount_code} for {customer_email} met korting {discount_amount}")
+            print(
+                f"✅ 折扣码保存成功: {new_code} for {customer_email} met korting {new_amount}"
+            )
 
         print("✅ 接收到订单:", data)
 


### PR DESCRIPTION
## Summary
- Add distinct `discount_amount`/`discount_code` and `discountAmount`/`discountCode` columns to order models
- Update order serialization and calculations to respect new and used discount fields independently
- Adjust create order logic to handle each discount set separately and log generated codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab7ba6ecc833396ef2efcabb94150