### PR TITLE
Remove 'Op rekening' payment option for delivery

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2576,7 +2576,6 @@ body.portrait-mode .cart-badge {
 <select id="deliveryPayment">
 <option value="online" selected>Online betaling</option>
 <option value="contant">Contant</option>
-<option value="oprekening">Op rekening</option>
 </select>
 </div>
 </div>
@@ -2666,7 +2665,6 @@ body.portrait-mode .cart-badge {
           <option value="online" selected>Online betaling</option>
           <option value="contant">Contant</option>
           <option value="pin">Pin</option>
-          <option value="oprekening">Op rekening</option>
         </select>
         <img
           id="cartIcon"
@@ -4717,8 +4715,7 @@ const soldoutMap = {
 const iconMap = {
   online: "https://raw.githubusercontent.com/iamatimnl/Nova-Asia/main/icons/online.svg",
   contant: "https://raw.githubusercontent.com/iamatimnl/Nova-Asia/main/icons/contant.svg",
-  pin: "https://raw.githubusercontent.com/iamatimnl/Nova-Asia/main/icons/pin.svg",
-  oprekening: "https://raw.githubusercontent.com/iamatimnl/Nova-Asia/main/icons/oprekening.svg"
+  pin: "https://raw.githubusercontent.com/iamatimnl/Nova-Asia/main/icons/pin.svg"
 };
 
 const cartIcon = document.getElementById("cartIcon");


### PR DESCRIPTION
## Summary
- remove 'Op rekening' option from delivery and cart payment dropdowns
- drop unused icon mapping for 'Op rekening'

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5799df2d08333aa0ca5c029729d8b