### PR TITLE
feat: persist POS orders to local SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+electron-pos/node_modules/
+__pycache__/
+*.pyc
+data/orders.db
+data/

--- a/electron-pos/package.json
+++ b/electron-pos/package.json
@@ -25,6 +25,7 @@
     }
   },
   "dependencies": {
-    "node-wav-player": "^1.0.0"
+    "node-wav-player": "^1.0.0",
+    "better-sqlite3": "^8.0.1"
   }
 }

--- a/electron-pos/preload.js
+++ b/electron-pos/preload.js
@@ -29,8 +29,14 @@ ipcRenderer.on('stop-ding-in-renderer', () => {
 
 // 本地 SQLite API（与 main.js 中 ipcMain.handle('local.*') 对齐）
 contextBridge.exposeInMainWorld('localDB', {
-  saveOrder: (order) => ipcRenderer.invoke('local.saveOrder', order),
+  saveOrder: (order, source) => ipcRenderer.invoke('local.saveOrder', order, source),
   getOrderById: (id) => ipcRenderer.invoke('local.getOrderById', id),
   getOrderByNumber: (no) => ipcRenderer.invoke('local.getOrderByNumber', no),
   listRecent: (limit = 50) => ipcRenderer.invoke('local.listRecent', limit),
+  getOrdersToday: () => ipcRenderer.invoke('local.getOrdersToday'),
+});
+
+// 兼容旧接口 window.pos.getOrdersToday()
+contextBridge.exposeInMainWorld('pos', {
+  getOrdersToday: () => ipcRenderer.invoke('local.getOrdersToday')
 });

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2279,14 +2279,17 @@ function submitOrder() {
     body: JSON.stringify(payload)
   })
     .then(r => r.json())
-    .then(res => {
+    .then(async res => {
       if (res.success || res.status === 'ok') {
-        
+        try {
+          await window.localDB?.saveOrder?.(payload, JSON.stringify(payload));
+        } catch (e) {
+          console.warn('⚠️ 本地保存失败:', e);
+        }
         showToast('Bestelling succesvol verzonden! Bestelnummer: ' + orderNumber);
         clearForm();
         fetchOrders();
       } else {
-       
         showToast('Er is een fout opgetreden bij het verzenden van uw bestelling. Probeer het opnieuw.');
       }
     })
@@ -2971,7 +2974,7 @@ socket.on('new_order', async (order) => {
   try {
     const existed = await window.localDB?.getOrderByNumber?.(order.order_number);
     if (!existed) {
-      await window.localDB?.saveOrder?.(order);
+      await window.localDB?.saveOrder?.(order, JSON.stringify(order));
       console.log("💾 已保存到本地 SQLite:", order.order_number);
     } else {
       console.log("↩️ 本地已存在，跳过保存:", order.order_number);

--- a/scripts/print-today.js
+++ b/scripts/print-today.js
@@ -1,0 +1,16 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const dbPath = path.join(__dirname, '..', 'data', 'orders.db');
+if (!fs.existsSync(dbPath)) {
+  console.log('Database not found.');
+  process.exit(0);
+}
+try {
+  const query = "SELECT order_number, data, source_json, created_at FROM orders WHERE date(created_at)=date('now','localtime') ORDER BY created_at DESC;";
+  const result = execSync(`sqlite3 ${dbPath} "${query}"`, { encoding: 'utf8' });
+  console.log(result.trim());
+} catch (e) {
+  console.error('Failed to query orders:', e.message);
+}

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1742,8 +1742,13 @@ function submitOrder() {
     body: JSON.stringify(payload)
   })
     .then(r => r.json())
-    .then(res => {
+    .then(async res => {
       if (res.success || res.status === 'ok') {
+        try {
+          await window.localDB?.saveOrder?.(payload, JSON.stringify(payload));
+        } catch (e) {
+          console.warn('⚠️ 本地保存失败:', e);
+        }
         showToast('Bestelling succesvol verzonden! Bestelnummer: ' + orderNumber);
         clearForm();
         fetchOrders();
@@ -2066,7 +2071,7 @@ const orderQueue = [];
 let isModalActive = false;
 let currentOrder = null;
 
-socket.on('new_order', order => {
+socket.on('new_order', async order => {
 
   console.log('🆕 Nieuwe bestelling ontvangen!', order);
   if (window.electronAPI && window.electronAPI.playDing) {
@@ -2076,7 +2081,14 @@ socket.on('new_order', order => {
   const row = addRow(order, true); // 添加订单到表格
 
   orderQueue.push(order); // 加入弹窗队列
-  if (!isModalActive) showNextOrderModal(); // 没有弹窗时立刻开始弹窗                            
+  if (!isModalActive) showNextOrderModal(); // 没有弹窗时立刻开始弹窗
+
+  try {
+    const existed = await window.localDB?.getOrderByNumber?.(order.order_number);
+    if (!existed) await window.localDB?.saveOrder?.(order, JSON.stringify(order));
+  } catch (e) {
+    console.warn('⚠️ 本地保存失败:', e);
+  }
 });
 
 function showNextOrderModal() {


### PR DESCRIPTION
## Summary
- log all POS and pushed orders to `data/orders.db` with original `source_json`
- expose `window.pos.getOrdersToday()` and helper CLI for listing today's orders
- save manual and socket orders from the POS UI into the local database

## Testing
- ✅ `python -m py_compile app.py`
- ✅ `node --check electron-pos/main.js`
- ✅ `node --check electron-pos/preload.js`
- ⚠️ `node scripts/print-today.js` (database not found)


------
https://chatgpt.com/codex/tasks/task_e_689b9c3e8c308333beeaac04e6226c80