### PR TITLE
Add statiegeld field to orders

### DIFF
--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -93,6 +93,7 @@ th:last-child {
        <th>Bezorgkosten</th>
        <th>Adres</th>
        <th>Betaalwijze</th>
+       <th>Statiegeld</th>
        <th>Fooi</th>
        <th>Acties</th>
       </tr>
@@ -138,6 +139,7 @@ th:last-child {
           {% else %}-{% endif %}
         </td>
         <td>{{ order.payment_method }}</td>
+        <td>€{{ '%.2f' % (order.statiegeld or 0) }}</td>
         <td>€{{ '%.2f' % (order.fooi or order.tip or 0) }}</td>
         <td>
           <button onclick="toggleComplete(this)"
@@ -252,6 +254,9 @@ th:last-child {
     const totaal = prompt('Totaal', data.totaal != null ? data.totaal : '');
     if(totaal === null) return;
 
+    const statiegeld = prompt('Statiegeld', data.statiegeld != null ? data.statiegeld : '0');
+    if(statiegeld === null) return;
+
     const fooi = prompt('Fooi', data.fooi != null ? data.fooi : (data.tip || '0'));
     if(fooi === null) return;
 
@@ -265,6 +270,7 @@ th:last-child {
         items: parseItemsString(newItemsInput, data.items || {}),
         payment_method: payment,
         totaal: parseFloat(totaal) || 0,
+        statiegeld: parseFloat(statiegeld) || 0,
         fooi: parseFloat(fooi) || 0,
         bron: data.bron
       })


### PR DESCRIPTION
## Summary
- handle `statiegeld` deposit on orders in Flask and Electron POS backends
- include statiegeld in order calculations and exports
- display and edit statiegeld in admin orders table

## Testing
- `python -m py_compile app.py electron-pos/appB.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3ec20fb688333ab2119086101d6b8