### PR TITLE
Use HTML wissel modal in orders table

### DIFF
--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -137,39 +137,105 @@
   #admin-orders-btn:hover {
     background-color: #0056b3;
   }
-
-   .change-modal {
+  .btn-wissel {
+    background: linear-gradient(#8787db, #5454f5);
+    color: #000;
+    border: 1px solid #c6c6cc;
+    border-radius: 12px;
+    padding: 6px 14px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    transition: all 0.2s ease-in-out;
+  }
+  .btn-wissel:hover {
+    background: linear-gradient(#090949, #4f4fc2);
+  }
+  .btn-wissel:active {
+    background: linear-gradient(#464661, #606091);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.2);
+  }
+  #wissel-modal {
+    display: none;
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    z-index: 10006570;
     justify-content: center;
     align-items: center;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 1000;
+    animation: fadeIn 0.25s ease;
   }
-  .change-modal.hidden { display: none; }
-  .change-box {
-    background: #fff;
+  #wissel-modal .modal-content {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 16px;
     padding: 20px;
-    border-radius: 8px;
-    width: 90%;
-    max-width: 320px;
+    width: 300px;
+    max-width: 90%;
     text-align: center;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+    animation: popUp 0.25s ease;
   }
-  .quick-buttons {
+  #wissel-modal h3 {
+    margin-bottom: 10px;
+    font-weight: 600;
+    font-size: 1.3em;
+    color: #222;
+  }
+  #wissel-modal input {
+    width: 100%;
+    margin: 8px 0;
+    padding: 10px;
+    font-size: 1.2em;
+    border: 1px solid rgba(29, 161, 238, 0.15);
+    border-radius: 12px;
+    background: #f5f7ff;
+    text-align: center;
+    outline: none;
+    box-sizing: border-box;
+  }
+  .wissel-quick {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px;
     justify-content: center;
-    margin: 10px 0;
+    margin-bottom: 8px;
   }
-  .quick-buttons button {
-    flex: 1 0 45%;
-    padding: 10px;
+  .wissel-quick button {
+    padding: 8px 14px;
+    border: none;
+    border-radius: 12px;
+    background: #007aff;
+    color: #fff;
+    font-size: 0.9em;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s ease;
   }
+  .wissel-quick button:hover {
+    background: #005ecb;
+  }
+  #wissel-close {
+    background: #a3a1a1;
+    color: #333;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 12px;
+    margin-top: 12px;
+    cursor: pointer;
+    font-weight: 500;
+  }
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @keyframes popUp {
+    from { transform: scale(0.9); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
+  }
+
 
 
 
@@ -231,11 +297,11 @@
         {% if subtotal_val %}
           <p><strong>Subtotal:</strong> €{{ '%.2f' % subtotal_val }}</p>
         {% endif %}
-        {% if order.packaging_fee %}
-          <p><strong>Verpakkingskosten:</strong> €{{ '%.2f' % order.packaging_fee }}</p>
+        {% if order.packaging_fee or order.verpakkingskosten %}
+          <p><strong>Verpakkingskosten:</strong> €{{ '%.2f' % (order.packaging_fee or order.verpakkingskosten or 0) }}</p>
         {% endif %}
-        {% if order.delivery_fee %}
-          <p><strong>Bezorgkosten:</strong> €{{ '%.2f' % order.delivery_fee }}</p>
+        {% if order.delivery_fee or order.bezorgkosten %}
+          <p><strong>Bezorgkosten:</strong> €{{ '%.2f' % (order.delivery_fee or order.bezorgkosten or 0) }}</p>
         {% endif %}
         {% if order.btw_9 is not none %}
           <p><strong>BTW 9%:</strong> €{{ '%.2f' % order.btw_9 }}</p>
@@ -250,9 +316,6 @@
         {% endif %}
         {% set totaal_val = order.totaal if order.totaal is not none else (order.total if order.total is not none else 0) %}
         <p><strong>Totaal:</strong> €{{ '%.2f' % totaal_val }}</p>
-        {% if order.tip %}
-          <p><strong>Fooi:</strong> €{{ '%.2f' % order.tip }}</p>
-        {% endif %}
 
         {# ===================== 折扣区（严格字段，不容错） ===================== #}
         {# 本次使用：只看 discountCode / discountAmount；KASSA 显示 Kassa korting #}
@@ -313,7 +376,7 @@
     <div class="card-actions">
       {% set pay = (order.payment_method or '')|lower %}
       {% if pay in ['contant', 'cash'] %}
-      <button class="btn-change" onclick="openChangeModal(this)">找零</button>
+      <button class="btn-wissel" data-total="{{ order.totaal or order.total or 0 }}" onclick="openWissel(this)">Wissel</button>
       {% endif %}
       <button class="btn-klaar" onclick="toggleComplete(this)">Klaar</button>
       <button class="btn-bewerk" onclick="editOrder(this)">Bewerk</button>
@@ -324,53 +387,87 @@
   {% endfor %}
 </div>
 
-<div id="change-modal" class="change-modal hidden">
-  <div class="change-box">
-    <p>应收: €<span id="change-total">0.00</span></p>
-    <label>实收: €<input type="number" id="cash-given" inputmode="decimal" /></label>
-    <div class="quick-buttons">
-      <button onclick="quickAmount(5)">5</button>
-      <button onclick="quickAmount(10)">10</button>
-      <button onclick="quickAmount(20)">20</button>
-      <button onclick="quickAmount(50)">50</button>
+<div id="wissel-modal">
+  <div class="modal-content">
+    <h3>Wissel</h3>
+    <p>Te ontvangen: <span id="wissel-due"></span></p>
+    <input id="wissel-paid" type="number" step="0.05" />
+    <div class="wissel-quick">
+      <button type="button" data-add="5">+5</button>
+      <button type="button" data-add="10">+10</button>
+      <button type="button" data-add="20">+20</button>
+      <button type="button" data-add="50">+50</button>
+      <button type="button" id="wissel-exact">Exact</button>
     </div>
-    <p>找零: €<span id="change-amount">0.00</span></p>
-    <button onclick="closeChangeModal()">关闭</button>
+    <p>Wisselgeld: <span id="wissel-change">€0,00</span></p>
+    <div id="wissel-denoms" style="margin-top:8px; text-align:left;"></div>
+    <button id="wissel-close">Sluiten</button>
   </div>
 </div>
 
   <!-- 管理订单列表按钮 -->
   <button id="admin-orders-btn" title="Admin Orders">📋</button>
   <script>
-    function openChangeModal(btn) {
-      const card = btn.closest('.order-card');
-      const order = JSON.parse(card.dataset.order || '{}');
-      const total = order.totaal ?? order.total ?? 0;
-      const modal = document.getElementById('change-modal');
-      modal.dataset.total = total;
-      document.getElementById('change-total').textContent = total.toFixed(2);
-      document.getElementById('cash-given').value = '';
-      document.getElementById('change-amount').textContent = '0.00';
-      modal.classList.remove('hidden');
-      document.getElementById('cash-given').focus();
+    const euroFmt = new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR' });
+    const round05 = v => Math.round(v * 20) / 20;
+    let wisselDue = 0;
+
+    function openWissel(btn) {
+      wisselDue = round05(Number(btn.dataset.total || 0));
+      const modal = document.getElementById('wissel-modal');
+      document.getElementById('wissel-due').textContent = euroFmt.format(wisselDue);
+      const paid = document.getElementById('wissel-paid');
+      paid.value = '';
+      document.getElementById('wissel-change').textContent = euroFmt.format(0);
+      document.getElementById('wissel-denoms').innerHTML = '';
+      modal.style.display = 'flex';
+      paid.focus();
     }
-    function closeChangeModal() {
-      document.getElementById('change-modal').classList.add('hidden');
+
+    function closeWissel() {
+      document.getElementById('wissel-modal').style.display = 'none';
     }
-    function quickAmount(val) {
-      const input = document.getElementById('cash-given');
-      const current = parseFloat(input.value || '0');
-      input.value = (current + val).toFixed(2);
-      calculateChange();
+
+    function updateWissel() {
+      const paidInput = document.getElementById('wissel-paid');
+      let paid = round05(parseFloat(String(paidInput.value).replace(',', '.')) || 0);
+      const change = round05(paid - wisselDue);
+      document.getElementById('wissel-change').textContent = euroFmt.format(change > 0 ? change : 0);
+      const denomsDiv = document.getElementById('wissel-denoms');
+      if (change > 0) {
+        const denoms = [50,20,10,5,2,1,0.5,0.2,0.1,0.05];
+        let remaining = change;
+        const lines = [];
+        for (const d of denoms) {
+          const cnt = Math.floor((remaining + 1e-8) / d);
+          if (cnt > 0) {
+            lines.push(`${cnt} × ${euroFmt.format(d)}`);
+            remaining = round05(remaining - cnt * d);
+          }
+        }
+        denomsDiv.innerHTML = lines.join('<br>');
+      } else {
+        denomsDiv.innerHTML = '';
+      }
     }
-    function calculateChange() {
-      const modal = document.getElementById('change-modal');
-      const total = parseFloat(modal.dataset.total || '0');
-      const given = parseFloat(document.getElementById('cash-given').value || '0');
-      const change = given - total;
-      document.getElementById('change-amount').textContent = change > 0 ? change.toFixed(2) : '0.00';
-    }
-    document.getElementById('cash-given').addEventListener('input', calculateChange);
+
+    document.getElementById('wissel-paid').addEventListener('input', updateWissel);
+    document.getElementById('wissel-close').addEventListener('click', closeWissel);
+    document.getElementById('wissel-modal').addEventListener('click', e => { if (e.target.id === 'wissel-modal') closeWissel(); });
+    document.getElementById('wissel-exact').addEventListener('click', () => {
+      const paidInput = document.getElementById('wissel-paid');
+      paidInput.value = wisselDue.toFixed(2);
+      updateWissel();
+    });
+    document.querySelectorAll('#wissel-modal [data-add]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const paidInput = document.getElementById('wissel-paid');
+        const current = parseFloat(paidInput.value || 0);
+        const newVal = round05(current + Number(btn.dataset.add));
+        paidInput.value = newVal.toFixed(2);
+        updateWissel();
+      });
+    });
 
     const toggleBtn = document.getElementById('toggle-map-btn');
     if (toggleBtn) {

--- a/electron-pos/public/orders_table.html
+++ b/electron-pos/public/orders_table.html
@@ -137,38 +137,103 @@
   #admin-orders-btn:hover {
     background-color: #0056b3;
   }
-
-  .change-modal {
+  .btn-wissel {
+    background: linear-gradient(#8787db, #5454f5);
+    color: #000;
+    border: 1px solid #c6c6cc;
+    border-radius: 12px;
+    padding: 6px 14px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    transition: all 0.2s ease-in-out;
+  }
+  .btn-wissel:hover {
+    background: linear-gradient(#090949, #4f4fc2);
+  }
+  .btn-wissel:active {
+    background: linear-gradient(#464661, #606091);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.2);
+  }
+  #wissel-modal {
+    display: none;
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    z-index: 10006570;
     justify-content: center;
     align-items: center;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 1000;
+    animation: fadeIn 0.25s ease;
   }
-  .change-modal.hidden { display: none; }
-  .change-box {
-    background: #fff;
+  #wissel-modal .modal-content {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 16px;
     padding: 20px;
-    border-radius: 8px;
-    width: 90%;
-    max-width: 320px;
+    width: 300px;
+    max-width: 90%;
     text-align: center;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+    animation: popUp 0.25s ease;
   }
-  .quick-buttons {
+  #wissel-modal h3 {
+    margin-bottom: 10px;
+    font-weight: 600;
+    font-size: 1.3em;
+    color: #222;
+  }
+  #wissel-modal input {
+    width: 100%;
+    margin: 8px 0;
+    padding: 10px;
+    font-size: 1.2em;
+    border: 1px solid rgba(29, 161, 238, 0.15);
+    border-radius: 12px;
+    background: #f5f7ff;
+    text-align: center;
+    outline: none;
+    box-sizing: border-box;
+  }
+  .wissel-quick {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px;
     justify-content: center;
-    margin: 10px 0;
+    margin-bottom: 8px;
   }
-  .quick-buttons button {
-    flex: 1 0 45%;
-    padding: 10px;
+  .wissel-quick button {
+    padding: 8px 14px;
+    border: none;
+    border-radius: 12px;
+    background: #007aff;
+    color: #fff;
+    font-size: 0.9em;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+  .wissel-quick button:hover {
+    background: #005ecb;
+  }
+  #wissel-close {
+    background: #a3a1a1;
+    color: #333;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 12px;
+    margin-top: 12px;
+    cursor: pointer;
+    font-weight: 500;
+  }
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @keyframes popUp {
+    from { transform: scale(0.9); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
   }
 
 
@@ -311,7 +376,7 @@
     <div class="card-actions">
       {% set pay = (order.payment_method or '')|lower %}
       {% if pay in ['contant', 'cash'] %}
-      <button class="btn-change" onclick="openChangeModal(this)">找零</button>
+      <button class="btn-wissel" data-total="{{ order.totaal or order.total or 0 }}" onclick="openWissel(this)">Wissel</button>
       {% endif %}
       <button class="btn-klaar" onclick="toggleComplete(this)">Klaar</button>
       <button class="btn-bewerk" onclick="editOrder(this)">Bewerk</button>
@@ -322,53 +387,87 @@
   {% endfor %}
 </div>
 
-<div id="change-modal" class="change-modal hidden">
-  <div class="change-box">
-    <p>应收: €<span id="change-total">0.00</span></p>
-    <label>实收: €<input type="number" id="cash-given" inputmode="decimal" /></label>
-    <div class="quick-buttons">
-      <button onclick="quickAmount(5)">5</button>
-      <button onclick="quickAmount(10)">10</button>
-      <button onclick="quickAmount(20)">20</button>
-      <button onclick="quickAmount(50)">50</button>
+<div id="wissel-modal">
+  <div class="modal-content">
+    <h3>Wissel</h3>
+    <p>Te ontvangen: <span id="wissel-due"></span></p>
+    <input id="wissel-paid" type="number" step="0.05" />
+    <div class="wissel-quick">
+      <button type="button" data-add="5">+5</button>
+      <button type="button" data-add="10">+10</button>
+      <button type="button" data-add="20">+20</button>
+      <button type="button" data-add="50">+50</button>
+      <button type="button" id="wissel-exact">Exact</button>
     </div>
-    <p>找零: €<span id="change-amount">0.00</span></p>
-    <button onclick="closeChangeModal()">关闭</button>
+    <p>Wisselgeld: <span id="wissel-change">€0,00</span></p>
+    <div id="wissel-denoms" style="margin-top:8px; text-align:left;"></div>
+    <button id="wissel-close">Sluiten</button>
   </div>
 </div>
 
   <!-- 管理订单列表按钮 -->
   <button id="admin-orders-btn" title="Admin Orders">📋</button>
   <script>
-    function openChangeModal(btn) {
-      const card = btn.closest('.order-card');
-      const order = JSON.parse(card.dataset.order || '{}');
-      const total = order.totaal ?? order.total ?? 0;
-      const modal = document.getElementById('change-modal');
-      modal.dataset.total = total;
-      document.getElementById('change-total').textContent = total.toFixed(2);
-      document.getElementById('cash-given').value = '';
-      document.getElementById('change-amount').textContent = '0.00';
-      modal.classList.remove('hidden');
-      document.getElementById('cash-given').focus();
+    const euroFmt = new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR' });
+    const round05 = v => Math.round(v * 20) / 20;
+    let wisselDue = 0;
+
+    function openWissel(btn) {
+      wisselDue = round05(Number(btn.dataset.total || 0));
+      const modal = document.getElementById('wissel-modal');
+      document.getElementById('wissel-due').textContent = euroFmt.format(wisselDue);
+      const paid = document.getElementById('wissel-paid');
+      paid.value = '';
+      document.getElementById('wissel-change').textContent = euroFmt.format(0);
+      document.getElementById('wissel-denoms').innerHTML = '';
+      modal.style.display = 'flex';
+      paid.focus();
     }
-    function closeChangeModal() {
-      document.getElementById('change-modal').classList.add('hidden');
+
+    function closeWissel() {
+      document.getElementById('wissel-modal').style.display = 'none';
     }
-    function quickAmount(val) {
-      const input = document.getElementById('cash-given');
-      const current = parseFloat(input.value || '0');
-      input.value = (current + val).toFixed(2);
-      calculateChange();
+
+    function updateWissel() {
+      const paidInput = document.getElementById('wissel-paid');
+      let paid = round05(parseFloat(String(paidInput.value).replace(',', '.')) || 0);
+      const change = round05(paid - wisselDue);
+      document.getElementById('wissel-change').textContent = euroFmt.format(change > 0 ? change : 0);
+      const denomsDiv = document.getElementById('wissel-denoms');
+      if (change > 0) {
+        const denoms = [50,20,10,5,2,1,0.5,0.2,0.1,0.05];
+        let remaining = change;
+        const lines = [];
+        for (const d of denoms) {
+          const cnt = Math.floor((remaining + 1e-8) / d);
+          if (cnt > 0) {
+            lines.push(`${cnt} × ${euroFmt.format(d)}`);
+            remaining = round05(remaining - cnt * d);
+          }
+        }
+        denomsDiv.innerHTML = lines.join('<br>');
+      } else {
+        denomsDiv.innerHTML = '';
+      }
     }
-    function calculateChange() {
-      const modal = document.getElementById('change-modal');
-      const total = parseFloat(modal.dataset.total || '0');
-      const given = parseFloat(document.getElementById('cash-given').value || '0');
-      const change = given - total;
-      document.getElementById('change-amount').textContent = change > 0 ? change.toFixed(2) : '0.00';
-    }
-    document.getElementById('cash-given').addEventListener('input', calculateChange);
+
+    document.getElementById('wissel-paid').addEventListener('input', updateWissel);
+    document.getElementById('wissel-close').addEventListener('click', closeWissel);
+    document.getElementById('wissel-modal').addEventListener('click', e => { if (e.target.id === 'wissel-modal') closeWissel(); });
+    document.getElementById('wissel-exact').addEventListener('click', () => {
+      const paidInput = document.getElementById('wissel-paid');
+      paidInput.value = wisselDue.toFixed(2);
+      updateWissel();
+    });
+    document.querySelectorAll('#wissel-modal [data-add]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const paidInput = document.getElementById('wissel-paid');
+        const current = parseFloat(paidInput.value || 0);
+        const newVal = round05(current + Number(btn.dataset.add));
+        paidInput.value = newVal.toFixed(2);
+        updateWissel();
+      });
+    });
 
     const toggleBtn = document.getElementById('toggle-map-btn');
     if (toggleBtn) {


### PR DESCRIPTION
## Summary
- replace dialog-based wissel prompt with HTML modal in orders table pages
- style and script updates ensure change modal stays above the POS view

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ebfe33d888333b8b0a79e719a2aae