### PR TITLE
Fix X-Bowl quantity controls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3635,7 +3635,7 @@ body.portrait-mode .cart-badge {
         <div class="qty-box">
       
           <button class="qty-minus remove-button" data-target="xBowlQty" type="button">-</button>
-          <select id="Qty" class="qty-select" name="xBowlQty"></select>
+          <select id="xBowlQty" class="qty-select" name="xBowlQty"></select>
           <button class="qty-plus add-button" data-target="xBowlQty" type="button">+</button>
         </div>
       </div>

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -3602,7 +3602,7 @@ body.portrait-mode .cart-badge {
         <div class="qty-box">
       
           <button class="qty-minus remove-button" data-target="xBowlQty" type="button">-</button>
-          <select id="Qty" class="qty-select" name="xBowlQty"></select>
+          <select id="xBowlQty" class="qty-select" name="xBowlQty"></select>
           <button class="qty-plus add-button" data-target="xBowlQty" type="button">+</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fix X-Bowl +/- buttons by giving quantity selector the correct `xBowlQty` id
- Mirror the fix in English template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0773caa7c83338b2940bab28ce146