### PR TITLE
feat: add order history by date

### DIFF
--- a/electron-pos/db.js
+++ b/electron-pos/db.js
@@ -284,6 +284,11 @@ const listTodayStmt   = db.prepare(`
   WHERE date(created_at)=date('now','localtime')
   ORDER BY created_at DESC
 `);
+const listByDateStmt  = db.prepare(`
+  SELECT * FROM orders
+  WHERE date(created_at)=date(?)
+  ORDER BY created_at DESC
+`);
 
 const txUpsert = db.transaction((row) => upsertStmt.run(row));
 
@@ -297,6 +302,7 @@ function getOrderByNumber(no) { return getByNumberStmt.get(String(no || '')) || 
 function getOrderById(id)     { return getByIdStmt.get(Number(id)) || null; }
 function listRecent(limit=50) { return listRecentStmt.all(Number(limit)); }
 function getOrdersToday()     { return listTodayStmt.all(); }
+function getOrdersByDate(date){ return listByDateStmt.all(String(date)); }
 
 /* ===================== 批量 UPSERT（给 fetch 后同步用） ===================== */
 function upsertBatch(orders = []) {
@@ -475,6 +481,7 @@ handleOnce('db:update-order-by-number', (_e, no, patch) => {
 
 // 查询
 handleOnce('db:get-orders-today', () => { try { return getOrdersToday(); } catch (e) { console.error(e); return []; } });
+handleOnce('db:get-orders-by-date', (_e, date) => { try { return getOrdersByDate(date); } catch (e) { console.error(e); return []; } });
 handleOnce('db:get-order-by-number', (_e, no) => { try { return getOrderByNumber(no); } catch (e) { console.error(e); return null; } });
 handleOnce('db:get-order-by-id', (_e, id) => { try { return getOrderById(id); } catch (e) { console.error(e); return null; } });
 handleOnce('db:list-recent', (_e, limit=50) => { try { return listRecent(limit); } catch (e) { console.error(e); return []; } });
@@ -484,5 +491,5 @@ module.exports = {
   dbPath, db,
   saveOrder, upsertBatch,
   updateOrderById, updateOrderByNumber,
-  getOrderByNumber, getOrderById, listRecent, getOrdersToday
+  getOrderByNumber, getOrderById, listRecent, getOrdersToday, getOrdersByDate
 };

--- a/electron-pos/preload.js
+++ b/electron-pos/preload.js
@@ -61,6 +61,7 @@ contextBridge.exposeInMainWorld('electron', {
 
     // 查询
     getOrdersToday:      ()             => ipcRenderer.invoke('db:get-orders-today'),
+    getOrdersByDate:     (date)         => ipcRenderer.invoke('db:get-orders-by-date', String(date)),
     getOrderByNumber:    (no)           => ipcRenderer.invoke('db:get-order-by-number', String(no)),
     getOrderById:        (id)           => ipcRenderer.invoke('db:get-order-by-id', Number(id)),
     listRecent:          (limit = 50)   => ipcRenderer.invoke('db:list-recent', Number(limit)),
@@ -78,6 +79,7 @@ contextBridge.exposeInMainWorld('pos', {
 
   // 查询
   getOrdersToday:   ()            => ipcRenderer.invoke('db:get-orders-today'),
+  getOrdersByDate:  (date)        => ipcRenderer.invoke('db:get-orders-by-date', String(date)),
   getOrderByNumber: (no)          => ipcRenderer.invoke('db:get-order-by-number', String(no)),
   getOrderById:     (id)          => ipcRenderer.invoke('db:get-order-by-id', Number(id)),
   listRecent:       (limit = 50)  => ipcRenderer.invoke('db:list-recent', Number(limit)),

--- a/electron-pos/public/pos.html
+++ b/electron-pos/public/pos.html
@@ -1444,12 +1444,12 @@ dialog::backdrop {
 
       <!-- 固定导航栏 -->
       <div class="orders-header">
+        <button id="datePickerBtn" class="btn-wissel">📅</button>
+        <input type="date" id="orderDate" style="display:none" />
         <button id="sort-toggle" class="btn-wissel">🕓</button>
         <button id="admin-orders-btn">📙</button>
         <button id="toggle-map-btn">🗺️</button>
         <button id="closeToday">✕</button>
-        
-    
       </div>
      
       <!-- 可滚动订单列表 -->
@@ -2520,6 +2520,25 @@ document.addEventListener('DOMContentLoaded',()=>{
       if(e.target===cartPanel) cartPanel.classList.remove('open');
     });
   }
+  const datePicker=document.getElementById('orderDate');
+  const datePickerBtn=document.getElementById('datePickerBtn');
+  if(datePicker){
+    datePicker.value=todayDate;
+    if(datePickerBtn){
+      datePickerBtn.textContent=todayDate;
+      datePickerBtn.addEventListener('click',()=>{
+        if(datePicker.showPicker){
+          datePicker.showPicker();
+        }else{
+          datePicker.click();
+        }
+      });
+    }
+    datePicker.addEventListener('change',()=>{
+      if(datePickerBtn) datePickerBtn.textContent=datePicker.value;
+      refreshOrders();
+    });
+  }
   updateOmakasePrefs();
   updateDragonPrefs();
   updateCart();
@@ -2534,7 +2553,7 @@ function toggleToday(){
   const open = panel.classList.contains('visible');
   document.body.classList.toggle('today-open', open);
   if(open){
-    fetchOrders();
+    refreshOrders();
     newOrderCount = 0;
     hasNewOrder = false;
     updateTabTitle();
@@ -2548,7 +2567,7 @@ function showTodayOrders(){
   if(!panel.classList.contains('visible')){
     panel.classList.add('visible');
     document.body.classList.add('today-open');
-    fetchOrders();
+    refreshOrders();
   }
 }
 
@@ -3186,7 +3205,7 @@ async function finalizeOrder(payload) {
     if (res.success || res.status === 'ok') {
       showToast('Bestelling succesvol verzonden! Bestelnummer: ' + payload.order_number);
       clearForm();
-      fetchOrders();
+      refreshOrders();
     } else {
       showToast('Er is een fout opgetreden bij het verzenden van uw bestelling. Probeer het opnieuw.');
     }
@@ -3857,6 +3876,7 @@ socket.on('payment_status', handlePaymentUpdate);
   const baseTitle = document.title;
   let newOrderCount = 0; // unseen orders for title
   let hasNewOrder = false;
+  const todayDate = new Date().toISOString().slice(0,10);
   function updateTabTitle(){
     document.title = newOrderCount ? `${baseTitle} (${newOrderCount})` : baseTitle;
   }
@@ -4186,6 +4206,36 @@ async function fetchOrders() {
   } catch (err) {
     console.error('订单拉取失败:', err);
     // TODO: 你也可以在这里给 UI 一个 toast 提示
+  }
+}
+
+async function loadOrdersByDate(dateStr){
+  try{
+    const rows = await window.pos?.getOrdersByDate?.(dateStr);
+    const container = document.querySelector('.orders-cards');
+    if(container){
+      container.innerHTML='';
+      (rows||[]).forEach(r=>{
+        let o={};
+        try{ o=JSON.parse(r.data||'{}'); }catch{}
+        const merged={...o,...r};
+        delete merged.data;
+        addRow(merged);
+      });
+    }
+  }catch(err){
+    console.error('加载历史订单失败:',err);
+  }
+}
+
+async function refreshOrders(){
+  const picker=document.getElementById('orderDate');
+  const val=picker?.value;
+  if(val && val!==todayDate){
+    stopPolling();
+    await loadOrdersByDate(val);
+  }else{
+    startPolling();
   }
 }
 


### PR DESCRIPTION
## Summary
- add SQLite query and IPC for fetching orders by date
- expose database date query to renderer
- allow POS UI to choose a date and render historical orders with existing controls
- add button to open a date picker when viewing historical orders

## Testing
- `node --check electron-pos/db.js`
- `node --check electron-pos/preload.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac83563c8c83339715e8ef1957062b