### PR TITLE
feat: add cash change calculator

### DIFF
--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -138,6 +138,39 @@
     background-color: #0056b3;
   }
 
+  .change-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+  }
+  .change-modal.hidden { display: none; }
+  .change-box {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 320px;
+    text-align: center;
+  }
+  .quick-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin: 10px 0;
+  }
+  .quick-buttons button {
+    flex: 1 0 45%;
+    padding: 10px;
+  }
+
 
 
 
@@ -279,6 +312,10 @@
     </div>
 
     <div class="card-actions">
+      {% set pay = (order.payment_method or '')|lower %}
+      {% if pay in ['contant', 'cash'] %}
+      <button class="btn-change" onclick="openChangeModal(this)">找零</button>
+      {% endif %}
       <button class="btn-klaar" onclick="toggleComplete(this)">Klaar</button>
       <button class="btn-bewerk" onclick="editOrder(this)">Bewerk</button>
       <button class="btn-annuleer" onclick="cancelOrder(this)">Annuleer</button>
@@ -288,10 +325,54 @@
   {% endfor %}
 </div>
 
+<div id="change-modal" class="change-modal hidden">
+  <div class="change-box">
+    <p>应收: €<span id="change-total">0.00</span></p>
+    <label>实收: €<input type="number" id="cash-given" inputmode="decimal" /></label>
+    <div class="quick-buttons">
+      <button onclick="quickAmount(5)">5</button>
+      <button onclick="quickAmount(10)">10</button>
+      <button onclick="quickAmount(20)">20</button>
+      <button onclick="quickAmount(50)">50</button>
+    </div>
+    <p>找零: €<span id="change-amount">0.00</span></p>
+    <button onclick="closeChangeModal()">关闭</button>
+  </div>
+</div>
+
   <!-- 管理订单列表按钮 -->
   <button id="admin-orders-btn" title="Admin Orders">📋</button>
-
   <script>
+    function openChangeModal(btn) {
+      const card = btn.closest('.order-card');
+      const order = JSON.parse(card.dataset.order || '{}');
+      const total = order.totaal ?? order.total ?? 0;
+      const modal = document.getElementById('change-modal');
+      modal.dataset.total = total;
+      document.getElementById('change-total').textContent = total.toFixed(2);
+      document.getElementById('cash-given').value = '';
+      document.getElementById('change-amount').textContent = '0.00';
+      modal.classList.remove('hidden');
+      document.getElementById('cash-given').focus();
+    }
+    function closeChangeModal() {
+      document.getElementById('change-modal').classList.add('hidden');
+    }
+    function quickAmount(val) {
+      const input = document.getElementById('cash-given');
+      const current = parseFloat(input.value || '0');
+      input.value = (current + val).toFixed(2);
+      calculateChange();
+    }
+    function calculateChange() {
+      const modal = document.getElementById('change-modal');
+      const total = parseFloat(modal.dataset.total || '0');
+      const given = parseFloat(document.getElementById('cash-given').value || '0');
+      const change = given - total;
+      document.getElementById('change-amount').textContent = change > 0 ? change.toFixed(2) : '0.00';
+    }
+    document.getElementById('cash-given').addEventListener('input', calculateChange);
+
     const toggleBtn = document.getElementById('toggle-map-btn');
     if (toggleBtn) {
       toggleBtn.addEventListener('click', () => {

--- a/electron-pos/public/orders_table.html
+++ b/electron-pos/public/orders_table.html
@@ -138,6 +138,39 @@
     background-color: #0056b3;
   }
 
+  .change-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+  }
+  .change-modal.hidden { display: none; }
+  .change-box {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 320px;
+    text-align: center;
+  }
+  .quick-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin: 10px 0;
+  }
+  .quick-buttons button {
+    flex: 1 0 45%;
+    padding: 10px;
+  }
+
 
 
 
@@ -276,6 +309,10 @@
     </div>
 
     <div class="card-actions">
+      {% set pay = (order.payment_method or '')|lower %}
+      {% if pay in ['contant', 'cash'] %}
+      <button class="btn-change" onclick="openChangeModal(this)">找零</button>
+      {% endif %}
       <button class="btn-klaar" onclick="toggleComplete(this)">Klaar</button>
       <button class="btn-bewerk" onclick="editOrder(this)">Bewerk</button>
       <button class="btn-annuleer" onclick="cancelOrder(this)">Annuleer</button>
@@ -285,10 +322,54 @@
   {% endfor %}
 </div>
 
+<div id="change-modal" class="change-modal hidden">
+  <div class="change-box">
+    <p>应收: €<span id="change-total">0.00</span></p>
+    <label>实收: €<input type="number" id="cash-given" inputmode="decimal" /></label>
+    <div class="quick-buttons">
+      <button onclick="quickAmount(5)">5</button>
+      <button onclick="quickAmount(10)">10</button>
+      <button onclick="quickAmount(20)">20</button>
+      <button onclick="quickAmount(50)">50</button>
+    </div>
+    <p>找零: €<span id="change-amount">0.00</span></p>
+    <button onclick="closeChangeModal()">关闭</button>
+  </div>
+</div>
+
   <!-- 管理订单列表按钮 -->
   <button id="admin-orders-btn" title="Admin Orders">📋</button>
-
   <script>
+    function openChangeModal(btn) {
+      const card = btn.closest('.order-card');
+      const order = JSON.parse(card.dataset.order || '{}');
+      const total = order.totaal ?? order.total ?? 0;
+      const modal = document.getElementById('change-modal');
+      modal.dataset.total = total;
+      document.getElementById('change-total').textContent = total.toFixed(2);
+      document.getElementById('cash-given').value = '';
+      document.getElementById('change-amount').textContent = '0.00';
+      modal.classList.remove('hidden');
+      document.getElementById('cash-given').focus();
+    }
+    function closeChangeModal() {
+      document.getElementById('change-modal').classList.add('hidden');
+    }
+    function quickAmount(val) {
+      const input = document.getElementById('cash-given');
+      const current = parseFloat(input.value || '0');
+      input.value = (current + val).toFixed(2);
+      calculateChange();
+    }
+    function calculateChange() {
+      const modal = document.getElementById('change-modal');
+      const total = parseFloat(modal.dataset.total || '0');
+      const given = parseFloat(document.getElementById('cash-given').value || '0');
+      const change = given - total;
+      document.getElementById('change-amount').textContent = change > 0 ? change.toFixed(2) : '0.00';
+    }
+    document.getElementById('cash-given').addEventListener('input', calculateChange);
+
     const toggleBtn = document.getElementById('toggle-map-btn');
     if (toggleBtn) {
       toggleBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add cash change modal with quick amounts
- show change button on cash/contant order cards

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689e0d34164c8333a9f5af9eebcb8468