### PR TITLE
Align POS order displays with canonical JSON fields

### DIFF
--- a/electron-pos/public/orders_table.html
+++ b/electron-pos/public/orders_table.html
@@ -194,20 +194,33 @@
         <p><strong>Opmerking:</strong> {{ order.opmerking or '-' }}</p>
         <p><strong>Ordernummer:</strong> {{ order.order_number or '' }}</p>
 
-        {# 价格只显示订单包里的值，不计算 #}
-        {% set totaal_val =
-             (order.totaal if order.totaal is not none else
-             (order.total if order.total is not none else 0)) %}
-        <p><strong>Totaal:</strong> €{{ '%.2f' % totaal_val }}</p>
-
-        <p><strong>BTW 9%:</strong> €{{ '%.2f' % (order.btw_9 or 0) }}</p>
-        {% if order.btw_21 %}
-          <p><strong>BTW 21%:</strong> €{{ '%.2f' % (order.btw_21 or 0) }}</p>
+        {# 价格字段：严格只读订单包，不做任何推导 #}
+        {% set subtotal_val = order.subtotal if order.subtotal is not none else 0 %}
+        {% if subtotal_val %}
+          <p><strong>Subtotal:</strong> €{{ '%.2f' % subtotal_val }}</p>
         {% endif %}
-        {% set btw_total_val =
-             (order.btw_total if order.btw_total is not none
-              else ((order.btw_9 or 0) + (order.btw_21 or 0))) %}
-        <p><strong>BTW Totaal:</strong> €{{ '%.2f' % btw_total_val }}</p>
+        {% if order.packaging_fee %}
+          <p><strong>Verpakkingskosten:</strong> €{{ '%.2f' % order.packaging_fee }}</p>
+        {% endif %}
+        {% if order.delivery_fee %}
+          <p><strong>Bezorgkosten:</strong> €{{ '%.2f' % order.delivery_fee }}</p>
+        {% endif %}
+        {% if order.btw_9 is not none %}
+          <p><strong>BTW 9%:</strong> €{{ '%.2f' % order.btw_9 }}</p>
+        {% endif %}
+        {% if order.btw_21 is not none %}
+          <p><strong>BTW 21%:</strong> €{{ '%.2f' % order.btw_21 }}</p>
+        {% endif %}
+        {% if order.btw_total is not none %}
+          <p><strong>BTW Totaal:</strong> €{{ '%.2f' % order.btw_total }}</p>
+        {% elif order.btw is not none %}
+          <p><strong>BTW:</strong> €{{ '%.2f' % order.btw }}</p>
+        {% endif %}
+        {% set totaal_val = order.totaal if order.totaal is not none else (order.total if order.total is not none else 0) %}
+        <p><strong>Totaal:</strong> €{{ '%.2f' % totaal_val }}</p>
+        {% if order.tip %}
+          <p><strong>Fooi:</strong> €{{ '%.2f' % order.tip }}</p>
+        {% endif %}
 
         {# ===================== 折扣区（严格字段，不容错） ===================== #}
         {# 本次使用：只看 discountCode / discountAmount；KASSA 显示 Kassa korting #}

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2822,29 +2822,36 @@ function addRow(order, highlight = false) {
     }).join('');
 
   // —— 金额区（严格“只读订单包”，不重新计算）
-  const totaal        = window.toNum(order.totaal ?? order.total ?? order.summary?.total ?? 0);
-  const packaging_fee = window.toNum(order.verpakkingskosten ?? order.packaging_fee ?? 0);
-  const delivery_fee  = window.toNum(order.bezorgkosten      ?? order.delivery_fee    ?? order.delivery_cost ?? 0);
-  const tip           = window.toNum(order.fooi ?? order.tip ?? 0);
-  const btw_total     = window.toNum(order.btw  ?? order.btw_total ?? order.btw_9 ?? 0);
+  const subtotal      = window.toNum(order.subtotal ?? 0);
+  const totaal        = window.toNum(order.totaal ?? order.total ?? 0);
+  const packaging_fee = window.toNum(order.packaging_fee ?? 0);
+  const delivery_fee  = window.toNum(order.delivery_fee ?? 0);
+  const tip           = window.toNum(order.tip ?? 0);
+  const btw_9         = window.toNum(order.btw_9 ?? 0);
+  const btw_21        = window.toNum(order.btw_21 ?? 0);
+  const btw_total     = window.toNum(order.btw_total ?? order.btw ?? 0);
 
   // —— 折扣（严格分流，**不容错**）
   // 1) 本次使用折扣：只取 discountCode / discountAmount
   let usedKortingHtml = '';
-  if (order.discountCode && Number(order.discountAmount) > 0) {
-    const isKassa = order.discountCode.toUpperCase() === 'KASSA';
-    const lbl = isKassa ? 'Kassa korting' : 'Korting';
-    const tail = !isKassa ? ` <span style="color:#888;">(Code: ${order.discountCode})</span>` : '';
-    usedKortingHtml = `<div><strong>${lbl}:</strong> -€${fmt2(order.discountAmount)}${tail}</div>`;
+  const usedCode = order.discountCode || '';
+  const usedAmt  = window.toNum(order.discountAmount);
+  if (usedCode || usedAmt !== 0) {
+    const isKassa = usedCode.toUpperCase() === 'KASSA';
+    const lbl = isKassa ? 'Kassa korting' : `Korting${usedCode && !isKassa ? ` (Code: ${usedCode})` : ''}`;
+    const amtTxt = usedAmt !== 0 ? `: -€${fmt2(usedAmt)}` : '';
+    usedKortingHtml = `<div><strong>${lbl}</strong>${amtTxt}</div>`;
   }
 
   // 2) 下次奖励码：只取 discount_code / discount_amount（金额可有可无）
   let volgendeHtml = '';
-  if (order.discount_code) {
-    const amt = Number(order.discount_amount) > 0 ? ` — €${fmt2(order.discount_amount)}` : '';
+  const nextCode = order.discount_code || '';
+  const nextAmt  = window.toNum(order.discount_amount);
+  if (nextCode || nextAmt !== 0) {
+    const amtTxt = nextAmt !== 0 ? ` — €${fmt2(nextAmt)}` : '';
     volgendeHtml = `<div class="next-coupon" style="margin-top:6px;">
                       <div><strong>Hier uw kortings code volgende bestelling:</strong></div>
-                      <div style="font-size:1.1em;">${order.discount_code}${amt}</div>
+                      <div style="font-size:1.1em;">${nextCode}${amtTxt}</div>
                     </div>`;
   }
 
@@ -2890,9 +2897,12 @@ function addRow(order, highlight = false) {
     <div><strong>Items:</strong><ul>${items}</ul></div>
     ${order.opmerking ? `<div><strong>Opmerking:</strong> ${order.opmerking}</div>` : ''}
 
-    ${btw_total     > 0 ? `<div><strong>BTW:</strong> €${fmt2(btw_total)}</div>` : ''}
+    ${subtotal      > 0 ? `<div><strong>Subtotal:</strong> €${fmt2(subtotal)}</div>` : ''}
     ${packaging_fee > 0 ? `<div><strong>Verpakkingskosten:</strong> €${fmt2(packaging_fee)}</div>` : ''}
     ${delivery_fee  > 0 ? `<div><strong>Bezorgkosten:</strong> €${fmt2(delivery_fee)}</div>` : ''}
+    ${btw_9         > 0 ? `<div><strong>BTW 9%:</strong> €${fmt2(btw_9)}</div>` : ''}
+    ${btw_21        > 0 ? `<div><strong>BTW 21%:</strong> €${fmt2(btw_21)}</div>` : ''}
+    ${btw_total     > 0 ? `<div><strong>BTW Totaal:</strong> €${fmt2(btw_total)}</div>` : ''}
 
     ${usedKortingHtml}
 

--- a/electron-pos/public/pos_orders.html
+++ b/electron-pos/public/pos_orders.html
@@ -175,6 +175,8 @@ function formatCurrency(value) {
   const num = parseFloat(value);
   return isNaN(num) ? "€0.00" : `€${num.toFixed(2)}`;
 }
+const toNum = v => (v === null || v === undefined || v === '' ? 0 : Number(String(v).replace(',', '.')));
+const fmt2  = n => toNum(n).toFixed(2);
 
 function pad(num) {
   return num.toString().padStart(2, '0');
@@ -207,7 +209,7 @@ function parseTimeToMinutes(str){
 
 function getSortKey(order){
   const isDelivery=['delivery','bezorgen'].includes(order.order_type);
-  const t=isDelivery ? (order.delivery_time||order.deliveryTime) : (order.pickup_time||order.pickupTime);
+  const t=isDelivery ? order.delivery_time : order.pickup_time;
   return parseTimeToMinutes(t);
 }
 
@@ -239,25 +241,42 @@ function insertSorted(tbody,tr){
     return `<li>${n} x ${qty}</li>`;
   }).join('');
 
-  // 只读：总价优先取 totaal，其次 total，再其次 summary.total
-  let totaalVal = order.totaal ?? order.total ?? order.summary?.total ?? 0;
+  // 只读：总价字段
+  let totaalVal = order.totaal ?? order.total ?? 0;
   if (typeof totaalVal === 'string') {
     totaalVal = parseFloat(totaalVal.replace(/[^\d,.-]/g, '').replace(',', '.').trim());
   }
 
   // 只读：时间字段
-  const pickup   = order.pickup_time   ?? order.pickupTime   ?? '';
-  const delivery = order.delivery_time ?? order.deliveryTime ?? '';
+  const pickup   = order.pickup_time   || '';
+  const delivery = order.delivery_time || '';
   const tijdslot = isDelivery ? delivery : pickup;
 
-  // 下单时间只做展示用（不推算）
-  let time = order.created_at || order.created_at_local || '';
+  // 下单时间展示
+  const created = order.created_at_local || order.created_at || '';
+  let time = created;
   if (typeof time === 'string' && time.includes(' ')) {
     time = time.split(' ')[1]?.slice(0,5) || time;
   }
 
+  // 折扣显示
+  const usedCode = order.discountCode || '';
+  const usedAmt  = toNum(order.discountAmount);
+  const showUsed = usedCode || usedAmt !== 0;
+  const isKassa  = usedCode.toUpperCase() === 'KASSA';
+  const usedStr  = showUsed
+    ? `${isKassa ? 'Kassa korting' : `Korting${usedCode && !isKassa ? ` (Code: ${usedCode})` : ''}`}${usedAmt !== 0 ? `: -€${fmt2(usedAmt)}` : ''}`
+    : '-';
+
+  const nextCode = order.discount_code || '';
+  const nextAmt  = toNum(order.discount_amount);
+  const showNext = nextCode || nextAmt !== 0;
+  const nextStr  = showNext
+    ? `${nextCode || '-'}` + (nextAmt !== 0 ? ` (waarde: €${fmt2(nextAmt)})` : '')
+    : '-';
+
   tr.innerHTML = `
-    <td>${order.created_date || order.created_at?.slice?.(0,10) || ''}</td>
+    <td>${created ? created.slice(0,10) : ''}</td>
     <td>${time || ''}</td>
     <td>${tijdslot || '-'}</td>
     <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
@@ -276,6 +295,8 @@ function insertSorted(tbody,tr){
     }</td>
     <td>${order.payment_method || '-'}</td>
     <td>${order.order_number || ''}</td>
+    <td>${usedStr}</td>
+    <td>${nextStr}</td>
   `;
 
   // 仅用“取/送时间”排序，不再做任何金额相关推算


### PR DESCRIPTION
## Summary
- read pricing fields directly from order JSON in POS cards and tables
- apply strict discount/next-code display rules across POS views
- unify POS orders page rendering with shared field names

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c74374b3483339934c09dbe6b661b