### PR TITLE
feat(pos): display discounts in order cards

### DIFF
--- a/electron-pos/public/orders_table.html
+++ b/electron-pos/public/orders_table.html
@@ -232,9 +232,11 @@
         {% set is_kassa = used_code|string|upper == 'KASSA' %}
         {% if used_code or used_amt_num != 0 %}
           <p>
-            <strong>{{ 'Kassa korting' if is_kassa else 'Korting' }}</strong>
-            {% if not is_kassa and used_code %}(Code: {{ used_code }}){% endif %}
-            {% if used_amt_num != 0 %}: -€{{ '%.2f' % used_amt_num }}{% endif %}
+            {% if is_kassa %}
+              <strong>Kassa korting</strong>
+            {% else %}
+              <strong>Korting {% if used_amt_num != 0 %}-€{{ '%.2f' % used_amt_num }}{% endif %}{% if used_code %} (Code: {{ used_code }}){% endif %}</strong>
+            {% endif %}
           </p>
         {% endif %}
 
@@ -244,11 +246,20 @@
         {% set next_amt_num = 0 if next_amt_raw is none else
                                (next_amt_raw if next_amt_raw is number
                                 else ((next_amt_raw|string)|replace(',', '.')|float)) %}
-        {% if next_code or next_amt_num != 0 %}
+        {% set next_amt_txt = '' %}
+        {% if next_amt_raw is string and next_amt_raw|trim|endswith('%') %}
+          {% set next_amt_txt = next_amt_raw|trim %}
+        {% elif next_amt_num != 0 %}
+          {% if 0 < next_amt_num < 1 %}
+            {% set next_amt_txt = ('%.2f' % (next_amt_num * 100)) ~ '%' %}
+          {% else %}
+            {% set next_amt_txt = '€' ~ ('%.2f' % next_amt_num) %}
+          {% endif %}
+        {% endif %}
+        {% if next_amt_txt %}
           <p>
-            <strong>Hier uw kortingscode volgende bestelling:</strong>
-            {{ next_code }}
-            {% if next_amt_num != 0 %} — €{{ '%.2f' % next_amt_num }}{% endif %}
+            <strong>Hier is uw korting {{ next_amt_txt }} voor volgende bedrag</strong>
+            {% if next_code %}(Code: {{ next_code }}){% endif %}
           </p>
         {% endif %}
         {# =================== 折扣区结束 =================== #}

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2832,20 +2832,32 @@ function addRow(order, highlight = false) {
   const usedAmt  = window.toNum(order.discountAmount);
   if (usedCode || usedAmt !== 0) {
     const isKassa = usedCode.toUpperCase() === 'KASSA';
-    const lbl = isKassa ? 'Kassa korting' : `Korting${usedCode && !isKassa ? ` (Code: ${usedCode})` : ''}`;
-    const amtTxt = usedAmt !== 0 ? `: -€${fmt2(usedAmt)}` : '';
-    usedKortingHtml = `<div><strong>${lbl}</strong>${amtTxt}</div>`;
+    if (isKassa) {
+      usedKortingHtml = `<div><strong>Kassa korting</strong></div>`;
+    } else {
+      const amtTxt = usedAmt !== 0 ? `-€${fmt2(usedAmt)}` : '';
+      const codeTxt = usedCode ? ` (Code: ${usedCode})` : '';
+      usedKortingHtml = `<div><strong>Korting ${amtTxt}${codeTxt}</strong></div>`;
+    }
   }
 
-  // 2) 下次奖励码：只取 discount_code / discount_amount（金额可有可无）
+  // 2) 下次奖励码：只取 discount_code / discount_amount（金额可为百分比或固定金额）
   let volgendeHtml = '';
   const nextCode = order.discount_code || '';
-  const nextAmt  = window.toNum(order.discount_amount);
-  if (nextCode || nextAmt !== 0) {
-    const amtTxt = nextAmt !== 0 ? ` — €${fmt2(nextAmt)}` : '';
+  const nextAmtRaw = order.discount_amount;
+  const nextAmtNum = window.toNum(nextAmtRaw);
+  let nextAmtTxt = '';
+  if (typeof nextAmtRaw === 'string' && nextAmtRaw.trim().endsWith('%')) {
+    nextAmtTxt = nextAmtRaw.trim();
+  } else if (!isNaN(nextAmtNum) && nextAmtNum !== 0) {
+    nextAmtTxt = (nextAmtNum > 0 && nextAmtNum < 1)
+      ? `${fmt2(nextAmtNum * 100)}%`
+      : `€${fmt2(nextAmtNum)}`;
+  }
+  if (nextAmtTxt) {
     volgendeHtml = `<div class="next-coupon" style="margin-top:6px;">
-                      <div><strong>Hier uw kortings code volgende bestelling:</strong></div>
-                      <div style="font-size:1.1em;">${nextCode}${amtTxt}</div>
+                      <div><strong>Hier is uw korting ${nextAmtTxt} voor volgende bedrag</strong></div>
+                      ${nextCode ? `<div style="font-size:1.1em;">Code: ${nextCode}</div>` : ''}
                     </div>`;
   }
 

--- a/electron-pos/public/pos_orders.html
+++ b/electron-pos/public/pos_orders.html
@@ -55,7 +55,7 @@ th:last-child {
         <th>Betaling</th>
         <th class="nowrap">Bestelnummer</th>
         <th class="nowrap">Korting (gebruikt)</th>
-        <th class="nowrap">Volgende kortingscode</th>
+        <th class="nowrap">Volgende korting</th>
       </tr>
     </thead>
 
@@ -134,23 +134,27 @@ th:last-child {
             {% if is_kassa %}
               Kassa korting
             {% else %}
-              Korting{% if used_code %} (Code: {{ used_code }}){% endif %}
-            {% endif %}
-            {% if used_amt is not none and used_amt_num != 0 %}
-              : -€{{ '%.2f' % used_amt_num }}
+              Korting{% if used_amt is not none and used_amt_num != 0 %} -€{{ '%.2f' % used_amt_num }}{% endif %}{% if used_code %} (Code: {{ used_code }}){% endif %}
             {% endif %}
           {% else %}
             -
           {% endif %}
         </td>
 
-        {# —— 下次奖励码：严格显示 discount_code；金额可作为说明 #}
+        {# —— 下次奖励：显示 discount_amount（可为百分比或固定金额） #}
+        {% set next_amt_txt = '' %}
+        {% if next_amt is string and next_amt|trim|endswith('%') %}
+          {% set next_amt_txt = next_amt|trim %}
+        {% elif next_amt is not none and next_amt_num != 0 %}
+          {% if 0 < next_amt_num < 1 %}
+            {% set next_amt_txt = ('%.2f' % (next_amt_num * 100)) ~ '%' %}
+          {% else %}
+            {% set next_amt_txt = '€' ~ ('%.2f' % next_amt_num) %}
+          {% endif %}
+        {% endif %}
         <td class="nowrap">
-          {% if show_next %}
-            {% if next_code %}{{ next_code }}{% else %}-{% endif %}
-            {% if next_amt is not none and next_amt_num != 0 %}
-              (waarde: €{{ '%.2f' % next_amt_num }})
-            {% endif %}
+          {% if next_amt_txt %}
+            Hier is uw korting {{ next_amt_txt }} voor volgende bedrag{% if next_code %} (Code: {{ next_code }}){% endif %}
           {% else %}
             -
           {% endif %}


### PR DESCRIPTION
## Summary
- show `Kassa korting` for KASSA codes and include amount + code for other discounts
- present upcoming discount amount with "Hier is uw korting" message in POS and order listings

## Testing
- `pytest`
- `cd electron-pos && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c947542c88333b6fc72423f0e8eb9