### PR TITLE
fix: adjust order card PIN payment API base

### DIFF
--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -2908,7 +2908,7 @@ async function openCheckout(btn) {
 
   if (id) {
     try {
-      await fetch(`/api/orders/${id}`, {
+      await fetch(`${API_BASE}/api/orders/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ payment_method: finalMethod, status: order.status })


### PR DESCRIPTION
## Summary
- ensure order card checkout uses `API_BASE` for updating payments

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a89c2200388333ac970fd351fd01c0