### PR TITLE
feat: improve Hoofddorp SEO

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,8 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0" name="viewport"/>
-<title>Nova Asia Ordering</title>
+<meta name="description" content="Nova Asia in Hoofddorp serveert bento boxen en teppanyaki gerechten. Ook sushi, pokébowls, ramen en Aziatische streetfood."/>
+<title>Nova Asia | Bento & Teppanyaki in Hoofddorp</title>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Quicksand:wght@400;700&family=Noto+Sans:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
 <!-- 网页标签图标 -->
 <!-- Favicon (桌面浏览器标签) -->
@@ -2527,10 +2528,10 @@ body.portrait-mode .cart-badge {
 </nav>
 </div>
 <h1 class="logo-heading">
-  <img src="static/images/Logo.png" alt="Nova Asia Logo" class="logo-desktop" />
-  Nova Asia Online Bestellen
+  <img src="static/images/Logo.png" alt="Nova Asia bento bezorgen Hoofddorp" class="logo-desktop" />
+  Bento & Teppanyaki in Hoofddorp
 </h1>
-
+<p>Bij Nova Asia in Hoofddorp proef je authentieke bento boxen en teppanyaki gerechten. We serveren ook verse sushi, kleurrijke pokébowls, hartverwarmende ramen en andere Aziatische streetfood favorieten. Zoek je Bento Hoofddorp, Teppanyaki Hoofddorp, Pokébowls Hoofddorp, Ramen Hoofddorp of Sushi Hoofddorp? Bestel online of kom langs.</p>
 
 <section id="delivery-options">
 <div class="delivery-options">
@@ -2893,7 +2894,7 @@ body.portrait-mode .cart-badge {
 <!-- Japans Chicken Bento -->
 <div class="menu-row menu-item" data-name="Japans Chicken Bento" data-packaging="0.2" data-price="22">
 <div class="menu-img">
-<img alt="Japans Chicken Bento" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
+<img alt="Japans Chicken Bento Hoofddorp" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Japans Chicken Bento</h3>
@@ -2915,7 +2916,7 @@ body.portrait-mode .cart-badge {
 <!-- Korean Chicken Bento -->
 <div class="menu-row menu-item" data-name="Korean Chicken Bento" data-packaging="0.2" data-price="22">
 <div class="menu-img">
-<img alt="Korean Chicken Bento" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
+<img alt="Korean Chicken Bento Hoofddorp" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Korean Chicken Bento</h3> 
@@ -2935,7 +2936,7 @@ body.portrait-mode .cart-badge {
 <!-- Korean Beef Bento -->
 <div class="menu-row menu-item" data-name="Korean Beef Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Korean Beef Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+<img alt="Korean Beef Bento Hoofddorp" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Korean Beef Bento </h3> 
@@ -2955,7 +2956,7 @@ body.portrait-mode .cart-badge {
 <!-- Meatlover Bento -->
 <div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Meatlover Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+<img alt="Meatlover Bento Hoofddorp" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Meatlover Bento</h3> 
@@ -2973,7 +2974,7 @@ body.portrait-mode .cart-badge {
 <!-- Zalm Lover Bento -->
 <div class="menu-row menu-item" data-name="Zalm Lover Bento" data-packaging="0.2" data-price="23">
 <div class="menu-img">
-<img alt="Zalm Lover Bento" src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}"/>
+<img alt="Zalm Lover Bento Hoofddorp" src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Zalmlover Bento</h3> 
@@ -2991,7 +2992,7 @@ body.portrait-mode .cart-badge {
 <!-- Ebi Lover Bento -->
 <div class="menu-row menu-item" data-name="Ebi Lover Bento" data-packaging="0.2" data-price="23">
 <div class="menu-img">
-<img alt="EbiLover Bento" src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}"/>
+<img alt="EbiLover Bento Hoofddorp" src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Ebi lover Bento</h3> 
@@ -3009,7 +3010,7 @@ body.portrait-mode .cart-badge {
 <!-- Surf & Turf Bento -->
 <div class="menu-row menu-item" data-name="Surf &amp; Turf Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Surf &amp; Turf Bento" src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}"/>
+<img alt="Surf &amp; Turf Bento Hoofddorp" src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Surf & Turf Bento</h3> 
@@ -3027,7 +3028,7 @@ body.portrait-mode .cart-badge {
 <!-- Dimsum Bento -->
 <div class="menu-row menu-item" data-name="Dimsum Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
-<img alt="Dimsum Bento" src="{{ url_for('static', filename='images/dimsum-bento.png') }}"/>
+<img alt="Dimsum Bento Hoofddorp" src="{{ url_for('static', filename='images/dimsum-bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Dimsum Bento</h3>
@@ -3046,7 +3047,7 @@ body.portrait-mode .cart-badge {
 <!-- Lamskotelet Bento -->
 <div class="menu-row menu-item" data-name="Lamskotelet Bento" data-packaging="0.2" data-price="30">
 <div class="menu-img">
-<img alt="Lamskotelet Bento" src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}"/>
+<img alt="Lamskotelet Bento Hoofddorp" src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Lamskotelet NZL Bento</h3>
@@ -3064,7 +3065,7 @@ body.portrait-mode .cart-badge {
 <!-- Unagi Bento -->
 <div class="menu-row menu-item" data-name="Unagi Bento" data-packaging="0.2" data-price="24">
 <div class="menu-img">
-<img alt="Unagi Bento" src="{{ url_for('static', filename='images/UNA.jpg') }}"/>
+<img alt="Unagi Bento Hoofddorp" src="{{ url_for('static', filename='images/UNA.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Unagi Bento</h3>
@@ -3082,7 +3083,7 @@ body.portrait-mode .cart-badge {
 
 <div class="menu-row menu-item" data-name="Usuyaki Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+<img alt="Tuna Bento Hoofddorp" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Usuyaki Bento</h3> 
@@ -3100,7 +3101,7 @@ body.portrait-mode .cart-badge {
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
-<img alt="Veggie Bento" src="{{ url_for('static', filename='images/veggie-bento.png') }}"/>
+<img alt="Veggie Bento Hoofddorp" src="{{ url_for('static', filename='images/veggie-bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Veggie Bento</h3> 
@@ -3117,7 +3118,7 @@ body.portrait-mode .cart-badge {
 </div>
 <div class="menu-row menu-item" data-name="Bento Sushi Omakase" data-packaging="0.2" data-price="24">
 <div class="menu-img">
-<img alt="Bento Sushi Omakase" src="{{ url_for('static', filename='images/SUSHI.png') }}"/>
+<img alt="Bento Sushi Omakase Hoofddorp" src="{{ url_for('static', filename='images/SUSHI.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Sushi Bento</h3>

--- a/templates/indexEN.html
+++ b/templates/indexEN.html
@@ -3,6 +3,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0" name="viewport"/>
+<meta name="description" content="Discover bento boxes and teppanyaki dishes at Nova Asia in Hoofddorp. Also sushi, pokébowls, ramen and Asian streetfood."/>
+<title>Nova Asia | Bento & Teppanyaki in Hoofddorp</title>
 
 <!-- iOS 设置 -->
 <meta name="apple-mobile-web-app-capable" content="yes">
@@ -2434,10 +2437,10 @@ body.portrait-mode .cart-badge {
 </nav>
 </div>
 <h1 class="logo-heading">
-  <img src="static/images/Logo.png" alt="Nova Asia Logo" class="logo-desktop" />
-  Nova Asia Online Bestellen
+  <img src="static/images/Logo.png" alt="Nova Asia bento bezorgen Hoofddorp" class="logo-desktop" />
+  Bento & Teppanyaki in Hoofddorp
 </h1>
-
+<p>At Nova Asia in Hoofddorp you can enjoy authentic bento boxes and teppanyaki dishes. We also serve fresh sushi, colourful pokébowls, comforting ramen and other Asian streetfood favourites. Looking for Bento Hoofddorp, Teppanyaki Hoofddorp, Pokébowls Hoofddorp, Ramen Hoofddorp or Sushi Hoofddorp? Order online or drop by.</p>
 
 <section id="delivery-options">
 <div class="delivery-options">
@@ -2801,7 +2804,7 @@ body.portrait-mode .cart-badge {
 <!-- Japans Chicken Bento -->
 <div class="menu-row menu-item" data-name="Japans Chicken Bento" data-packaging="0.2" data-price="22">
 <div class="menu-img">
-<img alt="Japans Chicken Bento" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
+<img alt="Japans Chicken Bento Hoofddorp" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Japans Chicken Bento</h3>
@@ -2823,7 +2826,7 @@ body.portrait-mode .cart-badge {
 <!-- Korean Chicken Bento -->
 <div class="menu-row menu-item" data-name="Korean Chicken Bento" data-packaging="0.2" data-price="22">
 <div class="menu-img">
-<img alt="Korean Chicken Bento" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
+<img alt="Korean Chicken Bento Hoofddorp" src="{{ url_for('static', filename='images/chicken-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Korean Chicken Bento</h3> 
@@ -2843,7 +2846,7 @@ body.portrait-mode .cart-badge {
 <!-- Korean Beef Bento -->
 <div class="menu-row menu-item" data-name="Korean Beef Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Korean Beef Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+<img alt="Korean Beef Bento Hoofddorp" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Korean Beef Bento </h3> 
@@ -2863,7 +2866,7 @@ body.portrait-mode .cart-badge {
 <!-- Meatlover Bento -->
 <div class="menu-row menu-item" data-name="Meatlover Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Meatlover Bento" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
+<img alt="Meatlover Bento Hoofddorp" src="{{ url_for('static', filename='images/Meatlove bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Korean Beef Bento</h3> 
@@ -2881,7 +2884,7 @@ body.portrait-mode .cart-badge {
 <!-- Zalm Lover Bento -->
 <div class="menu-row menu-item" data-name="Zalm Lover Bento" data-packaging="0.2" data-price="23">
 <div class="menu-img">
-<img alt="Zalm Lover Bento" src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}"/>
+<img alt="Zalm Lover Bento Hoofddorp" src="{{ url_for('static', filename='images/zalm-lover-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Zalmlover Bento</h3> 
@@ -2899,7 +2902,7 @@ body.portrait-mode .cart-badge {
 <!-- Ebi Lover Bento -->
 <div class="menu-row menu-item" data-name="Ebi Lover Bento" data-packaging="0.2" data-price="23">
 <div class="menu-img">
-<img alt="EbiLover Bento" src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}"/>
+<img alt="EbiLover Bento Hoofddorp" src="{{ url_for('static', filename='images/ebi-lover-bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Ebi lover Bento</h3> 
@@ -2917,7 +2920,7 @@ body.portrait-mode .cart-badge {
 <!-- Surf & Turf Bento -->
 <div class="menu-row menu-item" data-name="Surf &amp; Turf Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Surf &amp; Turf Bento" src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}"/>
+<img alt="Surf &amp; Turf Bento Hoofddorp" src="{{ url_for('static', filename='images/surf-turf-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Surf & Turf Bento</h3> 
@@ -2935,7 +2938,7 @@ body.portrait-mode .cart-badge {
 <!-- Dimsum Bento -->
 <div class="menu-row menu-item" data-name="Dimsum Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
-<img alt="Dimsum Bento" src="{{ url_for('static', filename='images/dimsum-bento.png') }}"/>
+<img alt="Dimsum Bento Hoofddorp" src="{{ url_for('static', filename='images/dimsum-bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Dimsum Bento</h3>
@@ -2954,7 +2957,7 @@ body.portrait-mode .cart-badge {
 <!-- Lamskotelet Bento -->
 <div class="menu-row menu-item" data-name="Lamskotelet Bento" data-packaging="0.2" data-price="30">
 <div class="menu-img">
-<img alt="Lamskotelet Bento" src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}"/>
+<img alt="Lamskotelet Bento Hoofddorp" src="{{ url_for('static', filename='images/lamskotelet-bento.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Lamskotelet NZL Bento</h3>
@@ -2972,7 +2975,7 @@ body.portrait-mode .cart-badge {
 <!-- Unagi Bento -->
 <div class="menu-row menu-item" data-name="Unagi Bento" data-packaging="0.2" data-price="24">
 <div class="menu-img">
-<img alt="Unagi Bento" src="{{ url_for('static', filename='images/UNA.jpg') }}"/>
+<img alt="Unagi Bento Hoofddorp" src="{{ url_for('static', filename='images/UNA.jpg') }}"/>
 </div>
 <div class="menu-content">
 <h3>Unagi Bento</h3>
@@ -2990,7 +2993,7 @@ body.portrait-mode .cart-badge {
 
 <div class="menu-row menu-item" data-name="Usuyaki Bento" data-packaging="0.2" data-price="25">
 <div class="menu-img">
-<img alt="Tuna Bento" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
+<img alt="Tuna Bento Hoofddorp" src="{{ url_for('static', filename='images/tunapo.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Usuyaki Bento</h3> 
@@ -3008,7 +3011,7 @@ body.portrait-mode .cart-badge {
 <!-- Veggie Bento -->
 <div class="menu-row menu-item" data-name="Veggie Bento" data-packaging="0.2" data-price="20">
 <div class="menu-img">
-<img alt="Veggie Bento" src="{{ url_for('static', filename='images/veggie-bento.png') }}"/>
+<img alt="Veggie Bento Hoofddorp" src="{{ url_for('static', filename='images/veggie-bento.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Veggie Bento</h3> 
@@ -3025,7 +3028,7 @@ body.portrait-mode .cart-badge {
 </div>
 <div class="menu-row menu-item" data-name="Bento Sushi Omakase" data-packaging="0.2" data-price="24">
 <div class="menu-img">
-<img alt="Bento Sushi Omakase" src="{{ url_for('static', filename='images/SUSHI.png') }}"/>
+<img alt="Bento Sushi Omakase Hoofddorp" src="{{ url_for('static', filename='images/SUSHI.png') }}"/>
 </div>
 <div class="menu-content">
 <h3>Sushi Bento</h3>


### PR DESCRIPTION
## Summary
- optimize homepages with Hoofddorp-focused titles, descriptions and H1 tags
- add Hoofddorp keywords to bento image alt text

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6a8364ebc833385b5f8a606f98db0