### PR TITLE
Handle statiegeld separately from BTW

### DIFF
--- a/electron-pos/db.js
+++ b/electron-pos/db.js
@@ -22,7 +22,7 @@ const WRITABLE_COLUMNS = new Set([
   'order_type','pickup_time','delivery_time','payment_method',
   'postcode','house_number','street','city',
   'opmerking','items',
-  'subtotal','total','packaging_fee','delivery_fee','tip',
+  'subtotal','total','packaging_fee','statiegeld','delivery_fee','tip',
   'btw_9','btw_21','btw_total',
   'discount_amount','discount_code','discountAmount','discountCode',
   'is_completed','is_cancelled',
@@ -86,6 +86,7 @@ db.exec(`
     subtotal REAL,
     total REAL,
     packaging_fee REAL,
+    statiegeld REAL,
     delivery_fee REAL,
     tip REAL,
     btw_9 REAL,
@@ -112,6 +113,7 @@ function ensureColumn(table, column, type) {
   }
 }
 ensureColumn('orders', 'bron', 'TEXT');
+ensureColumn('orders', 'statiegeld', 'REAL');
 ensureColumn('orders', 'discount_amount', 'REAL');
 ensureColumn('orders', 'discount_code', 'TEXT');
 ensureColumn('orders', 'discountAmount', 'REAL');
@@ -156,6 +158,7 @@ function toRow(oInput) {
   const subtotal      = toNum(pick(o,'summary.subtotal','subtotal'));
   const total         = toNum(pick(o,'summary.total','totaal','total'));
   const packaging_fee = toNum(pick(o,'summary.packaging_fee','verpakkingskosten','packaging_fee'));
+  const statiegeld    = toNum(pick(o,'summary.statiegeld','statiegeld'));
   const delivery_fee  = toNum(pick(o,'summary.delivery_fee','bezorgkosten','delivery_fee'));
   const tip           = toNum(pick(o,'summary.tip','fooi','tip'));
   const discount_amount = toNum(pick(o,'discount_amount'));
@@ -194,7 +197,7 @@ function toRow(oInput) {
     postcode, house_number, street, city,
     opmerking, items,
 
-    subtotal, total, packaging_fee, delivery_fee, tip,
+    subtotal, total, packaging_fee, statiegeld, delivery_fee, tip,
     discount_code, discount_amount,   // snake_case
     discountCode,  discountAmount,    // camelCase
 
@@ -210,14 +213,14 @@ const upsertSQL = `
 INSERT INTO orders (
   order_id, order_number, order_type, customer_name, phone, email,
   pickup_time, delivery_time, payment_method, postcode, house_number, street, city, opmerking,
-  items, subtotal, total, packaging_fee, delivery_fee, tip, btw_9, btw_21, btw_total, bron,
+  items, subtotal, total, packaging_fee, statiegeld, delivery_fee, tip, btw_9, btw_21, btw_total, bron,
   discount_code, discount_amount,
   discountCode, discountAmount,
   data
 ) VALUES (
   @order_id, @order_number, @order_type, @customer_name, @phone, @email,
   @pickup_time, @delivery_time, @payment_method, @postcode, @house_number, @street, @city, @opmerking,
-  @items, @subtotal, @total, @packaging_fee, @delivery_fee, @tip, @btw_9, @btw_21, @btw_total, @bron,
+  @items, @subtotal, @total, @packaging_fee, @statiegeld, @delivery_fee, @tip, @btw_9, @btw_21, @btw_total, @bron,
   @discount_code, @discount_amount,
   @discountCode, @discountAmount,
   @data
@@ -239,6 +242,7 @@ ON CONFLICT(order_number) DO UPDATE SET
   subtotal=excluded.subtotal,
   total=excluded.total,
   packaging_fee=excluded.packaging_fee,
+  statiegeld=excluded.statiegeld,
   delivery_fee=excluded.delivery_fee,
   tip=excluded.tip,
   btw_9=excluded.btw_9,
@@ -310,6 +314,7 @@ function sanitizePatch(patch = {}) {
       case 'subtotal':
       case 'total':
       case 'packaging_fee':
+      case 'statiegeld':
       case 'delivery_fee':
       case 'tip':
       case 'btw_9':

--- a/electron-pos/main.js
+++ b/electron-pos/main.js
@@ -329,6 +329,7 @@ function normalizeForPrint(order) {
   }
 
   const packagingRaw = pickMax(order.verpakkingskosten, order.packaging, order.package_fee, order.packaging_fee);
+  const statiegeldRaw= pickMax(order.statiegeld, order.deposit);
   const toeslagRaw   = pickMax(order.toeslag, order.surcharge, order.service_fee);
   const delivery     = pickMax(order.bezorgkosten, order.delivery_cost, order.delivery_fee);
   const tip          = pickMax(order.fooi, order.tip);
@@ -353,13 +354,14 @@ function normalizeForPrint(order) {
 
   // Verpakking + Toeslag 合并
   const packaging = Number(packagingRaw) + Number(toeslagRaw);
+  const statiegeld = Number(statiegeldRaw);
 
   // 直接采用 payload 的 BTW/Total（如有）
   const vatFromPayload   = toNumOrNull(order.btw_total ?? order.vat_total ?? order.btw ?? order.vat);
   const totalFromPayload = toNumOrNull(order.totaal ?? order.total);
 
   // 兜底 total（仅在 payload 没给时使用）
-  const fallbackTotal = Number(subtotal) + Number(packaging) + Number(delivery) + Number(tip)
+  const fallbackTotal = Number(subtotal) + Number(packaging) + Number(statiegeld) + Number(delivery) + Number(tip)
     - Number(discount_used_amount != null ? discount_used_amount : discountFallback);
 
   // ===== 返回标准化结构（只做字段映射，不做增值税换算）=====
@@ -391,6 +393,7 @@ function normalizeForPrint(order) {
     items,
     subtotal,
     packaging,                                 // Verpakking + Toeslag
+    statiegeld,
     discount: (discount_used_amount != null ? discount_used_amount : discountFallback),
     delivery_fee: delivery,
     tip,
@@ -673,6 +676,7 @@ col2('Subtotaal',   `EUR ${to2(order.subtotal)}`);
 }
 
 col2('Verpakking Toeslag', `EUR ${to2(order.packaging)}`);
+col2('Statiegeld',         `EUR ${to2(order.statiegeld)}`);
 col2('Bezorgkosten',       `EUR ${to2(order.delivery_fee)}`);
 col2('Fooi',               `EUR ${to2(order.tip)}`);
 

--- a/electron-pos/public/menu.html
+++ b/electron-pos/public/menu.html
@@ -1544,7 +1544,7 @@
 </div>
 </div>
 </div>
-<div class="menu-row menu-item" data-name="Heineken 330ml" data-packaging="0.15" data-price="3">
+<div class="menu-row menu-item" data-name="Heineken 330ml" data-statiegeld="0.15" data-price="3">
   <div class="menu-img">
     <img alt="Heineken 330ml" loading="lazy" src="{{ url_for('static', filename='images/HEINEKEN.png') }}">
   </div>

--- a/electron-pos/public/orders-table.html
+++ b/electron-pos/public/orders-table.html
@@ -3422,6 +3422,7 @@ function addRow(order, highlight = false) {
   const subtotal      = window.toNum(order.subtotal ?? 0);
   const totaal        = window.toNum(order.totaal ?? order.total ?? 0);
   const packaging_fee = window.toNum(order.packaging_fee ?? 0);
+  const statiegeld    = window.toNum(order.statiegeld ?? 0);
   const delivery_fee  = window.toNum(order.delivery_fee ?? order.bezorgkosten ?? 0);
   const tip           = window.toNum(order.tip ?? 0);
   const btw_9  = window.toNum(order.btw_9  ?? 0);
@@ -3516,6 +3517,7 @@ if (nextAmtNum !== 0) {
 
     ${subtotal      > 0 ? `<div><strong>Subtotal:</strong> €${fmt2(subtotal)}</div>` : ''}
     ${packaging_fee > 0 ? `<div><strong>Verpakkingskosten:</strong> €${fmt2(packaging_fee)}</div>` : ''}
+    ${statiegeld    > 0 ? `<div><strong>Statiegeld:</strong> €${fmt2(statiegeld)}</div>` : ''}
     ${delivery_fee  > 0 ? `<div><strong>Bezorgkosten:</strong> €${fmt2(delivery_fee)}</div>` : ''}
     ${btw_9         > 0 ? `<div><strong>BTW 9%:</strong> €${fmt2(btw_9)}</div>` : ''}
     ${btw_21        > 0 ? `<div><strong>BTW 21%:</strong> €${fmt2(btw_21)}</div>` : ''}

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1412,6 +1412,11 @@ dialog::backdrop {
   <span id="summaryPackaging">€0,00</span>
 </div>
 
+<div id="summaryStatiegeldRow" class="summary-row hidden">
+  <label>Statiegeld:</label>
+  <span id="summaryStatiegeld">€0,00</span>
+</div>
+
 <div id="summaryDeliveryRow" class="summary-row hidden">
   <label>Bezorgkosten:</label>
   <span id="summaryDelivery">€0,00</span>
@@ -2001,15 +2006,17 @@ function updatePokebowlSauces(id,name){
 function setPokebowlQty(id,name){
   const sel=document.getElementById(id);
   const qty=parseInt(sel.value||0);
-  const pack=parseFloat(sel.closest('.menu-item').dataset.packaging||0);
-  const price=parseFloat(sel.closest('.menu-item').dataset.price||0);
+  const menuItem = sel.closest('.menu-item');
+  const pack=parseFloat(menuItem.dataset.packaging||0);
+  const deposit=parseFloat(menuItem.dataset.statiegeld||0);
+  const price=parseFloat(menuItem.dataset.price||0);
   const container=document.getElementById(id+'Sauces');
   const prefs=[];
   for(let i=1;i<=qty;i++){
     const s=container.querySelector(`select[data-index="${i}"]`);
     prefs.push(s?s.value:'Geen');
   }
-  setQty(name,price,qty,pack,prefs);
+  setQty(name,price,qty,pack,prefs,deposit);
 }
 
 function isRamenValid(code){
@@ -2064,11 +2071,11 @@ function createSelect(current,onChange){
   for(let i=0;i<=20;i++){ const opt=document.createElement('option'); opt.value=i; opt.textContent=i; if(i===current) opt.selected=true; sel.appendChild(opt); }
   sel.addEventListener('change',()=>onChange(parseInt(sel.value))); return sel;
 }
-function setQty(name,price,qty,packaging=0,prefs=null){
+function setQty(name,price,qty,packaging=0,prefs=null,statiegeld=0){
   if(qty===0){
     delete cart[name];
   } else {
-    cart[name]={price,qty,packaging};
+    cart[name]={price,qty,packaging,statiegeld};
     if(prefs) cart[name].prefs=prefs; else if(cart[name]&&cart[name].prefs) delete cart[name].prefs;
   }
   updateCart();
@@ -2078,6 +2085,7 @@ function updateCart() {
   list.innerHTML = '';
   let subtotal = 0;
   let packagingTotal = 0;
+  let statiegeldTotal = 0;
   let count = 0;
 
   Object.entries(cart).forEach(([name, item]) => {
@@ -2107,7 +2115,7 @@ function updateCart() {
           const qtyInput = menuItem.querySelector('select');
           if (qtyInput) qtyInput.value = val;
         }
-        setQty(name, item.price, val, item.packaging, item.prefs);
+        setQty(name, item.price, val, item.packaging, item.prefs, item.statiegeld);
 
         if (name === 'Bento Sushi Omakase') {
           document.getElementById('sushiBentoCount').value = val;
@@ -2138,6 +2146,7 @@ function updateCart() {
     if (item.qty > 0) {
       subtotal += rowTotal;
       packagingTotal += (item.packaging || 0) * item.qty;
+      statiegeldTotal += (item.statiegeld || 0) * item.qty;
     }
 
     count += item.qty;
@@ -2155,7 +2164,7 @@ function updateCart() {
   }
   if (discount < 0 || isNaN(discount)) discount = 0;
 
-  const total = subtotal + packagingTotal + delivery - discount;
+  const total = subtotal + packagingTotal + statiegeldTotal + delivery - discount;
   const heinekenTotal = Object.entries(cart).reduce((sum,[k,v])=>{
     const name = v.displayName || k;
     return sum + (/heineken/i.test(name) ? v.price * v.qty : 0);
@@ -2170,6 +2179,8 @@ function updateCart() {
 
   document.getElementById('summarySubtotal').textContent = fmt(subtotal);
   document.getElementById('summaryPackaging').textContent = fmt(packagingTotal);
+  document.getElementById('summaryStatiegeld').textContent = fmt(statiegeldTotal);
+  document.getElementById('summaryStatiegeldRow').classList.toggle('hidden', !statiegeldTotal);
   document.getElementById('summaryDelivery').textContent = fmt(delivery);
   document.getElementById('summaryDeliveryRow').classList.toggle('hidden', !delivery);
   document.getElementById('summaryDiscount').textContent = discount ? `- ${fmt(discount)}` : '€0,00';
@@ -2233,6 +2244,7 @@ document.addEventListener('DOMContentLoaded',()=>{
       const name=parent.dataset.name;
       const price=parseFloat(parent.dataset.price);
       const pack=parseFloat(parent.dataset.packaging||0);
+      const deposit=parseFloat(parent.dataset.statiegeld||0);
       if(name==='Bento Sushi Omakase'){
         sel.addEventListener('change',()=>changeOmakaseQty(0));
       } else if(name==='Dragon Roll Omakase'){
@@ -2241,7 +2253,7 @@ document.addEventListener('DOMContentLoaded',()=>{
         sel.addEventListener('change',()=>updatePokebowlSauces(sel.id,name));
         updatePokebowlSauces(sel.id,name);
       } else {
-        sel.addEventListener('change',()=>{ setQty(name,price,parseInt(sel.value),pack); });
+        sel.addEventListener('change',()=>{ setQty(name,price,parseInt(sel.value),pack,null,deposit); });
       }
     }
   });
@@ -2305,7 +2317,8 @@ document.addEventListener('DOMContentLoaded',()=>{
       } else if(POKEBOWL_IDS.includes(sel.id)){
         updatePokebowlSauces(sel.id,parent.dataset.name);
       } else {
-        setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0));
+        const deposit=parseFloat(parent.dataset.statiegeld||0);
+        setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0),null,deposit);
       }
     });
   });
@@ -2324,7 +2337,8 @@ document.addEventListener('DOMContentLoaded',()=>{
       } else if(POKEBOWL_IDS.includes(sel.id)){
         updatePokebowlSauces(sel.id,parent.dataset.name);
       } else {
-        setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0));
+        const deposit=parseFloat(parent.dataset.statiegeld||0);
+        setQty(parent.dataset.name,parseFloat(parent.dataset.price),val,parseFloat(parent.dataset.packaging||0),null,deposit);
       }
     });
   });
@@ -2718,6 +2732,7 @@ async function submitOrder() {
   // ✅ 结算汇总
   const subtotal = Object.values(cart).reduce((sum, item) => sum + item.price * item.qty, 0);
   const packagingTotal = Object.values(cart).reduce((sum, item) => sum + (item.packaging || 0) * item.qty, 0);
+  const statiegeldTotal = Object.values(cart).reduce((sum, item) => sum + (item.statiegeld || 0) * item.qty, 0);
   const deliveryCost = delivery ? 2.5 : 0;
   const discountType = document.getElementById('discountType').value;
   const discountVal = parseFloat(document.getElementById('discountValue').value) || 0;
@@ -2725,7 +2740,7 @@ async function submitOrder() {
   if (discountType === 'amount') discount = Math.min(discountVal, subtotal);
   else if (discountType === 'percent') discount = Math.min(100, discountVal) / 100 * subtotal;
 
-  const totalBeforeBtw = subtotal + packagingTotal + deliveryCost - discount;
+  const totalBeforeBtw = subtotal + packagingTotal + statiegeldTotal + deliveryCost - discount;
   const heinekenTotal = Object.entries(cart).reduce((sum,[k,v])=>{
     const name = v.displayName || k;
     return sum + (/heineken/i.test(name) ? v.price * v.qty : 0);
@@ -2750,6 +2765,8 @@ async function submitOrder() {
     btw_total: parseFloat(btw.toFixed(2)),
     btw_split: { '9': btw9.toFixed(2), '21': btw21.toFixed(2) },
     total: parseFloat(totalBeforeBtw.toFixed(2)), total_gross: parseFloat(totalGross.toFixed(2)) };
+
+  if (statiegeldTotal > 0) summary.statiegeld = parseFloat(statiegeldTotal.toFixed(2));
 
 
   const orderType = delivery ? 'bezorgen' : 'afhalen';
@@ -2792,6 +2809,10 @@ async function submitOrder() {
   summary
 };
 
+
+  if (statiegeldTotal > 0) {
+    payload.statiegeld = parseFloat(statiegeldTotal.toFixed(2));
+  }
 
   if (discount > 0) {
     payload.discountCode = 'KASSA';
@@ -3426,6 +3447,7 @@ function addRow(order, highlight = false) {
   const subtotal      = window.toNum(order.subtotal ?? 0);
   const totaal        = window.toNum(order.totaal ?? order.total ?? 0);
   const packaging_fee = window.toNum(order.packaging_fee ?? 0);
+  const statiegeld    = window.toNum(order.statiegeld ?? 0);
   const delivery_fee  = window.toNum(order.delivery_fee ?? order.bezorgkosten ?? 0);
   const tip           = window.toNum(order.tip ?? 0);
   const btw_9  = window.toNum(order.btw_9  ?? 0);
@@ -3520,6 +3542,7 @@ if (nextAmtNum !== 0) {
 
     ${subtotal      > 0 ? `<div><strong>Subtotal:</strong> €${fmt2(subtotal)}</div>` : ''}
     ${packaging_fee > 0 ? `<div><strong>Verpakkingskosten:</strong> €${fmt2(packaging_fee)}</div>` : ''}
+    ${statiegeld    > 0 ? `<div><strong>Statiegeld:</strong> €${fmt2(statiegeld)}</div>` : ''}
     ${delivery_fee  > 0 ? `<div><strong>Bezorgkosten:</strong> €${fmt2(delivery_fee)}</div>` : ''}
     ${btw_9         > 0 ? `<div><strong>BTW 9%:</strong> €${fmt2(btw_9)}</div>` : ''}
     ${btw_21        > 0 ? `<div><strong>BTW 21%:</strong> €${fmt2(btw_21)}</div>` : ''}
@@ -3773,6 +3796,7 @@ function normalizeOrder(o = {}) {
     subtotal:        toNum(o.subtotal ?? o.summary?.subtotal),
     total:           toNum(o.total ?? o.summary?.total ?? o.totaal),
     packaging_fee:   toNum(o.packaging_fee ?? o.summary?.packaging_fee ?? o.verpakkingskosten),
+    statiegeld:      toNum(o.statiegeld ?? o.summary?.statiegeld),
     delivery_fee:    toNum(o.delivery_fee  ?? o.summary?.delivery_fee  ?? o.bezorgkosten),
     tip:             toNum(o.tip),
     btw_9:           toNum(o.btw_9),
@@ -3815,6 +3839,11 @@ function toUIOrder(o) {
     src.package_fee ??
     0
   );
+  const statiegeld = toNum(
+    src.statiegeld ??
+    src.summary?.statiegeld ??
+    0
+  );
   const delivery_fee  = isDelivery ? toNum(
     src.delivery_fee ??
     src.summary?.delivery_fee ??
@@ -3855,6 +3884,7 @@ function toUIOrder(o) {
         qty: it.quantity ?? it.qty ?? 1,
         price: toNum(it.unit_price ?? it.price ?? 0),
         packaging: toNum(it.packaging ?? 0),
+        statiegeld: toNum(it.statiegeld ?? 0),
         line_total: toNum(it.line_total ?? ((it.unit_price ?? it.price ?? 0) * (it.quantity ?? it.qty ?? 1)))
       };
       return acc;
@@ -3875,6 +3905,7 @@ function toUIOrder(o) {
     totaal,
     subtotal,
     packaging_fee,
+    statiegeld,
     delivery_fee,
     tip: fooi,
     btw_9,

--- a/templates/index.html
+++ b/templates/index.html
@@ -4309,7 +4309,7 @@ body.portrait-mode .cart-badge {
 </section>
 <section id="drinks">
 <div class="menu-group">
-<div class="menu-row menu-item" data-name="Cola" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Cola" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Cola" loading="lazy" src="{{ url_for('static', filename='images/COLA.png') }}">
   </div>
@@ -4325,7 +4325,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
-<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Cola Zero" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Cola Zero" loading="lazy" src="{{ url_for('static', filename='images/COLAZERO.webp') }}">
   </div>
@@ -4341,7 +4341,7 @@ body.portrait-mode .cart-badge {
          </div>
 </div>
 </div>
-<div class="menu-row menu-item" data-name="Spa Blauw" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Spa Blauw" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Spa Blauw" loading="lazy" src="{{ url_for('static', filename='images/SPA_BLAUW.png') }}">
   </div>
@@ -4357,7 +4357,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
-<div class="menu-row menu-item" data-name="Spa Rood" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Spa Rood" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Spa Rood" loading="lazy" src="{{ url_for('static', filename='images/SPA_ROOD.png') }}">
   </div>
@@ -4373,7 +4373,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
-<div class="menu-row menu-item" data-name="Red Bull" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Red Bull" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Red Bull" loading="lazy" src="{{ url_for('static', filename='images/RED_BULL.png') }}">
   </div>
@@ -4389,7 +4389,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
- <div class="menu-row menu-item" data-name="Heineken 330ml" data-packaging="0.15" data-price="3">
+<div class="menu-row menu-item" data-name="Heineken 330ml" data-statiegeld="0.15" data-price="3">
   <div class="menu-img">
     <img alt="Heineken 330ml" loading="lazy" src="{{ url_for('static', filename='images/HEINEKEN.png') }}">
   </div>

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -4208,7 +4208,7 @@ body.portrait-mode .cart-badge {
 </section>
 <section id="drinks">
 <div class="menu-group">
-<div class="menu-row menu-item" data-name="Cola" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Cola" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Cola" loading="lazy" src="{{ url_for('static', filename='images/COLA.png') }}">
   </div>
@@ -4224,7 +4224,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
-<div class="menu-row menu-item" data-name="Cola Zero" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Cola Zero" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Cola Zero" loading="lazy" src="{{ url_for('static', filename='images/COLAZERO.webp') }}">
   </div>
@@ -4240,7 +4240,7 @@ body.portrait-mode .cart-badge {
          </div>
 </div>
 </div>
-<div class="menu-row menu-item" data-name="Spa Blauw" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Spa Blauw" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Spa Blauw" loading="lazy" src="{{ url_for('static', filename='images/SPA_BLAUW.png') }}">
   </div>
@@ -4256,7 +4256,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
-<div class="menu-row menu-item" data-name="Spa Rood" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Spa Rood" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Spa Rood" loading="lazy" src="{{ url_for('static', filename='images/SPA_ROOD.png') }}">
   </div>
@@ -4272,7 +4272,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
-<div class="menu-row menu-item" data-name="Red Bull" data-packaging="0.15" data-price="2.5">
+<div class="menu-row menu-item" data-name="Red Bull" data-statiegeld="0.15" data-price="2.5">
   <div class="menu-img">
     <img alt="Red Bull" loading="lazy" src="{{ url_for('static', filename='images/RED_BULL.png') }}">
   </div>
@@ -4288,7 +4288,7 @@ body.portrait-mode .cart-badge {
     </div>
   </div>
 </div>
- <div class="menu-row menu-item" data-name="Heineken 330ml" data-packaging="0.15" data-price="3">
+<div class="menu-row menu-item" data-name="Heineken 330ml" data-statiegeld="0.15" data-price="3">
   <div class="menu-img">
     <img alt="Heineken 330ml" loading="lazy" src="{{ url_for('static', filename='images/HEINEKEN.png') }}">
   </div>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -1544,7 +1544,7 @@
 </div>
 </div>
 </div>
-<div class="menu-row menu-item" data-name="Heineken 330ml" data-packaging="0.15" data-price="3">
+<div class="menu-row menu-item" data-name="Heineken 330ml" data-statiegeld="0.15" data-price="3">
   <div class="menu-img">
     <img alt="Heineken 330ml" loading="lazy" src="{{ url_for('static', filename='images/HEINEKEN.png') }}">
   </div>


### PR DESCRIPTION
## Summary
- Track and display `statiegeld` deposits separately from packaging fees in the POS
- Exclude statiegeld from BTW calculations and forward it to the backend and database
- Replace `data-packaging="0.15"` drink attributes with `data-statiegeld="0.15"`

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3935a4968833393d97abae916f034