### PR TITLE
Display packaging cost on Electron POS order cards

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2993,7 +2993,14 @@ function toUIOrder(o) {
   const toNum = v => (v === null || v === undefined || v === '') ? 0 : Number(v);
   const totaal        = toNum(src.totaal ?? src.total ?? 0);
   const subtotal      = toNum(src.subtotal ?? 0);
-  const packaging_fee = toNum(src.packaging_fee ?? 0);
+  const packaging_fee = toNum(
+    src.packaging_fee ??
+    src.summary?.packaging_fee ??
+    src.verpakkingskosten ??
+    src.packaging ??
+    src.package_fee ??
+    0
+  );
   const delivery_fee  = toNum(
     src.delivery_fee ??
     src.summary?.delivery_fee ??


### PR DESCRIPTION
## Summary
- ensure order cards read packaging cost from multiple possible fields and show it when present

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9898ec388333aaef37fad195a706