### PR TITLE
feat: add order source bron

### DIFF
--- a/app.py
+++ b/app.py
@@ -196,6 +196,7 @@ def order_to_dict(order):
         "id": order.id,
         "order_number": order.order_number,
         "order_type": order.order_type,
+        "bron": order.bron,
         "customer_name": order.customer_name,
         "phone": order.phone,
         "email": order.email,
@@ -419,6 +420,7 @@ def orders_to_dicts(orders):
             "phone": o.phone,
             "email": o.email,
             "payment_method": o.payment_method,
+            "bron": o.bron,
             "pickup_time": o.pickup_time,
             "delivery_time": o.delivery_time,
             "tijdslot_display": o.tijdslot_display,
@@ -521,6 +523,7 @@ class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     order_number = db.Column(db.String(20))
     order_type = db.Column(db.String(20))
+    bron = db.Column(db.String(20))
     customer_name = db.Column(db.String(100))
     phone = db.Column(db.String(20))
     email = db.Column(db.String(120))
@@ -555,6 +558,7 @@ class Order(db.Model):
             "id": self.id,
             "order_number": self.order_number,
             "order_type": self.order_type,
+            "bron": self.bron,
             "customer_name": self.customer_name,
             "phone": self.phone,
             "email": self.email,
@@ -838,6 +842,7 @@ def api_orders():
         settings = {s.key: s.value for s in Setting.query.all()}
         now = datetime.now(NL_TZ)
         source = (data.get("source") or "").lower()
+        bron = data.get("bron") or ("Kassa" if source == "pos" else "Online")
         is_zsm = str(data.get("is_zsm")).lower() == "true"
 
         if not (source == "pos" and is_zsm):
@@ -891,6 +896,7 @@ def api_orders():
         summary_data = data.get("summary") or {}
         order = Order(
             order_type=order_type,
+            bron=bron,
             customer_name=data.get("name") or data.get("customer_name"),
             phone=data.get("phone"),
             email=data.get("customerEmail") or data.get("email"),
@@ -1163,7 +1169,7 @@ def edit_order(order_id: int):
     allowed = [
         'customer_name', 'phone', 'email', 'street', 'house_number', 'postcode',
         'city', 'pickup_time', 'delivery_time', 'order_type', 'items',
-        'payment_method', 'totaal', 'fooi'
+        'payment_method', 'totaal', 'fooi', 'bron'
     ]
     for f in allowed:
         if f not in data:
@@ -1186,6 +1192,9 @@ def edit_order(order_id: int):
             order.fooi = float(data['tip'])
         except (TypeError, ValueError):
             order.fooi = 0.0
+    if not order.bron:
+        source = (data.get("source") or "").lower()
+        order.bron = data.get("bron") or ("Kassa" if source == "pos" else "Online")
     db.session.commit()
     return jsonify({'success': True})
 

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2235,6 +2235,7 @@ function submitOrder() {
   const pickupVal = !delivery && isZsm ? getAsapTime() : pickupSel;
   const deliveryVal = delivery && isZsm ? getAsapTime() : deliverySel;
   const payload = {
+    bron: 'Kassa',
     orderType,
     name,
     phone,
@@ -2540,6 +2541,7 @@ function orderComplete(btn) {
     phone: orderData.phone || btn.dataset.phone,
     email: orderData.email || btn.dataset.email,
     order_type: orderType,
+    bron: orderData.bron || 'Kassa',
     tijdslot: orderData.tijdslot || orderData.delivery_time || orderData.pickup_time || '',
     street: orderData.street || '',
     house_number: orderData.house_number || '',
@@ -2648,6 +2650,7 @@ function confirmDeliveryPerson() {
     phone: orderData.phone || btn.dataset.phone,
     email: orderData.email || btn.dataset.email,
     order_type: btn.dataset.type,
+    bron: orderData.bron || 'Kassa',
     tijdslot: orderData.tijdslot || orderData.delivery_time || orderData.pickup_time || '',
     street: orderData.street || '',
     house_number: orderData.house_number || '',
@@ -2688,7 +2691,8 @@ function orderCancelNotify(btn) {
     name: btn.dataset.name,
     phone: btn.dataset.phone,
     email: btn.dataset.email,
-    order_type: btn.dataset.type
+    order_type: btn.dataset.type,
+    bron: 'Kassa'
   };
 
   fetch('https://flask-order-api.onrender.com/api/order_cancelled', {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6074,6 +6074,7 @@ function checkout() {
     body: JSON.stringify({
       // ✅ 关键：声明来源 index，让后端走 index 分支并采用前端 BTW
       source: 'index',
+      bron: 'Online',
       orderType,
       name: orderType === 'afhalen' ? document.getElementById('pickupName').value.trim() : document.getElementById('deliveryName').value.trim(),
       phone: orderType === 'afhalen' ? document.getElementById('pickupPhone').value.trim() : document.getElementById('deliveryPhone').value.trim(),

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -5629,6 +5629,7 @@ function checkout() {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
+      bron: 'Online',
       orderType: orderType,
       name: orderType === 'afhalen' ? document.getElementById('pickupName').value.trim() : document.getElementById('deliveryName').value.trim(),
       phone: orderType === 'afhalen' ? document.getElementById('pickupPhone').value.trim() : document.getElementById('deliveryPhone').value.trim(),

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -265,7 +265,8 @@ th:last-child {
         items: parseItemsString(newItemsInput, data.items || {}),
         payment_method: payment,
         totaal: parseFloat(totaal) || 0,
-        fooi: parseFloat(fooi) || 0
+        fooi: parseFloat(fooi) || 0,
+        bron: data.bron
       })
     }).then(()=>fetchOrders());
   }

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1711,6 +1711,7 @@ function submitOrder() {
   const deliveryVal = deliverySel === 'Z.S.M.' ? getAsapTime() : deliverySel;
   const tijdslotDisplay = delivery ? deliverySel : pickupSel;
   const payload = {
+    bron: 'Kassa',
     orderType,
     name,
     phone,


### PR DESCRIPTION
## Summary
- add `bron` field to orders to track source (Kassa or Online)
- include `bron` in all order APIs and defaults
- send `bron` from POS and online clients during create/update

## Testing
- `python -m py_compile app.py electron-pos/appB.py`


------
https://chatgpt.com/codex/tasks/task_e_689d5cf41768833391a55e3895231a12